### PR TITLE
fix: prevent full-page horizontal scroll on mobile settings tables

### DIFF
--- a/app/routes/$orgSlug/settings/_layout.tsx
+++ b/app/routes/$orgSlug/settings/_layout.tsx
@@ -100,7 +100,7 @@ export default function SettingsLayout({
         <aside className="top-0 lg:sticky lg:w-52">
           <SidebarNav items={sidebarNavItems} />
         </aside>
-        <div className="flex w-full overflow-y-hidden p-1 pr-4">
+        <div className="flex min-w-0 flex-1 overflow-y-hidden p-1 pr-4">
           <Outlet />
         </div>
       </div>


### PR DESCRIPTION
## Summary

- モバイルで Settings 配下のテーブルページ (Members, Repositories, GitHub Users 等) を開くと、ページ全体が横スクロールになっていた
- Outlet ラッパーの flex 子要素に `min-w-0` を追加し、テーブルの中だけスクロールするように修正

## Root cause

flex 子要素のデフォルト `min-width: auto` により、テーブルの自然幅が親を押し広げていた。`min-w-0` で親の幅に収まるようにし、Table コンポーネント内の `overflow-auto` が効くようにした。

## Test plan

- [ ] モバイル幅で Members / Repositories / GitHub Users ページを表示し、テーブルだけが横スクロールすること
- [ ] デスクトップでのレイアウトに影響がないこと

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Improved layout behavior in the settings area to better handle content resizing and overflow management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->