### PR TITLE
perf: memoize store loaders to eliminate redundant file reads

### DIFF
--- a/batch/provider/github/store.ts
+++ b/batch/provider/github/store.ts
@@ -42,6 +42,10 @@ export const createStore = ({
       pathBuilder.jsonPath(filename),
       JSON.stringify(content, null, 2),
     )
+    // 書き込み後はキャッシュを無効化して read-after-write の一貫性を保つ
+    commitsCache.clear()
+    discussionsCache.clear()
+    reviewsCache.clear()
   }
 
   // メモ化キャッシュ（PR番号 → Promise）で同一ファイルの重複読み込みを防止
@@ -58,7 +62,10 @@ export const createStore = ({
     if (!cached) {
       cached = load<ShapedGitHubCommit[]>(
         pathBuilder.commitsJsonFilename(number),
-      )
+      ).catch((error) => {
+        commitsCache.delete(number)
+        throw error
+      })
       commitsCache.set(number, cached)
     }
     return cached
@@ -68,7 +75,10 @@ export const createStore = ({
     if (!cached) {
       cached = load<ShapedGitHubReviewComment[]>(
         pathBuilder.discussionsJsonFilename(number),
-      )
+      ).catch((error) => {
+        discussionsCache.delete(number)
+        throw error
+      })
       discussionsCache.set(number, cached)
     }
     return cached
@@ -78,7 +88,10 @@ export const createStore = ({
     if (!cached) {
       cached = load<ShapedGitHubReview[]>(
         pathBuilder.reviewJsonFilename(number),
-      )
+      ).catch((error) => {
+        reviewsCache.delete(number)
+        throw error
+      })
       reviewsCache.set(number, cached)
     }
     return cached


### PR DESCRIPTION
## Summary
- Add in-memory memoization cache to store loaders (commits, reviews, discussions)
- Prevents O(N²) file I/O caused by `findReleaseDateByBranch` reading commits for every merged PR on every iteration
- Analyze time for iris (4,900 PRs): **1m44s → 4s**
- Memory overhead: ~3MB (14,787 JSON files totaling 3.1MB on disk)

## Test plan
- [x] Ran `upsert iris` — analyze completed in 4s (was 1m44s)
- [x] Ran `upsert` for personal org — completed in <1s
- [x] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized pull request data loading to eliminate duplicate requests for commits, discussions, and reviews, improving overall performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->