### PR TITLE
refactor: branded OrganizationId type + remove RepositoryWithOrg

### DIFF
--- a/app/libs/auth.server.ts
+++ b/app/libs/auth.server.ts
@@ -4,6 +4,7 @@ import { organization } from 'better-auth/plugins/organization'
 import { nanoid } from 'nanoid'
 import { href, redirect } from 'react-router'
 import { db, dialect } from '~/app/services/db.server'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 
 export const auth = betterAuth({
   baseURL: process.env.BETTER_AUTH_URL,
@@ -182,7 +183,7 @@ export const isReservedSlug = (slug: string): boolean => {
 
 export interface OrgContext {
   user: NonNullable<Awaited<ReturnType<typeof getSession>>>['user']
-  organization: { id: string; name: string; slug: string }
+  organization: { id: OrganizationId; name: string; slug: string }
   membership: { id: string; role: string }
 }
 
@@ -216,7 +217,7 @@ export const requireOrgMember = async (
   return {
     user: session.user,
     organization: {
-      id: result.orgId,
+      id: result.orgId as OrganizationId,
       name: result.orgName,
       slug: result.orgSlug,
     },

--- a/app/routes/$orgSlug/_index/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/_index/+functions/queries.server.ts
@@ -1,9 +1,12 @@
 import { pipe, sortBy } from 'remeda'
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 import { calculateBusinessHours } from './utils'
 
 export const getMergedPullRequestReport = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   fromDateTime: string | null,
   toDateTime: string | null,
   objective: number,

--- a/app/routes/$orgSlug/ongoing/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/ongoing/+functions/queries.server.ts
@@ -1,9 +1,12 @@
 import { pipe, sortBy } from 'remeda'
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 import { calculateBusinessHours } from './utils'
 
 export const getOngoingPullRequestReport = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   fromDateTime: string | null,
   toDateTime: string | null,
 ) => {

--- a/app/routes/$orgSlug/settings/_index/+functions/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/_index/+functions/mutations.server.ts
@@ -4,6 +4,7 @@ import { db, sql, type DB, type Updateable } from '~/app/services/db.server'
 import {
   deleteTenantDb,
   getTenantDb,
+  type OrganizationId,
   type TenantDB,
 } from '~/app/services/tenant-db.server'
 
@@ -19,7 +20,7 @@ export const updateOrganization = async (
 }
 
 export const updateOrganizationSetting = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   data: Pick<
     Updateable<TenantDB.OrganizationSettings>,
     | 'releaseDetectionMethod'
@@ -35,13 +36,13 @@ export const updateOrganizationSetting = async (
     .execute()
 }
 
-export const deleteOrganization = async (id: string) => {
+export const deleteOrganization = async (id: OrganizationId) => {
   await deleteTenantDb(id)
   await db.deleteFrom('organizations').where('id', '=', id).execute()
 }
 
 export const upsertIntegration = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   data: Omit<Insertable<TenantDB.Integrations>, 'id'>,
 ) => {
   const tenantDb = getTenantDb(organizationId)
@@ -64,7 +65,7 @@ export const upsertIntegration = async (
 }
 
 export const upsertExportSetting = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   data: Omit<Insertable<TenantDB.ExportSettings>, 'id' | 'updatedAt'>,
 ) => {
   const tenantDb = getTenantDb(organizationId)

--- a/app/routes/$orgSlug/settings/_index/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/settings/_index/+functions/queries.server.ts
@@ -1,7 +1,10 @@
 import { db } from '~/app/services/db.server'
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
-export const getOrganization = async (organizationId: string) => {
+export const getOrganization = async (organizationId: OrganizationId) => {
   return await db
     .selectFrom('organizations')
     .selectAll()
@@ -9,7 +12,9 @@ export const getOrganization = async (organizationId: string) => {
     .executeTakeFirst()
 }
 
-export const getOrganizationSetting = async (organizationId: string) => {
+export const getOrganizationSetting = async (
+  organizationId: OrganizationId,
+) => {
   const tenantDb = getTenantDb(organizationId)
   return await tenantDb
     .selectFrom('organizationSettings')
@@ -18,7 +23,7 @@ export const getOrganizationSetting = async (organizationId: string) => {
 }
 
 export const createDefaultOrganizationSetting = async (
-  organizationId: string,
+  organizationId: OrganizationId,
 ) => {
   const tenantDb = getTenantDb(organizationId)
   const id = crypto.randomUUID()
@@ -35,7 +40,7 @@ export const createDefaultOrganizationSetting = async (
   return row
 }
 
-export const getExportSetting = async (organizationId: string) => {
+export const getExportSetting = async (organizationId: OrganizationId) => {
   const tenantDb = getTenantDb(organizationId)
   return await tenantDb
     .selectFrom('exportSettings')
@@ -43,7 +48,7 @@ export const getExportSetting = async (organizationId: string) => {
     .executeTakeFirst()
 }
 
-export const getIntegration = async (organizationId: string) => {
+export const getIntegration = async (organizationId: OrganizationId) => {
   const tenantDb = getTenantDb(organizationId)
   return await tenantDb
     .selectFrom('integrations')

--- a/app/routes/$orgSlug/settings/data-management/index.tsx
+++ b/app/routes/$orgSlug/settings/data-management/index.tsx
@@ -85,6 +85,7 @@ export const action = async ({ request, params }: Route.ActionArgs) => {
       }
 
       const { pulls, reviewResponses } = await provider.analyze(
+        orgContext.id,
         organization.organizationSetting,
         organization.repositories,
       )

--- a/app/routes/$orgSlug/settings/github-users._index/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/github-users._index/mutations.server.ts
@@ -1,9 +1,12 @@
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
 export const addGithubUser = async (params: {
   login: string
   displayName: string
-  organizationId: string
+  organizationId: OrganizationId
 }) => {
   const tenantDb = getTenantDb(params.organizationId)
   await tenantDb
@@ -18,7 +21,7 @@ export const addGithubUser = async (params: {
 
 export const updateGithubUser = async (params: {
   login: string
-  organizationId: string
+  organizationId: OrganizationId
   displayName: string
   name: string | null
   email: string | null
@@ -38,7 +41,7 @@ export const updateGithubUser = async (params: {
 
 export const deleteGithubUser = async (
   login: string,
-  organizationId: string,
+  organizationId: OrganizationId,
 ) => {
   const tenantDb = getTenantDb(organizationId)
   await tenantDb

--- a/app/routes/$orgSlug/settings/github-users._index/queries.server.ts
+++ b/app/routes/$orgSlug/settings/github-users._index/queries.server.ts
@@ -1,8 +1,11 @@
 import { sql } from 'kysely'
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
 interface ListFilteredGithubUsersArgs {
-  organizationId: string
+  organizationId: OrganizationId
   search: string
   currentPage: number
   pageSize: number

--- a/app/routes/$orgSlug/settings/members/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/members/mutations.server.ts
@@ -1,8 +1,9 @@
 import { db } from '~/app/services/db.server'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 
 export const changeMemberRole = async (
   memberId: string,
-  organizationId: string,
+  organizationId: OrganizationId,
   role: string,
 ) => {
   await db
@@ -15,7 +16,7 @@ export const changeMemberRole = async (
 
 export const removeMember = async (
   memberId: string,
-  organizationId: string,
+  organizationId: OrganizationId,
 ) => {
   const member = await db
     .selectFrom('members')

--- a/app/routes/$orgSlug/settings/members/queries.server.ts
+++ b/app/routes/$orgSlug/settings/members/queries.server.ts
@@ -1,8 +1,9 @@
 import { sql } from 'kysely'
 import { db } from '~/app/services/db.server'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 
 interface ListFilteredMembersArgs {
-  organizationId: string
+  organizationId: OrganizationId
   name: string
   filters: Record<string, string[]>
   currentPage: number

--- a/app/routes/$orgSlug/settings/repositories.$repository.$pull/queries.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.$repository.$pull/queries.server.ts
@@ -1,8 +1,11 @@
 import { jsonObjectFrom } from 'kysely/helpers/sqlite'
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
 export const getRepository = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   repositoryId: string,
 ) => {
   const tenantDb = getTenantDb(organizationId)
@@ -24,7 +27,7 @@ export const getRepository = async (
 }
 
 export const getPullRequest = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   repositoryId: string,
   number: number,
 ) => {

--- a/app/routes/$orgSlug/settings/repositories.$repository._index/queries.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.$repository._index/queries.server.ts
@@ -1,7 +1,10 @@
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
 export const getRepository = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   repositoryId: string,
 ) => {
   const tenantDb = getTenantDb(organizationId)
@@ -13,7 +16,7 @@ export const getRepository = async (
 }
 
 export const listPullRequests = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   repositoryId: string,
 ) => {
   const tenantDb = getTenantDb(organizationId)

--- a/app/routes/$orgSlug/settings/repositories.$repository.delete/+functions/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.$repository.delete/+functions/mutations.server.ts
@@ -1,7 +1,10 @@
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
 export const deleteRepository = (
-  organizationId: string,
+  organizationId: OrganizationId,
   repositoryId: string,
 ) => {
   const tenantDb = getTenantDb(organizationId)

--- a/app/routes/$orgSlug/settings/repositories.$repository.delete/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.$repository.delete/+functions/queries.server.ts
@@ -1,7 +1,10 @@
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
 export const getRepository = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   repositoryId: string,
 ) => {
   const tenantDb = getTenantDb(organizationId)

--- a/app/routes/$orgSlug/settings/repositories.$repository.settings/+functions/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.$repository.settings/+functions/mutations.server.ts
@@ -1,8 +1,12 @@
 import type { Updateable } from 'kysely'
-import { getTenantDb, type TenantDB } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+  type TenantDB,
+} from '~/app/services/tenant-db.server'
 
 export const updateRepository = (
-  organizationId: string,
+  organizationId: OrganizationId,
   repositoryId: string,
   data: Pick<
     Updateable<TenantDB.Repositories>,

--- a/app/routes/$orgSlug/settings/repositories.$repository.settings/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.$repository.settings/+functions/queries.server.ts
@@ -1,7 +1,10 @@
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
 export const getRepository = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   repositoryId: string,
 ) => {
   const tenantDb = getTenantDb(organizationId)
@@ -12,7 +15,7 @@ export const getRepository = async (
     .executeTakeFirst()
 }
 
-export const getIntegration = async (organizationId: string) => {
+export const getIntegration = async (organizationId: OrganizationId) => {
   const tenantDb = getTenantDb(organizationId)
   return await tenantDb
     .selectFrom('integrations')

--- a/app/routes/$orgSlug/settings/repositories._index/queries.server.ts
+++ b/app/routes/$orgSlug/settings/repositories._index/queries.server.ts
@@ -1,8 +1,11 @@
 import { sql } from 'kysely'
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
 interface ListFilteredRepositoriesArgs {
-  organizationId: string
+  organizationId: OrganizationId
   repo: string
   currentPage: number
   pageSize: number

--- a/app/routes/$orgSlug/settings/repositories.add/+functions/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.add/+functions/mutations.server.ts
@@ -1,9 +1,12 @@
 import { nanoid } from 'nanoid'
 import { sql } from '~/app/services/db.server'
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
 export const addRepository = async (
-  organizationId: string,
+  organizationId: OrganizationId,
   data: { owner: string; repo: string },
 ) => {
   const tenantDb = getTenantDb(organizationId)

--- a/app/routes/$orgSlug/settings/repositories.add/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.add/+functions/queries.server.ts
@@ -1,7 +1,10 @@
 import { jsonArrayFrom } from 'kysely/helpers/sqlite'
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 
-export const getIntegration = async (organizationId: string) => {
+export const getIntegration = async (organizationId: OrganizationId) => {
   const tenantDb = getTenantDb(organizationId)
   return await tenantDb
     .selectFrom('integrations')
@@ -20,7 +23,7 @@ export const getIntegration = async (organizationId: string) => {
     .executeTakeFirst()
 }
 
-export const listRepositories = async (organizationId: string) => {
+export const listRepositories = async (organizationId: OrganizationId) => {
   const tenantDb = getTenantDb(organizationId)
   return await tenantDb.selectFrom('repositories').selectAll().execute()
 }

--- a/app/routes/admin/+create/mutations.server.ts
+++ b/app/routes/admin/+create/mutations.server.ts
@@ -5,6 +5,7 @@ import {
   createTenantDb,
   deleteTenantDb,
   getTenantDb,
+  type OrganizationId,
 } from '~/app/services/tenant-db.server'
 
 export const createOrganization = async ({
@@ -47,9 +48,10 @@ export const createOrganization = async ({
   })
 
   // 2. Create tenant DB file + apply migrations + default settings
+  const orgId = organization.id as OrganizationId
   try {
-    createTenantDb(organization.id)
-    const tenantDb = getTenantDb(organization.id)
+    createTenantDb(orgId)
+    const tenantDb = getTenantDb(orgId)
     await tenantDb
       .insertInto('organizationSettings')
       .values({
@@ -63,7 +65,7 @@ export const createOrganization = async ({
       .deleteFrom('organizations')
       .where('id', '=', organization.id)
       .execute()
-    await deleteTenantDb(organization.id)
+    await deleteTenantDb(orgId)
     throw e
   }
 

--- a/app/services/tenant-db.server.test.ts
+++ b/app/services/tenant-db.server.test.ts
@@ -17,6 +17,8 @@ vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
 
 const { closeTenantDb, closeAllTenantDbs, deleteTenantDb, getTenantDb } =
   await import('./tenant-db.server')
+type OrganizationId = import('./tenant-db.server').OrganizationId
+const toOrgId = (s: string) => s as OrganizationId
 
 function createTestTenantDb(orgId: string): string {
   const dbPath = path.join(testDir, `tenant_${orgId}.db`)
@@ -27,7 +29,7 @@ function createTestTenantDb(orgId: string): string {
 }
 
 describe('getTenantDb', () => {
-  const orgId = `test-org-get-${Date.now()}`
+  const orgId = toOrgId(`test-org-get-${Date.now()}`)
 
   beforeEach(() => {
     createTestTenantDb(orgId)
@@ -49,12 +51,12 @@ describe('getTenantDb', () => {
   })
 
   test('throws when tenant DB file does not exist', () => {
-    expect(() => getTenantDb('nonexistent-org')).toThrow()
+    expect(() => getTenantDb(toOrgId('nonexistent-org'))).toThrow()
   })
 })
 
 describe('closeTenantDb', () => {
-  const orgId = `test-org-close-${Date.now()}`
+  const orgId = toOrgId(`test-org-close-${Date.now()}`)
 
   beforeEach(() => {
     createTestTenantDb(orgId)
@@ -68,13 +70,13 @@ describe('closeTenantDb', () => {
   })
 
   test('does not throw for unknown orgId', async () => {
-    await expect(closeTenantDb('unknown-org')).resolves.not.toThrow()
+    await expect(closeTenantDb(toOrgId('unknown-org'))).resolves.not.toThrow()
   })
 })
 
 describe('closeAllTenantDbs', () => {
-  const orgId1 = `test-org-all-1-${Date.now()}`
-  const orgId2 = `test-org-all-2-${Date.now()}`
+  const orgId1 = toOrgId(`test-org-all-1-${Date.now()}`)
+  const orgId2 = toOrgId(`test-org-all-2-${Date.now()}`)
 
   beforeEach(() => {
     createTestTenantDb(orgId1)
@@ -98,7 +100,7 @@ describe('closeAllTenantDbs', () => {
 })
 
 describe('deleteTenantDb', () => {
-  const orgId = `test-org-delete-${Date.now()}`
+  const orgId = toOrgId(`test-org-delete-${Date.now()}`)
 
   test('deletes the DB file and WAL/SHM files', async () => {
     const dbPath = createTestTenantDb(orgId)
@@ -118,7 +120,7 @@ describe('deleteTenantDb', () => {
 
   test('does not throw when DB file does not exist', async () => {
     await expect(
-      deleteTenantDb('nonexistent-delete-org'),
+      deleteTenantDb(toOrgId('nonexistent-delete-org')),
     ).resolves.not.toThrow()
   })
 })

--- a/app/services/tenant-db.server.ts
+++ b/app/services/tenant-db.server.ts
@@ -13,11 +13,14 @@ import type * as TenantDB from './tenant-type'
 
 export type { TenantDB }
 
+/** Branded type for organization IDs to prevent mixing with arbitrary strings */
+export type OrganizationId = string & { readonly __brand: 'OrganizationId' }
+
 const debug = createDebug('app:tenant-db')
 
 const tenantDbCache = new Map<string, Kysely<TenantDB.DB>>()
 
-function getTenantDbPath(organizationId: string): string {
+function getTenantDbPath(organizationId: OrganizationId): string {
   if (!process.env.DATABASE_URL) {
     throw new Error('DATABASE_URL environment variable is required')
   }
@@ -26,7 +29,9 @@ function getTenantDbPath(organizationId: string): string {
   return path.join(dir, `tenant_${organizationId}.db`)
 }
 
-export function getTenantDb(organizationId: string): Kysely<TenantDB.DB> {
+export function getTenantDb(
+  organizationId: OrganizationId,
+): Kysely<TenantDB.DB> {
   const cached = tenantDbCache.get(organizationId)
   if (cached) return cached
 
@@ -44,7 +49,9 @@ export function getTenantDb(organizationId: string): Kysely<TenantDB.DB> {
   return tenantDb
 }
 
-export async function closeTenantDb(organizationId: string): Promise<void> {
+export async function closeTenantDb(
+  organizationId: OrganizationId,
+): Promise<void> {
   const tenantDb = tenantDbCache.get(organizationId)
   if (tenantDb) {
     await tenantDb.destroy()
@@ -63,7 +70,7 @@ export async function closeAllTenantDbs(): Promise<void> {
  * Create a new tenant DB file and apply migrations.
  * Call this when creating a new organization.
  */
-export function createTenantDb(organizationId: string): void {
+export function createTenantDb(organizationId: OrganizationId): void {
   const tenantDbPath = getTenantDbPath(organizationId)
   execFileSync(
     'atlas',
@@ -83,7 +90,9 @@ export function createTenantDb(organizationId: string): void {
  * Delete the tenant DB file.
  * Call closeTenantDb first to release the connection.
  */
-export async function deleteTenantDb(organizationId: string): Promise<void> {
+export async function deleteTenantDb(
+  organizationId: OrganizationId,
+): Promise<void> {
   await closeTenantDb(organizationId)
   const tenantDbPath = getTenantDbPath(organizationId)
   if (existsSync(tenantDbPath)) {

--- a/batch/commands/fetch.ts
+++ b/batch/commands/fetch.ts
@@ -1,5 +1,6 @@
 import consola from 'consola'
 import invariant from 'tiny-invariant'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { getOrganization } from '~/batch/db'
 import { allConfigs } from '../config'
 import { createProvider } from '../provider'
@@ -22,7 +23,8 @@ export async function fetchCommand(props: FetchCommandProps) {
     return
   }
 
-  const organization = await getOrganization(props.organizationId)
+  const orgId = props.organizationId as OrganizationId
+  const organization = await getOrganization(orgId)
   invariant(organization.integration, 'integration should related')
 
   const provider = createProvider(organization.integration)
@@ -34,7 +36,7 @@ export async function fetchCommand(props: FetchCommandProps) {
       : repo.id !== props.exclude
   })
   for (const repository of repositories) {
-    await provider.fetch(repository, {
+    await provider.fetch(orgId, repository, {
       refresh: props.refresh,
       halt: false,
     })

--- a/batch/commands/report.ts
+++ b/batch/commands/report.ts
@@ -1,5 +1,6 @@
 import consola from 'consola'
 import invariant from 'tiny-invariant'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { getOrganization, getPullRequestReport } from '~/batch/db'
 import { allConfigs } from '../config'
 import { timeFormatTz } from '../helper/timeformat'
@@ -19,7 +20,8 @@ export async function reportCommand({ organizationId }: reportCommandProps) {
     return
   }
 
-  const organization = await getOrganization(organizationId)
+  const orgId = organizationId as OrganizationId
+  const organization = await getOrganization(orgId)
   invariant(organization.integration, 'integration should related')
 
   console.log(
@@ -46,7 +48,7 @@ export async function reportCommand({ organizationId }: reportCommandProps) {
   )
   const tz = 'Asia/Tokyo'
 
-  const prList = await getPullRequestReport(organization.id)
+  const prList = await getPullRequestReport(orgId)
   for (const pr of prList) {
     console.log(
       [

--- a/batch/commands/upsert.ts
+++ b/batch/commands/upsert.ts
@@ -1,5 +1,6 @@
 import consola from 'consola'
 import invariant from 'tiny-invariant'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { getOrganization } from '~/batch/db'
 import { allConfigs } from '../config'
 import { createProvider } from '../provider/index'
@@ -20,7 +21,8 @@ export async function upsertCommand({ organizationId }: UpsertCommandProps) {
     return
   }
 
-  const organization = await getOrganization(organizationId)
+  const orgId = organizationId as OrganizationId
+  const organization = await getOrganization(orgId)
   invariant(organization.integration, 'integration should related')
   invariant(
     organization.organizationSetting,
@@ -32,8 +34,10 @@ export async function upsertCommand({ organizationId }: UpsertCommandProps) {
 
   await analyzeAndUpsert({
     organization: {
-      ...organization,
+      id: orgId,
       organizationSetting: organization.organizationSetting,
+      repositories: organization.repositories,
+      exportSetting: organization.exportSetting,
     },
     provider,
   })

--- a/batch/config/index.ts
+++ b/batch/config/index.ts
@@ -1,7 +1,8 @@
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { listAllOrganizations } from '~/batch/db'
 
 export interface Config {
-  organizationId: string
+  organizationId: OrganizationId
   organizationName: string
   integration: {
     id: string
@@ -16,7 +17,7 @@ export const allConfigs = async () => {
   const organizations = await listAllOrganizations()
   const configs = organizations.map((org) => {
     return {
-      organizationId: org.id,
+      organizationId: org.id as OrganizationId,
       organizationName: org.name,
       integration: org.integration,
       repositories: org.repositories.map((repo) => ({ id: repo.id })),
@@ -25,7 +26,7 @@ export const allConfigs = async () => {
   return configs
 }
 
-export const loadConfig = async (organizationId: string) => {
+export const loadConfig = async (organizationId: OrganizationId) => {
   const configs = await allConfigs()
   return configs.find((config) => config.organizationId === organizationId)
 }

--- a/batch/db/mutations.ts
+++ b/batch/db/mutations.ts
@@ -1,9 +1,13 @@
 import type { Insertable } from 'kysely'
-import { getTenantDb, type TenantDB } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+  type TenantDB,
+} from '~/app/services/tenant-db.server'
 import { timeFormatUTC } from '../helper/timeformat'
 
 export function upsertPullRequest(
-  organizationId: string,
+  organizationId: OrganizationId,
   data: Insertable<TenantDB.PullRequests>,
 ) {
   const firstCommittedAt = timeFormatUTC(data.firstCommittedAt)
@@ -54,7 +58,7 @@ export function upsertPullRequest(
 }
 
 export function upsertPullRequestReview(
-  organizationId: string,
+  organizationId: OrganizationId,
   data: Insertable<TenantDB.PullRequestReviews>,
 ) {
   const tenantDb = getTenantDb(organizationId)
@@ -73,7 +77,7 @@ export function upsertPullRequestReview(
 }
 
 export async function upsertPullRequestReviewers(
-  organizationId: string,
+  organizationId: OrganizationId,
   repositoryId: string,
   pullRequestNumber: number,
   reviewers: string[],

--- a/batch/db/queries.ts
+++ b/batch/db/queries.ts
@@ -1,7 +1,8 @@
 import { db } from '~/app/services/db.server'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { getTenantDb } from '~/app/services/tenant-db.server'
 
-export const getPullRequestReport = async (organizationId: string) => {
+export const getPullRequestReport = async (organizationId: OrganizationId) => {
   const tenantDb = getTenantDb(organizationId)
   return await tenantDb
     .selectFrom('pullRequests')
@@ -11,7 +12,7 @@ export const getPullRequestReport = async (organizationId: string) => {
     .execute()
 }
 
-async function getTenantData(organizationId: string) {
+async function getTenantData(organizationId: OrganizationId) {
   const tenantDb = getTenantDb(organizationId)
   const [organizationSetting, integration, repositories, exportSetting] =
     await Promise.all([
@@ -57,9 +58,9 @@ async function getTenantData(organizationId: string) {
     ])
   return {
     organizationSetting: organizationSetting ?? null,
-    integration: integration ? { ...integration, organizationId } : null,
-    repositories: repositories.map((r) => ({ ...r, organizationId })),
-    exportSetting: exportSetting ? { ...exportSetting, organizationId } : null,
+    integration: integration ?? null,
+    repositories,
+    exportSetting: exportSetting ?? null,
   }
 }
 
@@ -71,19 +72,19 @@ export const listAllOrganizations = async () => {
 
   return Promise.all(
     orgs.map(async (org) => {
-      const tenantData = await getTenantData(org.id)
+      const tenantData = await getTenantData(org.id as OrganizationId)
       return { ...org, ...tenantData }
     }),
   )
 }
 
-export const getOrganization = async (organizationId: string) => {
+export const getOrganization = async (organizationId: OrganizationId) => {
   const org = await db
     .selectFrom('organizations')
     .select(['id', 'name', 'slug', 'createdAt'])
     .where('id', '=', organizationId)
     .executeTakeFirstOrThrow()
 
-  const tenantData = await getTenantData(org.id)
+  const tenantData = await getTenantData(org.id as OrganizationId)
   return { ...org, ...tenantData }
 }

--- a/batch/helper/path-builder.test.ts
+++ b/batch/helper/path-builder.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, test } from 'vitest'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { createPathBuilder, getDataDir } from './path-builder'
 
 describe('getDataDir', () => {
@@ -10,7 +11,7 @@ describe('getDataDir', () => {
 describe('path-builder', () => {
   test('jsonPath builds correct path', () => {
     const pathBuilder = createPathBuilder({
-      organizationId: 'test-company',
+      organizationId: 'test-company' as OrganizationId,
       repositoryId: 'test-repository',
     })
 

--- a/batch/helper/path-builder.ts
+++ b/batch/helper/path-builder.ts
@@ -1,4 +1,5 @@
 import path from 'node:path'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 
 /**
  * データディレクトリを取得
@@ -14,7 +15,7 @@ export const getDataDir = () => {
 }
 
 interface createPathBuilderProps {
-  organizationId: string
+  organizationId: OrganizationId
   repositoryId: string
 }
 export const createPathBuilder = ({

--- a/batch/jobs/crawl.ts
+++ b/batch/jobs/crawl.ts
@@ -1,4 +1,7 @@
-import { getTenantDb } from '~/app/services/tenant-db.server'
+import {
+  getTenantDb,
+  type OrganizationId,
+} from '~/app/services/tenant-db.server'
 import { listAllOrganizations } from '~/batch/db'
 import { logger } from '../helper/logger'
 import { createProvider } from '../provider'
@@ -34,6 +37,8 @@ export const crawlJob = async () => {
       continue
     }
 
+    const orgId = organization.id as OrganizationId
+
     // refreshRequestedAt が設定されていれば full refresh
     const refresh = organization.organizationSetting.refreshRequestedAt != null
     if (refresh) {
@@ -44,13 +49,13 @@ export const crawlJob = async () => {
     // fetch
     for (const repository of organization.repositories) {
       logger.info('fetch started...')
-      await provider.fetch(repository, options)
+      await provider.fetch(orgId, repository, options)
       logger.info('fetch completed.')
     }
 
     // refresh フラグを消費
     if (refresh) {
-      const tenantDb = getTenantDb(organization.id)
+      const tenantDb = getTenantDb(orgId)
       await tenantDb
         .updateTable('organizationSettings')
         .set({ refreshRequestedAt: null })
@@ -61,8 +66,10 @@ export const crawlJob = async () => {
     // analyze + upsert + export
     await analyzeAndUpsert({
       organization: {
-        ...organization,
+        id: orgId,
         organizationSetting: organization.organizationSetting,
+        repositories: organization.repositories,
+        exportSetting: organization.exportSetting,
       },
       provider,
     })

--- a/batch/provider/github/provider.ts
+++ b/batch/provider/github/provider.ts
@@ -13,6 +13,7 @@ export const createGitHubProvider = (
   integration: Selectable<TenantDB.Integrations>,
 ): Provider => {
   const fetch: Provider['fetch'] = async (
+    organizationId,
     repository,
     { refresh = false, halt = false },
   ) => {
@@ -27,11 +28,11 @@ export const createGitHubProvider = (
     })
     const aggregator = createAggregator()
     const store = createStore({
-      organizationId: repository.organizationId,
+      organizationId,
       repositoryId: repository.id,
     })
     const pathBuilder = createPathBuilder({
-      organizationId: repository.organizationId,
+      organizationId,
       repositoryId: repository.id,
     })
 
@@ -153,6 +154,7 @@ export const createGitHubProvider = (
   }
 
   const analyze: Provider['analyze'] = async (
+    organizationId,
     organizationSetting,
     repositories,
     onProgress,
@@ -188,13 +190,13 @@ export const createGitHubProvider = (
       onProgress?.({ repo: repository.repo, current, total })
 
       const store = createStore({
-        organizationId: repository.organizationId,
+        organizationId,
         repositoryId: repository.id,
       })
       const { pulls, reviews, reviewers, reviewResponses } =
         await buildPullRequests(
           {
-            organizationId: repository.organizationId,
+            organizationId,
             repositoryId: repository.id,
             releaseDetectionMethod:
               repository.releaseDetectionMethod ??

--- a/batch/provider/github/pullrequest.ts
+++ b/batch/provider/github/pullrequest.ts
@@ -1,7 +1,7 @@
 import type { Selectable } from 'kysely'
 import { first } from 'remeda'
 import dayjs from '~/app/libs/dayjs'
-import type { TenantDB } from '~/app/services/tenant-db.server'
+import type { OrganizationId, TenantDB } from '~/app/services/tenant-db.server'
 import {
   codingTime,
   deployTime,
@@ -40,7 +40,7 @@ interface PrDates {
 
 /** buildPullRequests の設定 */
 interface BuildConfig {
-  organizationId: string
+  organizationId: OrganizationId
   repositoryId: string
   releaseDetectionMethod: string
   releaseDetectionKey: string

--- a/batch/provider/github/store.ts
+++ b/batch/provider/github/store.ts
@@ -1,5 +1,6 @@
 import fs from 'node:fs/promises'
 import path from 'node:path'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { createPathBuilder } from '~/batch/helper/path-builder'
 import type {
   ShapedGitHubCommit,
@@ -10,7 +11,7 @@ import type {
 } from './model'
 
 interface createStoreProps {
-  organizationId: string
+  organizationId: OrganizationId
   repositoryId: string
 }
 export const createStore = ({

--- a/batch/provider/index.ts
+++ b/batch/provider/index.ts
@@ -1,26 +1,23 @@
 import type { Selectable } from 'kysely'
 import { match } from 'ts-pattern'
-import type { TenantDB } from '~/app/services/tenant-db.server'
+import type { OrganizationId, TenantDB } from '~/app/services/tenant-db.server'
 import { createGitHubProvider } from './github/provider'
-
-/** Repository with organizationId (added back by getTenantData for batch compatibility) */
-type RepositoryWithOrg = Selectable<TenantDB.Repositories> & {
-  organizationId: string
-}
 
 /** Provider が提供する機能の契約 */
 export interface Provider {
   fetch: (
-    repository: RepositoryWithOrg,
+    organizationId: OrganizationId,
+    repository: Selectable<TenantDB.Repositories>,
     options: { refresh?: boolean; halt?: boolean },
   ) => Promise<void>
 
   analyze: (
+    organizationId: OrganizationId,
     organizationSetting: Pick<
       Selectable<TenantDB.OrganizationSettings>,
       'releaseDetectionMethod' | 'releaseDetectionKey' | 'excludedUsers'
     >,
-    repositories: RepositoryWithOrg[],
+    repositories: Selectable<TenantDB.Repositories>[],
     onProgress?: (progress: {
       repo: string
       current: number

--- a/batch/scripts/golden-compare.ts
+++ b/batch/scripts/golden-compare.ts
@@ -2,6 +2,7 @@ import { cli } from 'cleye'
 import consola from 'consola'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { getOrganization, listAllOrganizations } from '~/batch/db'
 import { createProvider } from '~/batch/provider'
 
@@ -81,7 +82,7 @@ const sortReviewResponses = (responses: unknown[]) =>
 
 const buildSnapshot = async () => {
   const organizations = argv.flags.org
-    ? [await getOrganization(argv.flags.org)]
+    ? [await getOrganization(argv.flags.org as OrganizationId)]
     : await listAllOrganizations()
 
   const snapshot = {
@@ -128,6 +129,7 @@ const buildSnapshot = async () => {
     }
 
     const { pulls, reviewResponses } = await provider.analyze(
+      organization.id as OrganizationId,
       {
         releaseDetectionMethod: orgSetting.releaseDetectionMethod,
         releaseDetectionKey: orgSetting.releaseDetectionKey,

--- a/batch/scripts/golden-snapshot.ts
+++ b/batch/scripts/golden-snapshot.ts
@@ -2,6 +2,7 @@ import { cli } from 'cleye'
 import consola from 'consola'
 import { mkdir, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { getOrganization, listAllOrganizations } from '~/batch/db'
 import { createProvider } from '~/batch/provider'
 
@@ -77,7 +78,7 @@ const sortReviewResponses = (responses: unknown[]) =>
 const main = async () => {
   const outPath = argv.flags.out
   const organizations = argv.flags.org
-    ? [await getOrganization(argv.flags.org)]
+    ? [await getOrganization(argv.flags.org as OrganizationId)]
     : await listAllOrganizations()
 
   const snapshot = {
@@ -124,6 +125,7 @@ const main = async () => {
     }
 
     const { pulls, reviewResponses } = await provider.analyze(
+      organization.id as OrganizationId,
       {
         releaseDetectionMethod: orgSetting.releaseDetectionMethod,
         releaseDetectionKey: orgSetting.releaseDetectionKey,

--- a/batch/usecases/analyze-and-upsert.ts
+++ b/batch/usecases/analyze-and-upsert.ts
@@ -1,5 +1,5 @@
 import type { Selectable } from 'kysely'
-import type { TenantDB } from '~/app/services/tenant-db.server'
+import type { OrganizationId, TenantDB } from '~/app/services/tenant-db.server'
 import { createSpreadsheetExporter } from '~/batch/bizlogic/export-spreadsheet'
 import {
   upsertPullRequest,
@@ -11,14 +11,12 @@ import type { Provider } from '~/batch/provider'
 
 /** analyzeAndUpsert に渡す organization の必須フィールド */
 interface OrganizationForAnalyze {
-  id: string
+  id: OrganizationId
   organizationSetting: Pick<
     Selectable<TenantDB.OrganizationSettings>,
     'releaseDetectionMethod' | 'releaseDetectionKey' | 'excludedUsers'
   >
-  repositories: (Selectable<TenantDB.Repositories> & {
-    organizationId: string
-  })[]
+  repositories: Selectable<TenantDB.Repositories>[]
   exportSetting?: Selectable<TenantDB.ExportSettings> | null
 }
 
@@ -39,6 +37,7 @@ export async function analyzeAndUpsert({
   // 1. analyze
   logger.info('analyze started...', orgId)
   const { pulls, reviews, reviewers, reviewResponses } = await provider.analyze(
+    orgId,
     organization.organizationSetting,
     organization.repositories,
   )

--- a/db/seed.ts
+++ b/db/seed.ts
@@ -8,6 +8,7 @@ import {
   createTenantDb,
   getTenantDb,
   getTenantDbPath,
+  type OrganizationId,
 } from '~/app/services/tenant-db.server'
 
 async function seed() {
@@ -87,11 +88,12 @@ async function seed() {
 
   // --- Tenant DB ---
   // Create tenant DB file and apply migrations
-  const tenantDbPath = getTenantDbPath(organization.id)
+  const orgId = organization.id as OrganizationId
+  const tenantDbPath = getTenantDbPath(orgId)
   consola.info(`Creating tenant DB at ${tenantDbPath}...`)
-  createTenantDb(organization.id)
+  createTenantDb(orgId)
 
-  const tenantDb = getTenantDb(organization.id)
+  const tenantDb = getTenantDb(orgId)
 
   // organization settings
   await tenantDb
@@ -170,7 +172,7 @@ async function seed() {
     .execute()
 
   // Close tenant DB connection to flush WAL before copying
-  await closeTenantDb(organization.id)
+  await closeTenantDb(orgId)
 
   // Copy tenant DB for type generation (used by db:generate:tenant)
   copyFileSync(tenantDbPath, './data/tenant_seed.db')

--- a/lab/fetch.ts
+++ b/lab/fetch.ts
@@ -13,6 +13,7 @@ import consola from 'consola'
 import 'dotenv/config'
 import fs from 'node:fs'
 import path from 'node:path'
+import type { OrganizationId } from '~/app/services/tenant-db.server'
 import { getOrganization, listAllOrganizations } from '~/batch/db/queries'
 import { createGitHubClient } from './lib/github'
 
@@ -38,7 +39,7 @@ async function main() {
     process.exit(1)
   }
 
-  const org = await getOrganization(orgs[0].id)
+  const org = await getOrganization(orgs[0].id as OrganizationId)
   if (!org.integration) {
     consola.error('No integration configured for organization:', org.name)
     process.exit(1)


### PR DESCRIPTION
## Summary
- Introduce `OrganizationId` branded type (`string & { __brand: 'OrganizationId' }`) for compile-time safety
- Remove `RepositoryWithOrg` type hack from Provider interface; pass `organizationId` as separate argument to `fetch`/`analyze`
- Remove organizationId re-attach in `batch/db/queries.ts` (`getTenantData`)
- Update all 40 files across routes, batch, services, tests, and scripts

Follows up on items documented in `docs/database-per-tenant.md` "フォローアップ TODO" section.

## Design decisions
- Cast at system boundaries only: `requireOrgMember`/`requireOrgAdmin` return, DB reads, CLI args
- All downstream functions receive `OrganizationId` — no raw `string` flows through tenant-scoped code paths

## Test plan
- [x] `pnpm validate` — lint, format, typecheck, build, test all pass (31 tests)
- [x] Branded type correctly catches `string` misuse at compile time

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored organization identifier handling across the application by introducing a specialized type for organization references. Updates affect multiple system operations including organization management, data access operations, repository handling, and background processing workflows.

* **Tests**
  * Updated tests to ensure compatibility with the refactored organization identifier type.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->