### PR TITLE
perf: use nested GraphQL query for fetch command

### DIFF
--- a/batch/provider/github/provider.ts
+++ b/batch/provider/github/provider.ts
@@ -45,6 +45,11 @@ export const createGitHubProvider = (
       leastMergeRequest?.updated_at ?? '2000-01-01T00:00:00Z'
     logger.info(`last fetched at: ${lastFetchedAt}`)
 
+    if (halt) {
+      logger.fatal('halted')
+      return
+    }
+
     // ネストクエリで PR + commits + reviews + comments を一括取得
     logger.info('fetching all pullrequests with details (nested query)...')
     const allDetails = await fetcher.pullrequestsWithDetails()


### PR DESCRIPTION
## Summary
- Replace N+1 individual API calls (commits, reviews, comments per PR) with `pullrequestsWithDetails()` nested GraphQL query
- Fall back to individual fetches only when `needsMore*` overflow flags are set (e.g., PRs with 100+ commits)
- Reduces API calls from ~3N+1 to ~N/25 for typical repositories (5 hours → ~1 minute for 300+ PRs)

## Test plan
- [x] Ran `batch/cli.ts fetch` against all repos — completed in ~1 min
- [x] Verified overflow fallback triggered (durably PR #11 commits overflow)
- [x] Ran `upsert` and verified DB data integrity (5,246 PRs, 16,065 reviews, 3,719 reviewers)
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Enhancements**
  * Improved efficiency in fetching and processing GitHub pull request data by leveraging combined queries and conditional data retrieval.
  * Enhanced handling of cached pull request information to reduce unnecessary data refetches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->