### PR TITLE
perf: reduce deploy downtime from ~51s to ~22s

### DIFF
--- a/db/apply-tenant-migrations.ts
+++ b/db/apply-tenant-migrations.ts
@@ -1,13 +1,16 @@
 /**
  * Apply tenant migrations to all tenant DBs.
  * Scans data/ directory for tenant_*.db files and applies Atlas migrations.
- * Also used during db:setup to apply migrations to newly created tenant DBs.
+ * Skips tenants that already have the latest migration applied.
  */
+import Database from 'better-sqlite3'
 import { consola } from 'consola'
 import { execFileSync } from 'node:child_process'
 import { readdirSync } from 'node:fs'
+import { join } from 'node:path'
 
 const dataDir = './data'
+const migrationsDir = './db/migrations/tenant'
 
 function getTenantDbFiles(): string[] {
   try {
@@ -16,6 +19,41 @@ function getTenantDbFiles(): string[] {
     )
   } catch {
     return []
+  }
+}
+
+function getLatestMigrationVersion(): string | null {
+  try {
+    const files = readdirSync(migrationsDir).filter((f) => f.endsWith('.sql'))
+    if (files.length === 0) return null
+    // Migration files are named like 20260226112249_initial_tenant.sql or 20260227163239.sql
+    // Sort lexicographically to get the latest version
+    files.sort()
+    const latest = files[files.length - 1]
+    // Extract version (timestamp prefix before _ or .sql)
+    const match = latest.match(/^(\d+)/)
+    return match ? match[1] : null
+  } catch {
+    return null
+  }
+}
+
+function isMigrationApplied(dbPath: string, version: string): boolean {
+  try {
+    const db = new Database(dbPath, { readonly: true })
+    try {
+      const row = db
+        .prepare(
+          'SELECT version FROM atlas_schema_revisions WHERE version = ? LIMIT 1',
+        )
+        .get(version) as { version: string } | undefined
+      return row !== undefined
+    } finally {
+      db.close()
+    }
+  } catch {
+    // Table doesn't exist or DB is new → needs migration
+    return false
   }
 }
 
@@ -31,8 +69,23 @@ const tenantDbs = getTenantDbFiles()
 if (tenantDbs.length === 0) {
   consola.info('No tenant databases found. Skipping tenant migrations.')
 } else {
-  for (const dbFile of tenantDbs) {
-    applyMigrations(dbFile)
+  const latestVersion = getLatestMigrationVersion()
+  if (!latestVersion) {
+    consola.info('No migration files found. Skipping tenant migrations.')
+  } else {
+    let appliedCount = 0
+    let skippedCount = 0
+    for (const dbFile of tenantDbs) {
+      const dbPath = join(dataDir, dbFile)
+      if (isMigrationApplied(dbPath, latestVersion)) {
+        skippedCount++
+      } else {
+        applyMigrations(dbFile)
+        appliedCount++
+      }
+    }
+    consola.info(
+      `Tenant migrations: ${appliedCount} applied, ${skippedCount} skipped (already up-to-date).`,
+    )
   }
-  consola.info(`Applied tenant migrations to ${tenantDbs.length} database(s).`)
 }

--- a/fly.toml
+++ b/fly.toml
@@ -6,7 +6,7 @@
 app = "upflow"
 primary_region = "nrt"
 kill_signal = "SIGINT"
-kill_timeout = "5s"
+kill_timeout = "3s"
 swap_size_mb = 512
 
 [experimental]
@@ -43,9 +43,9 @@ swap_size_mb = 512
     grace_period = "1s"
 
   [[services.http_checks]]
-    interval = "10s"
+    interval = "3s"
     timeout = "2s"
-    grace_period = "5s"
+    grace_period = "10s"
     method = "get"
     path = "/healthcheck"
     protocol = "http"

--- a/server.mjs
+++ b/server.mjs
@@ -60,9 +60,19 @@ app.all(
 )
 
 const port = process.env.PORT || 3000
-app.listen(port, () => {
+const server = app.listen(port, () => {
   consola.info(`Express server listening on port ${port}`)
 })
+
+// Graceful shutdown
+function shutdown() {
+  consola.info('Shutting down...')
+  server.close(() => {
+    process.exit(0)
+  })
+}
+process.on('SIGINT', shutdown)
+process.on('SIGTERM', shutdown)
 
 if (process.env.NODE_ENV === 'production') {
   const { startScheduler } = createJobScheduler()


### PR DESCRIPTION
## Summary

- **Tenant migration skip**: Check `atlas_schema_revisions` via `better-sqlite3` before spawning `atlas` CLI. Up-to-date tenants are skipped instantly (~17s → ~0.1s)
- **Graceful shutdown**: Add SIGINT/SIGTERM handler to `server.mjs` so Fly.io doesn't wait for kill_timeout (~6s → ~1s)
- **Health check tuning**: Reduce check interval to 3s (faster first pass), increase grace_period to 10s (tolerate slow startup)

## Expected improvement

| Phase | Before | After |
|---|---|---|
| shutdown | 6s | ~1s |
| tenant migration | 17s | ~0.1s (skip) |
| server.mjs startup | 15s | 15s (no change) |
| health check first pass | +8s | +3s |
| **Total downtime** | **~51s** | **~22s** |

## Test plan

- [x] `pnpm validate` passes (lint, format, typecheck, build, test)
- [x] `pnpm db:setup` applies migrations correctly (new tenants get full migration, existing tenants are skipped)
- [ ] `fly deploy` and verify startup time in logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added graceful shutdown mechanism to handle termination signals properly.

* **Chores**
  * Optimized tenant database migrations to skip already-applied versions.
  * Adjusted server health check intervals and timeout configuration settings for improved reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->