### PR TITLE
fix: add page headers to Dashboard and Ongoing pages

### DIFF
--- a/app/components/layout/main.tsx
+++ b/app/components/layout/main.tsx
@@ -9,7 +9,7 @@ export const Main = ({ fixed, className, ...props }: MainProps) => {
   return (
     <main
       className={cn(
-        'px-4 py-6',
+        'px-4 pt-0 pb-2',
         fixed && 'flex grow flex-col overflow-hidden',
         className,
       )}

--- a/app/routes/$orgSlug/_index/index.tsx
+++ b/app/routes/$orgSlug/_index/index.tsx
@@ -2,6 +2,12 @@ import { CopyIcon } from 'lucide-react'
 import { useSearchParams } from 'react-router'
 import { toast } from 'sonner'
 import { AppDataTable } from '~/app/components'
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderHeading,
+  PageHeaderTitle,
+} from '~/app/components/layout/page-header'
 import { Badge, Button, HStack, Label, Stack } from '~/app/components/ui'
 import WeeklyCalendar from '~/app/components/week-calendar'
 import { requireOrgMember } from '~/app/libs/auth.server'
@@ -69,6 +75,25 @@ export default function OrganizationIndex({
 
   return (
     <Stack>
+      <PageHeader>
+        <PageHeaderHeading>
+          <PageHeaderTitle>Dashboard</PageHeaderTitle>
+        </PageHeaderHeading>
+        <PageHeaderActions>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              navigator.clipboard.writeText(generateMarkdown(pullRequests))
+              toast.info(`Copied ${pullRequests.length} rows`)
+            }}
+          >
+            <CopyIcon size="16" />
+          </Button>
+        </PageHeaderActions>
+      </PageHeader>
+
       <div className="flex flex-col items-start gap-x-4 gap-y-2 md:flex-row">
         <HStack>
           <div>
@@ -116,20 +141,6 @@ export default function OrganizationIndex({
             </div>
           </div>
         </div>
-
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="w-full md:w-auto"
-          onClick={() => {
-            // markdown 表形式でコピー
-            navigator.clipboard.writeText(generateMarkdown(pullRequests))
-            toast.info(`Copied ${pullRequests.length} rows`)
-          }}
-        >
-          <CopyIcon size="16" />
-        </Button>
       </div>
 
       <AppDataTable

--- a/app/routes/$orgSlug/ongoing/index.tsx
+++ b/app/routes/$orgSlug/ongoing/index.tsx
@@ -1,6 +1,12 @@
 import { CopyIcon } from 'lucide-react'
 import { toast } from 'sonner'
 import { AppDataTable } from '~/app/components'
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderHeading,
+  PageHeaderTitle,
+} from '~/app/components/layout/page-header'
 import { Button, Stack } from '~/app/components/ui'
 import { requireOrgMember } from '~/app/libs/auth.server'
 import dayjs from '~/app/libs/dayjs'
@@ -34,22 +40,26 @@ export default function OngoingPage({
 }: Route.ComponentProps) {
   return (
     <Stack>
-      <div className="text-right">
-        <Button
-          type="button"
-          variant="outline"
-          size="sm"
-          className="w-full md:w-auto"
-          onClick={() => {
-            navigator.clipboard
-              .writeText(generateMarkdown(pullRequests))
-              .then(() => toast.info(`Copied ${pullRequests.length} rows`))
-              .catch(() => toast.error('Failed to copy to clipboard'))
-          }}
-        >
-          <CopyIcon size="16" />
-        </Button>
-      </div>
+      <PageHeader>
+        <PageHeaderHeading>
+          <PageHeaderTitle>Ongoing</PageHeaderTitle>
+        </PageHeaderHeading>
+        <PageHeaderActions>
+          <Button
+            type="button"
+            variant="outline"
+            size="sm"
+            onClick={() => {
+              navigator.clipboard
+                .writeText(generateMarkdown(pullRequests))
+                .then(() => toast.info(`Copied ${pullRequests.length} rows`))
+                .catch(() => toast.error('Failed to copy to clipboard'))
+            }}
+          >
+            <CopyIcon size="16" />
+          </Button>
+        </PageHeaderActions>
+      </PageHeader>
 
       <AppDataTable
         title={


### PR DESCRIPTION
## Summary
- Add `PageHeader` with title and copy action button to Dashboard and Ongoing pages for consistent layout
- Reduce `Main` component top padding (`py-6` → `pt-0 pb-2`) for tighter header-to-content spacing

## Test plan
- [ ] Dashboard page shows "Dashboard" title with copy button in header
- [ ] Ongoing page shows "Ongoing" title with copy button in header
- [ ] Settings pages still look correct with reduced padding
- [ ] Copy button still works on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Style**
  * Refined spacing and padding in the main layout component.

* **UI Improvements**
  * Introduced new page header sections for the dashboard and ongoing pages.
  * Relocated the copy button to the page header for improved visibility and easier access.
  * Restructured header layouts to provide a cleaner, more organized interface.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->