### PR TITLE
perf: switch Docker build cache to GHA backend

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -158,15 +158,6 @@ jobs:
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
-      # Setup cache
-      - name: ⚡️ Cache Docker layers
-        uses: actions/cache@v4
-        with:
-          path: /tmp/.buildx-cache
-          key: ${{ runner.os }}-buildx-${{ github.sha }}
-          restore-keys: |
-            ${{ runner.os }}-buildx-
-
       - name: 🔑 Fly Registry Auth
         uses: docker/login-action@v2
         with:
@@ -182,18 +173,9 @@ jobs:
           tags: registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.ref_name }}-${{ github.sha }}
           build-args: |
             COMMIT_SHA=${{ github.sha }}
-          cache-from: type=local,src=/tmp/.buildx-cache
-          cache-to: type=local,mode=max,dest=/tmp/.buildx-cache-new
-
-      # This ugly bit is necessary if you don't want your cache to grow forever
-      # till it hits GitHub's limit of 5GB.
-      # Temp fix
-      # https://github.com/docker/build-push-action/issues/252
-      # https://github.com/moby/buildkit/issues/1896
-      - name: 🚚 Move cache
-        run: |
-          rm -rf /tmp/.buildx-cache
-          mv /tmp/.buildx-cache-new /tmp/.buildx-cache
+          provenance: false
+          cache-from: type=gha
+          cache-to: type=gha,mode=min
 
   deploy:
     name: 🚀 Deploy


### PR DESCRIPTION
## Summary

- Docker build cache を local file → GHA backend に切り替え
- BuildKit が GHA cache API と直接通信するため、cache export ステップ (17.9s) が不要に
- `provenance: false` で attestation 生成・push を省略
- `mode=min` で最終イメージのレイヤーのみキャッシュ (cache サイズ削減)
- `actions/cache` ステップと `Move cache` ハックを削除

## Expected improvement

| Phase | Before | After (予想) |
|---|---|---|
| cache export | 17.9s | ~5s |
| push (provenance省略) | 12.9s | ~10s |
| **Docker build job 合計** | ~75s | ~60s |

## Test plan

- [ ] main マージ後の CI で Docker build が正常に完了することを確認
- [ ] 2回目以降のビルドで cache hit することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)