### PR TITLE
fix: exit immediately on shutdown instead of draining

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -67,9 +67,8 @@ const server = app.listen(port, () => {
 // Graceful shutdown
 function shutdown() {
   consola.info('Shutting down...')
-  server.close(() => {
-    process.exit(0)
-  })
+  server.close()
+  process.exit(0)
 }
 process.on('SIGINT', shutdown)
 process.on('SIGTERM', shutdown)


### PR DESCRIPTION
## Summary

- `server.close()` のコールバック内で `process.exit(0)` していたが、Fly.io の health check が keep-alive 接続を維持するためコールバックが呼ばれなかった
- `server.close()` 後に即 `process.exit(0)` するように変更

## Evidence

前回のデプロイログで SIGINT 後 5s 待って SIGTERM で kill されていた:
```
05:23:19 SIGINT 送信
05:23:24 SIGTERM 送信 (5s後)
05:23:25 "Shutting down..." ← SIGTERM で初めて出力
```

## Expected improvement

shutdown: 6s → ~0s (SIGINT で即終了)

## Test plan

- [ ] `fly deploy` してログで SIGINT 後すぐ終了することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)