### PR TITLE
fix: stable sort and optimistic UI for inline feedback

### DIFF
--- a/app/components/AppDataTable.test.ts
+++ b/app/components/AppDataTable.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, test } from 'vitest'
+import { reorderRows } from './AppDataTable'
+
+const row = (id: string) => ({ id }) as { id: string }
+
+describe('reorderRows', () => {
+  test('preserves snapshot order when data changes', () => {
+    const snapshot = ['a', 'b', 'c']
+    const rows = [row('c'), row('a'), row('b')]
+    const result = reorderRows(rows, snapshot)
+    expect(result.map((r) => r.id)).toEqual(['a', 'b', 'c'])
+  })
+
+  test('appends new rows at the end', () => {
+    const snapshot = ['a', 'b']
+    const rows = [row('a'), row('b'), row('new')]
+    const result = reorderRows(rows, snapshot)
+    expect(result.map((r) => r.id)).toEqual(['a', 'b', 'new'])
+  })
+
+  test('handles removed rows gracefully', () => {
+    const snapshot = ['a', 'b', 'c']
+    const rows = [row('c'), row('a')]
+    const result = reorderRows(rows, snapshot)
+    expect(result.map((r) => r.id)).toEqual(['a', 'c'])
+  })
+
+  test('handles empty snapshot (no sort applied)', () => {
+    const snapshot: string[] = []
+    const rows = [row('a'), row('b')]
+    const result = reorderRows(rows, snapshot)
+    expect(result.map((r) => r.id)).toEqual(['a', 'b'])
+  })
+
+  test('handles empty rows', () => {
+    const snapshot = ['a', 'b']
+    const result = reorderRows([], snapshot)
+    expect(result).toEqual([])
+  })
+})

--- a/app/components/AppDataTable.tsx
+++ b/app/components/AppDataTable.tsx
@@ -26,6 +26,30 @@ interface AppDataTableProps<TData, TValue> {
   columns: ColumnDef<TData, TValue>[]
   data: TData[]
   optionsChildren?: React.ReactNode
+  /** Stable key for each row. When provided, row order is frozen until the user re-sorts via column header click. */
+  getRowId?: (row: TData) => string
+}
+
+/**
+ * Reorder rows according to a saved order snapshot.
+ * Rows whose id is not in the snapshot are appended at the end.
+ */
+export function reorderRows<T extends { id: string }>(
+  rows: T[],
+  orderedIds: string[],
+): T[] {
+  const idToIndex = new Map(orderedIds.map((id, i) => [id, i]))
+  const known: T[] = []
+  const unknown: T[] = []
+  for (const row of rows) {
+    if (idToIndex.has(row.id)) {
+      known.push(row)
+    } else {
+      unknown.push(row)
+    }
+  }
+  known.sort((a, b) => idToIndex.get(a.id)! - idToIndex.get(b.id)!)
+  return [...known, ...unknown]
 }
 
 export function AppDataTable<TData, TValue>({
@@ -33,6 +57,7 @@ export function AppDataTable<TData, TValue>({
   columns,
   data,
   optionsChildren,
+  getRowId,
 }: AppDataTableProps<TData, TValue>) {
   const [sorting, setSorting] = React.useState<SortingState>([])
   const [columnVisibility, setColumnVisibility] =
@@ -52,12 +77,34 @@ export function AppDataTable<TData, TValue>({
   const table = useReactTable({
     data,
     columns,
+    getRowId,
     getCoreRowModel: getCoreRowModel(),
     onSortingChange: setSorting,
     getSortedRowModel: getSortedRowModel(),
     onColumnVisibilityChange: setColumnVisibility,
     state: { sorting, columnVisibility },
   })
+
+  // Stable sort: snapshot the sorted row order and only update it when
+  // the user explicitly changes the sort (column header click).
+  // Data changes (e.g. revalidation after inline edit) do NOT re-order rows.
+  const sortedRows = table.getSortedRowModel().rows
+  const [orderSnapshot, setOrderSnapshot] = React.useState<string[]>(() =>
+    sortedRows.map((r) => r.id),
+  )
+
+  // Update snapshot only when sorting state changes (user clicked a header).
+  // We use a ref to track the previous sorting to detect actual changes.
+  const prevSortingRef = React.useRef(sorting)
+  React.useEffect(() => {
+    if (prevSortingRef.current !== sorting) {
+      prevSortingRef.current = sorting
+      setOrderSnapshot(sortedRows.map((r) => r.id))
+    }
+  }, [sorting, sortedRows])
+
+  const displayRows =
+    getRowId != null ? reorderRows(sortedRows, orderSnapshot) : sortedRows
 
   return (
     <Stack>
@@ -89,8 +136,8 @@ export function AppDataTable<TData, TValue>({
             ))}
           </TableHeader>
           <TableBody>
-            {table.getRowModel().rows?.length ? (
-              table.getRowModel().rows.map((row) => (
+            {displayRows.length ? (
+              displayRows.map((row) => (
                 <TableRow
                   key={row.id}
                   data-state={row.getIsSelected() ? 'selected' : null}

--- a/app/libs/escape-xml.ts
+++ b/app/libs/escape-xml.ts
@@ -1,5 +1,6 @@
-export function escapeXml(s: string): string {
-  return s
+export function escapeXml(s: unknown): string {
+  const str = typeof s === 'string' ? s : String(s ?? '')
+  return str
     .replace(/&/g, '&amp;')
     .replace(/</g, '&lt;')
     .replace(/>/g, '&gt;')

--- a/app/routes/$orgSlug/+components/size-badge-popover.tsx
+++ b/app/routes/$orgSlug/+components/size-badge-popover.tsx
@@ -4,7 +4,7 @@ import {
   PencilIcon,
   SparklesIcon,
 } from 'lucide-react'
-import { useEffect, useMemo, useState } from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import { useFetcher, useParams } from 'react-router'
 import { Badge, Button } from '~/app/components/ui'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
@@ -65,9 +65,19 @@ export function SizeBadgePopover({
     }
   }, [draftFetcher.data])
 
-  // Optimistic UI: fetcher.formData during flight, then server value
+  // Optimistic UI: bridge the gap between fetcher completion and revalidation.
+  // React Router may commit fetcher.idle before loaderData updates (startTransition),
+  // so we hold the last-submitted value in a ref until the prop catches up.
+  const lastSubmittedRef = useRef<string | null>(null)
+  if (fetcher.formData) {
+    lastSubmittedRef.current =
+      fetcher.formData.get('correctedComplexity')?.toString() ?? null
+  } else if (lastSubmittedRef.current === correctedComplexity) {
+    lastSubmittedRef.current = null
+  }
   const optimistic =
     fetcher.formData?.get('correctedComplexity')?.toString() ??
+    lastSubmittedRef.current ??
     correctedComplexity
   const validCorrected =
     optimistic != null &&
@@ -135,7 +145,11 @@ export function SizeBadgePopover({
           )}
         </button>
       </PopoverTrigger>
-      <PopoverContent className="w-80 max-w-sm p-2" align="start">
+      <PopoverContent
+        className="w-80 max-w-sm p-2"
+        align="start"
+        sticky="always"
+      >
         {originalLabel !== 'Unclassified' && (
           <div className="mb-2 max-w-64 space-y-1 text-xs">
             <div className="flex items-center gap-1.5">
@@ -193,11 +207,11 @@ export function SizeBadgePopover({
             </button>
           ))}
         </div>
-        {selectedSize && (
-          <p className="text-muted-foreground mt-1 text-[10px] leading-snug">
-            {PR_SIZE_DESCRIPTION[selectedSize]}
-          </p>
-        )}
+        <p className="text-muted-foreground mt-1 text-[10px] leading-snug">
+          {(selectedSize
+            ? PR_SIZE_DESCRIPTION[selectedSize]
+            : PR_SIZE_DESCRIPTION[displayLabel as PRSize]) ?? '\u00A0'}
+        </p>
         <div className="mt-2 space-y-2">
           <Textarea
             placeholder={`Why ${selectedSize ?? displayLabel}? (optional)`}
@@ -212,7 +226,7 @@ export function SizeBadgePopover({
               {draftFetcher.data.error}
             </p>
           )}
-          <div className="flex items-center gap-1">
+          <div className="flex items-center justify-end gap-1">
             {hasFeedback &&
               (() => {
                 const feedbackName = feedbackBy ?? feedbackByLogin ?? 'human'

--- a/app/routes/$orgSlug/_index/index.tsx
+++ b/app/routes/$orgSlug/_index/index.tsx
@@ -165,6 +165,7 @@ export default function OrganizationIndex({
         title={<div>Merged this week: {pullRequests.length}</div>}
         columns={columns}
         data={pullRequests}
+        getRowId={(row) => `${row.repositoryId}:${row.number}`}
         optionsChildren={
           <>
             <DropdownMenuLabel>Duration</DropdownMenuLabel>

--- a/app/routes/$orgSlug/ongoing/index.tsx
+++ b/app/routes/$orgSlug/ongoing/index.tsx
@@ -84,6 +84,7 @@ export default function OngoingPage({
         title={<div>Ongoing pull requests: {pullRequests.length}</div>}
         columns={columns}
         data={pullRequests}
+        getRowId={(row) => `${row.repositoryId}:${row.number}`}
         optionsChildren={
           <>
             <DropdownMenuLabel>Duration</DropdownMenuLabel>


### PR DESCRIPTION
## Summary
- **Stable sort**: Row order in dashboard/ongoing tables is now frozen during inline feedback edits. Rows only reorder when the user explicitly clicks a column header to re-sort. This prevents rows from jumping around while reviewing PRs sequentially by size.
- **Optimistic UI flicker fix**: Hold last-submitted value in a ref to bridge the gap between fetcher completion and revalidation (React Router's startTransition causes a timing gap).
- **Popover layout stability**: Always show size description text to prevent popover repositioning when selecting a size. Right-align action buttons when no feedback attribution is shown.
- **escapeXml robustness**: Handle non-string values (e.g. parsed JSON arrays from riskAreas) to fix AI Draft crash.

## Test plan
- [ ] Sort by Size on dashboard or ongoing page
- [ ] Save feedback changing a PR's size → row stays in place
- [ ] Click Size column header → rows re-sort with corrected sizes
- [ ] Verify no badge flicker on save (especially rows 2+)
- [ ] Click AI Draft button → no crash, reason populates textarea
- [ ] Popover doesn't jump when selecting a size button

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Data tables now support stable row ordering that persists across user interactions.
  * Size badge popover provides immediate visual feedback during updates.

* **Bug Fixes**
  * XML escaping now safely handles non-string inputs and additional special characters.

* **Tests**
  * Added comprehensive test coverage for row reordering functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->