### PR TITLE
feat: GitHub ユーザー削除時にもセッション即時無効化

### DIFF
--- a/app/routes/$orgSlug/settings/github-users._index/mutations.server.test.ts
+++ b/app/routes/$orgSlug/settings/github-users._index/mutations.server.test.ts
@@ -47,7 +47,8 @@ const { closeTenantDb } = await import('~/app/services/tenant-db.server')
 type OrganizationId = import('~/app/services/tenant-db.server').OrganizationId
 const toOrgId = (s: string) => s as OrganizationId
 
-const { toggleGithubUserActive } = await import('./mutations.server')
+const { deleteGithubUser, toggleGithubUserActive } =
+  await import('./mutations.server')
 
 const TENANT_SCHEMA = `
   CREATE TABLE IF NOT EXISTS company_github_users (
@@ -122,12 +123,12 @@ function cleanSharedDb() {
   raw.close()
 }
 
+afterAll(() => {
+  vi.unstubAllEnvs()
+})
+
 describe('toggleGithubUserActive session invalidation', () => {
   let orgId: OrganizationId
-
-  afterAll(() => {
-    vi.unstubAllEnvs()
-  })
 
   beforeEach(() => {
     cleanSharedDb()
@@ -181,5 +182,38 @@ describe('toggleGithubUserActive session invalidation', () => {
         organizationId: orgId,
       }),
     ).resolves.not.toThrow()
+  })
+})
+
+describe('deleteGithubUser session invalidation', () => {
+  let orgId: OrganizationId
+
+  beforeEach(() => {
+    cleanSharedDb()
+    orgId = createFreshOrg()
+  })
+
+  afterEach(async () => {
+    await closeTenantDb(orgId)
+  })
+
+  test('deletes all sessions for the user', async () => {
+    const userId = 'user-delete-1'
+    seedUser(userId)
+    seedSession('sess-del-1', userId)
+    seedSession('sess-del-2', userId)
+    seedTenantGithubUser(orgId, 'octocat-del', userId)
+
+    expect(countSessions(userId)).toBe(2)
+
+    await deleteGithubUser('octocat-del', orgId)
+
+    expect(countSessions(userId)).toBe(0)
+  })
+
+  test('with null userId does not error', async () => {
+    seedTenantGithubUser(orgId, 'no-user-del', null)
+
+    await expect(deleteGithubUser('no-user-del', orgId)).resolves.not.toThrow()
   })
 })

--- a/app/routes/$orgSlug/settings/github-users._index/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/github-users._index/mutations.server.ts
@@ -53,6 +53,18 @@ export const deleteGithubUser = async (
   organizationId: OrganizationId,
 ) => {
   const tenantDb = getTenantDb(organizationId)
+
+  // Revoke all sessions for the user before deleting
+  const row = await tenantDb
+    .selectFrom('companyGithubUsers')
+    .select('userId')
+    .where('login', '=', login)
+    .executeTakeFirst()
+
+  if (row?.userId) {
+    await db.deleteFrom('sessions').where('userId', '=', row.userId).execute()
+  }
+
   await tenantDb
     .deleteFrom('companyGithubUsers')
     .where('login', '=', login)


### PR DESCRIPTION
## Summary

- #123 の補完。`deleteGithubUser` にも同じセッション削除ロジックを追加
- ユーザー削除時に既存セッションが有効期限まで残るセキュリティの穴を塞ぐ

## Test plan

- [x] 削除時に userId のセッションが削除される
- [x] userId が null でもエラーにならない
- [x] `pnpm validate` パス（lint, format, typecheck, build, 47 tests）

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * When a GitHub user is removed from an organization, all of their active sessions are now properly invalidated.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->