### PR TITLE
fix: use exec in start.sh for graceful shutdown

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -15,4 +15,4 @@ atlas migrate apply --env local --url "$DB_URL"
 # 2. Apply tenant migrations to all existing tenant DBs
 node build/db/apply-tenant-migrations.js
 
-node server.mjs
+exec node server.mjs


### PR DESCRIPTION
## Summary

- `start.sh` の `node server.mjs` を `exec node server.mjs` に変更
- `sh` プロセスが SIGINT を握りつぶしていたため、`server.mjs` の graceful shutdown ハンドラが動作していなかった
- `exec` により shell が node プロセスに置き換わり、Fly.io からのシグナルが直接届く

## Evidence

デプロイログで SIGINT 後 5s 待って SIGTERM で kill されていた:
```
05:16:01 Sending signal SIGINT to main child process
05:16:06 Sending signal SIGTERM to main child process  ← 5s後
05:16:07 Main child exited with signal SIGTERM
```

## Expected improvement

shutdown: 6s → ~1s

## Test plan

- [ ] `fly deploy` してログで SIGINT 後すぐに exit することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)