### PR TITLE
chore: parameterize Node.js version in Dockerfile for improved flexibility

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,8 @@
-# base node image
-FROM node:22-bookworm-slim as base
+ARG NODE_VERSION=22.14.0
 ARG PNPM_VERSION=10.5.2
+
+# base node image
+FROM node:${NODE_VERSION}-slim AS base
 
 # Install openssl for Prisma
 RUN apt-get update \
@@ -10,7 +12,7 @@ RUN apt-get update \
   && rm -rf /var/lib/apt/lists/* 
 
 # Install all node_modules, including dev dependencies
-FROM base as deps
+FROM base AS deps
 
 WORKDIR /upflow
 
@@ -20,7 +22,7 @@ RUN pnpm fetch
 
 
 # Setup production node_modules
-FROM base as production-deps
+FROM base AS production-deps
 
 ENV NODE_ENV production
 WORKDIR /upflow
@@ -31,7 +33,7 @@ RUN pnpm install --prod --offline --frozen-lockfile
 
 
 # Build the app
-FROM base as build
+FROM base AS build
 
 WORKDIR /upflow
 


### PR DESCRIPTION
This pull request includes changes to the `Dockerfile` to improve its flexibility and consistency. The most important changes include introducing an argument for the Node.js version and standardizing the case for the `FROM` statements.

Improvements to flexibility and consistency:

* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L1-R6): Introduced `NODE_VERSION` argument to allow specifying the Node.js version dynamically.
* [`Dockerfile`](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L13-R15): Standardized the case of `FROM` statements to use uppercase for consistency. [[1]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L13-R15) [[2]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L23-R25) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557L34-R36)