### PR TITLE
fix: improve header breadcrumbs, sidebar SSR state, and settings nav

### DIFF
--- a/app/hooks/use-breadcrumbs.tsx
+++ b/app/hooks/use-breadcrumbs.tsx
@@ -48,7 +48,7 @@ export const useBreadcrumbs = () => {
   const Breadcrumbs = () => {
     return (
       <Breadcrumb>
-        <BreadcrumbList className="px-4">
+        <BreadcrumbList>
           {breadcrumbItems.map((item, idx) => {
             return (
               <React.Fragment key={item.label}>

--- a/app/routes/$orgSlug/_layout.tsx
+++ b/app/routes/$orgSlug/_layout.tsx
@@ -38,11 +38,19 @@ export const loader = async ({ request, params }: Route.LoaderArgs) => {
     orgSlug,
   )
   const organizations = await getUserOrganizations(user.id)
-  return { user, organization, membership, organizations }
+
+  const cookieHeader = request.headers.get('Cookie') ?? ''
+  const sidebarState = cookieHeader
+    .split('; ')
+    .find((c) => c.startsWith('sidebar_state='))
+    ?.split('=')[1]
+  const defaultOpen = sidebarState !== 'false'
+
+  return { user, organization, membership, organizations, defaultOpen }
 }
 
 export default function OrgLayout({
-  loaderData: { user, organization, membership, organizations },
+  loaderData: { user, organization, membership, organizations, defaultOpen },
 }: Route.ComponentProps) {
   const { Breadcrumbs } = useBreadcrumbs()
   const matches = useMatches()
@@ -52,7 +60,7 @@ export default function OrgLayout({
   }, {}) as RouteHandle
 
   return (
-    <SidebarProvider>
+    <SidebarProvider defaultOpen={defaultOpen}>
       <AppSidebar
         user={user}
         organization={organization}
@@ -69,8 +77,9 @@ export default function OrgLayout({
           'flex h-svh flex-col',
         )}
       >
-        <Header fixed={handle.headerFixed} />
-        <Breadcrumbs />
+        <Header fixed={handle.headerFixed}>
+          <Breadcrumbs />
+        </Header>
         <Main fixed={handle.mainFixed}>
           <Outlet />
         </Main>

--- a/app/routes/$orgSlug/settings/+components/sidebar-nav.tsx
+++ b/app/routes/$orgSlug/settings/+components/sidebar-nav.tsx
@@ -1,5 +1,5 @@
 import type { JSX } from 'react'
-import { Link, useLocation, useNavigate } from 'react-router'
+import { NavLink, useLocation, useNavigate } from 'react-router'
 import { buttonVariants } from '~/app/components/ui/button'
 import { ScrollArea, ScrollBar } from '~/app/components/ui/scroll-area'
 import {
@@ -27,10 +27,16 @@ export default function SidebarNav({
   const { pathname } = useLocation()
   const navigate = useNavigate()
 
+  const isEndHref = (href: string) => href === items[0]?.href
+
   const activeHref =
-    items.find(
-      (item) => pathname === item.href || pathname.startsWith(`${item.href}/`),
-    )?.href ??
+    [...items]
+      .sort((a, b) => b.href.length - a.href.length)
+      .find(
+        (item) =>
+          pathname === item.href ||
+          (!isEndHref(item.href) && pathname.startsWith(`${item.href}/`)),
+      )?.href ??
     items[0]?.href ??
     ''
 
@@ -66,20 +72,23 @@ export default function SidebarNav({
           {...props}
         >
           {items.map((item) => (
-            <Link
+            <NavLink
               key={item.href}
               to={item.href}
-              className={cn(
-                buttonVariants({ variant: 'ghost' }),
-                pathname === item.href || pathname.startsWith(`${item.href}/`)
-                  ? 'bg-muted hover:bg-muted'
-                  : 'hover:bg-transparent hover:underline',
-                'justify-start',
-              )}
+              end={isEndHref(item.href)}
+              className={({ isActive }) =>
+                cn(
+                  buttonVariants({ variant: 'ghost' }),
+                  isActive
+                    ? 'bg-muted hover:bg-muted'
+                    : 'hover:bg-transparent hover:underline',
+                  'justify-start',
+                )
+              }
             >
               <span>{item.icon}</span>
               {item.title}
-            </Link>
+            </NavLink>
           ))}
         </nav>
         <ScrollBar orientation="horizontal" />


### PR DESCRIPTION
## Summary
- Move breadcrumbs into the header bar (next to sidebar trigger) to save vertical space
- Persist sidebar open/closed state across page reloads by reading `sidebar_state` cookie in SSR loader
- Fix settings sidebar nav where "General" was always highlighted by using `NavLink` with `end` prop

## Test plan
- [ ] Verify breadcrumbs appear inline in the header bar
- [ ] Toggle sidebar closed, reload page — sidebar should stay closed
- [ ] Navigate to Settings > Members, Repositories, etc. — only the current item should be highlighted

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sidebar now remembers open/closed state between sessions.

* **Bug Fixes**
  * Improved navigation item active state detection for accurate highlighting in settings menu.

* **Style**
  * Adjusted breadcrumb spacing and repositioned breadcrumbs within header layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->