### PR TITLE
fix: case-insensitive author matching and remove dead bot filter

### DIFF
--- a/app/routes/$orgSlug/_index/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/_index/+functions/queries.server.ts
@@ -30,7 +30,6 @@ export const getMergedPullRequestReport = async (
     .$if(teamId != null, (qb) =>
       qb.where('repositories.teamId', '=', teamId as string),
     )
-
     .orderBy('mergedAt', 'desc')
     .orderBy('pullRequestCreatedAt', 'desc')
     .select([

--- a/app/routes/$orgSlug/ongoing/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/ongoing/+functions/queries.server.ts
@@ -33,7 +33,6 @@ export const getOngoingPullRequestReport = async (
     )
     .where('mergedAt', 'is', null)
     .where('state', '=', 'open')
-
     .orderBy('pullRequestCreatedAt', 'desc')
     .select([
       'pullRequests.author',

--- a/app/routes/$orgSlug/reviews/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/reviews/+functions/queries.server.ts
@@ -118,7 +118,6 @@ export const getWipCycleRawData = async (
     )
     .where('pullRequests.mergedAt', 'is not', null)
     .where('pullRequests.reviewTime', 'is not', null)
-
     .where('pullRequests.mergedAt', '>=', sinceDate)
     .$if(teamId != null, (qb) =>
       qb.where('repositories.teamId', '=', teamId as string),
@@ -163,7 +162,6 @@ export const getPRSizeDistribution = async (
       ),
     )
     .where('pullRequests.mergedAt', 'is not', null)
-
     .where('pullRequests.mergedAt', '>=', sinceDate)
     .where('pullRequests.additions', 'is not', null)
     .where('pullRequests.deletions', 'is not', null)


### PR DESCRIPTION
## Summary

- companyGithubUsers との LEFT JOIN で `lower()` を両側にかけ、login の大文字小文字が違ってもdisplay nameが解決されるように修正
- GraphQL移行後に機能しなくなっていた `NOT LIKE '%[bot]'` フィルタを削除（bot authorに `[bot]` サフィックスが付かなくなったため）

Bot フィルタは #143 で `authorType` カラムを追加して正しく対応予定。

## Test plan

- [ ] dashboard / ongoing / reviews で author の display name が正しく表示されること
- [ ] `pnpm typecheck` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved contributor name matching to be case-insensitive across PR queries for more accurate identification.
  * Bot-authored pull requests are now included in PR listings, reviews, and performance reports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->