### PR TITLE
fix: prevent concurrent crawl jobs from running

### DIFF
--- a/batch/job-scheduler.ts
+++ b/batch/job-scheduler.ts
@@ -9,18 +9,19 @@ export const createJobScheduler = () => {
     let isRunning = false
 
     schedule.scheduleJob('30 * * * *', async () => {
+      if (isRunning) {
+        logger.warn('crawl job already running, skipping.')
+        return
+      }
+      isRunning = true
       try {
-        if (isRunning) throw new Error('crawl job already running.')
-        isRunning = true
         logger.info('crawl job started.')
-
         await crawlJob()
-
-        isRunning = false
         logger.info('crawl job completed.')
       } catch (e) {
-        isRunning = false
         logger.error(e)
+      } finally {
+        isRunning = false
       }
     })
   }


### PR DESCRIPTION
## Summary
- crawl job の `isRunning` ガードにバグがあり、「already running」で throw → catch で flag リセット → 次のスケジュールで重複起動していた
- refresh のような長時間ジョブで毎時30分ごとに新しいジョブが積み重なり、同じリポを複数プロセスが同時に fetch する状態になっていた
- throw ではなく早期 return に変更し、finally で flag をリセットするように修正

## Test plan
- [ ] デプロイ後、fly logs で fetch ストリームが1つだけになることを確認
- [ ] refresh フラグを立てて長時間ジョブを実行し、:30 のスケジュールで重複起動しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced scheduled crawl job to handle overlapping runs gracefully and ensure proper state tracking in all scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->