### PR TITLE
fix: update Dockerfile to copy package.json for improved dependency management

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ FROM base as deps
 
 WORKDIR /upflow
 
-COPY pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml ./
 ENV PRISMA_SKIP_POSTINSTALL_GENERATE=true
 RUN pnpm fetch
 


### PR DESCRIPTION
This pull request includes a small change to the `Dockerfile`. The change involves copying both `package.json` and `pnpm-lock.yaml` instead of just `pnpm-lock.yaml` to the working directory.

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L17-R17): Modified the `COPY` command to include `package.json` along with `pnpm-lock.yaml` to ensure that all dependencies are properly fetched.