### PR TITLE
perf: make batch analyze incremental to eliminate CPU spikes

### DIFF
--- a/batch/github/__tests__/buildPullRequests-filter.test.ts
+++ b/batch/github/__tests__/buildPullRequests-filter.test.ts
@@ -1,0 +1,287 @@
+import { describe, expect, test } from 'vitest'
+import type { OrganizationId } from '~/app/types/organization'
+import type {
+  ShapedGitHubCommit,
+  ShapedGitHubPullRequest,
+  ShapedGitHubReview,
+  ShapedGitHubReviewComment,
+  ShapedTimelineItem,
+} from '../model'
+import { buildPullRequests } from '../pullrequest'
+import type { PullRequestLoaders } from '../types'
+
+// --- テストデータ ---
+
+const basePr: ShapedGitHubPullRequest = {
+  id: 0,
+  organization: 'test-org',
+  repo: 'test-repo',
+  number: 0,
+  state: 'closed',
+  title: '',
+  body: null,
+  url: 'https://github.com/test-org/test-repo/pull/0',
+  author: 'author1',
+  assignees: [],
+  reviewers: [],
+  draft: false,
+  sourceBranch: 'feature',
+  targetBranch: 'main',
+  createdAt: '2024-01-01T00:00:00Z',
+  updatedAt: '2024-01-02T00:00:00Z',
+  mergedAt: '2024-01-02T00:00:00Z',
+  closedAt: '2024-01-02T00:00:00Z',
+  mergeCommitSha: 'abc123',
+  additions: 10,
+  deletions: 5,
+  changedFiles: 2,
+  files: [],
+}
+
+const prs: ShapedGitHubPullRequest[] = [
+  {
+    ...basePr,
+    id: 1,
+    number: 1,
+    title: 'PR 1 - merged',
+    mergeCommitSha: 'sha1',
+    createdAt: '2024-01-01T00:00:00Z',
+    updatedAt: '2024-01-03T00:00:00Z',
+    mergedAt: '2024-01-02T00:00:00Z',
+    closedAt: '2024-01-02T00:00:00Z',
+    reviewers: [{ login: 'reviewer1', requestedAt: '2024-01-01T01:00:00Z' }],
+  },
+  {
+    ...basePr,
+    id: 2,
+    number: 2,
+    title: 'PR 2 - merged released',
+    mergeCommitSha: 'sha2',
+    createdAt: '2024-01-05T00:00:00Z',
+    updatedAt: '2024-01-08T00:00:00Z',
+    mergedAt: '2024-01-07T00:00:00Z',
+    closedAt: '2024-01-07T00:00:00Z',
+  },
+  {
+    ...basePr,
+    id: 3,
+    number: 3,
+    title: 'PR 3 - open',
+    state: 'open',
+    mergeCommitSha: null,
+    createdAt: '2024-01-10T00:00:00Z',
+    updatedAt: '2024-01-11T00:00:00Z',
+    mergedAt: null,
+    closedAt: null,
+  },
+  {
+    ...basePr,
+    id: 4,
+    number: 4,
+    title: 'PR 4 - release branch PR',
+    sourceBranch: 'release/v1.0',
+    targetBranch: 'main',
+    mergeCommitSha: 'sha_release',
+    createdAt: '2024-01-06T00:00:00Z',
+    updatedAt: '2024-01-08T00:00:00Z',
+    mergedAt: '2024-01-08T00:00:00Z',
+    closedAt: '2024-01-08T00:00:00Z',
+  },
+]
+
+const commitsMap: Record<number, ShapedGitHubCommit[]> = {
+  1: [
+    {
+      sha: 'c1',
+      url: '',
+      committer: 'author1',
+      date: '2023-12-31T00:00:00Z',
+    },
+  ],
+  2: [
+    {
+      sha: 'c2',
+      url: '',
+      committer: 'author1',
+      date: '2024-01-04T00:00:00Z',
+    },
+  ],
+  3: [
+    {
+      sha: 'c3',
+      url: '',
+      committer: 'author1',
+      date: '2024-01-09T00:00:00Z',
+    },
+  ],
+  4: [
+    {
+      sha: 'c4',
+      url: '',
+      committer: 'author1',
+      date: '2024-01-05T00:00:00Z',
+    },
+  ],
+}
+
+const reviewsMap: Record<number, ShapedGitHubReview[]> = {
+  1: [
+    {
+      id: 101,
+      user: 'reviewer1',
+      isBot: false,
+      state: 'APPROVED',
+      url: '',
+      submittedAt: '2024-01-01T12:00:00Z',
+    },
+  ],
+  2: [
+    {
+      id: 102,
+      user: 'reviewer2',
+      isBot: false,
+      state: 'CHANGES_REQUESTED',
+      url: '',
+      submittedAt: '2024-01-06T00:00:00Z',
+    },
+  ],
+  3: [],
+  4: [],
+}
+
+const discussionsMap: Record<number, ShapedGitHubReviewComment[]> = {
+  1: [
+    {
+      id: 201,
+      user: 'reviewer1',
+      isBot: false,
+      url: '',
+      createdAt: '2024-01-01T10:00:00Z',
+    },
+  ],
+  2: [
+    {
+      id: 202,
+      user: 'reviewer2',
+      isBot: false,
+      url: '',
+      createdAt: '2024-01-06T00:00:00Z',
+    },
+  ],
+  3: [],
+  4: [],
+}
+
+const timelineItemsMap: Record<number, ShapedTimelineItem[]> = {
+  1: [
+    {
+      type: 'review_requested',
+      createdAt: '2024-01-01T01:00:00Z',
+      reviewer: 'reviewer1',
+    },
+  ],
+  2: [],
+  3: [],
+  4: [],
+}
+
+const mockLoaders: PullRequestLoaders = {
+  commits: async (n) => commitsMap[n] ?? [],
+  reviews: async (n) => reviewsMap[n] ?? [],
+  discussions: async (n) => discussionsMap[n] ?? [],
+  tags: async () => [],
+  timelineItems: async (n) => timelineItemsMap[n] ?? [],
+}
+
+const config = {
+  organizationId: 'org-1' as OrganizationId,
+  repositoryId: 'repo-1',
+  releaseDetectionMethod: 'branch',
+  releaseDetectionKey: 'release/',
+  excludedUsers: '',
+}
+
+// --- テスト ---
+
+describe('buildPullRequests filter', () => {
+  test('フィルタなし vs 全PR番号指定 → 結果が一致する', async () => {
+    const allNumbers = new Set(prs.map((p) => p.number))
+
+    const resultAll = await buildPullRequests(config, prs, mockLoaders)
+    const resultFiltered = await buildPullRequests(
+      config,
+      prs,
+      mockLoaders,
+      allNumbers,
+    )
+
+    expect(resultFiltered.pulls).toEqual(resultAll.pulls)
+    expect(resultFiltered.reviews).toEqual(resultAll.reviews)
+    expect(resultFiltered.reviewers).toEqual(resultAll.reviewers)
+    expect(resultFiltered.reviewResponses).toEqual(resultAll.reviewResponses)
+  })
+
+  test('サブセットフィルタ → 対象PRの結果が全件処理時と一致する', async () => {
+    const subset = new Set([1, 3])
+
+    const resultAll = await buildPullRequests(config, prs, mockLoaders)
+    const resultSubset = await buildPullRequests(
+      config,
+      prs,
+      mockLoaders,
+      subset,
+    )
+
+    // pulls: サブセット結果と、全件結果から同じPR番号を抽出したものが一致
+    const expectedPulls = resultAll.pulls.filter((p) => subset.has(p.number))
+    expect(resultSubset.pulls).toEqual(expectedPulls)
+
+    // reviews
+    const expectedReviews = resultAll.reviews.filter((r) =>
+      subset.has(r.pullRequestNumber),
+    )
+    expect(resultSubset.reviews).toEqual(expectedReviews)
+
+    // reviewers
+    const expectedReviewers = resultAll.reviewers.filter((r) =>
+      subset.has(r.pullRequestNumber),
+    )
+    expect(resultSubset.reviewers).toEqual(expectedReviewers)
+
+    // reviewResponses
+    const expectedResponses = resultAll.reviewResponses.filter((r) =>
+      subset.has(Number(r.number)),
+    )
+    expect(resultSubset.reviewResponses).toEqual(expectedResponses)
+  })
+
+  test('空フィルタ → 結果が空になる', async () => {
+    const empty = new Set<number>()
+
+    const result = await buildPullRequests(config, prs, mockLoaders, empty)
+
+    expect(result.pulls).toEqual([])
+    expect(result.reviews).toEqual([])
+    expect(result.reviewers).toEqual([])
+    expect(result.reviewResponses).toEqual([])
+  })
+
+  test('リリース検出はフィルタに関係なく全PRから行われる', async () => {
+    // PR 2 は PR 4 (release branch) によってリリース検出される
+    // フィルタで PR 2 だけ指定しても、リリース日が正しく設定されることを確認
+    const filterJustPr2 = new Set([2])
+
+    const resultAll = await buildPullRequests(config, prs, mockLoaders)
+    const resultFiltered = await buildPullRequests(
+      config,
+      prs,
+      mockLoaders,
+      filterJustPr2,
+    )
+
+    const pr2All = resultAll.pulls.find((p) => p.number === 2)
+    const pr2Filtered = resultFiltered.pulls.find((p) => p.number === 2)
+
+    expect(pr2Filtered).toEqual(pr2All)
+  })
+})

--- a/batch/github/analyze-repos.ts
+++ b/batch/github/analyze-repos.ts
@@ -1,6 +1,7 @@
 import type { Selectable } from 'kysely'
 import type { TenantDB } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
+import { logger } from '~/batch/helper/logger'
 import { buildPullRequests } from './pullrequest'
 import { createStore } from './store'
 import type {
@@ -21,6 +22,8 @@ export async function analyzeRepos(
     current: number
     total: number
   }) => void,
+  /** リポジトリID → 更新PR番号セット。undefined なら全件処理 */
+  updatedPrNumbers?: Map<string, Set<number>>,
 ) {
   const allPulls: Selectable<TenantDB.PullRequests>[] = []
   const allReviews: AnalyzedReview[] = []
@@ -33,6 +36,17 @@ export async function analyzeRepos(
   for (const repository of repositories) {
     current++
     onProgress?.({ repo: repository.repo, current, total })
+
+    // フィルタが指定されていて、このリポジトリに更新PRがなければスキップ
+    if (updatedPrNumbers && !updatedPrNumbers.has(repository.id)) {
+      logger.info(
+        `skipping ${repository.repo} (no updated PRs)`,
+        organizationId,
+      )
+      continue
+    }
+
+    const filterPrNumbers = updatedPrNumbers?.get(repository.id)
 
     const store = createStore({
       organizationId,
@@ -56,6 +70,7 @@ export async function analyzeRepos(
         },
         await store.loader.pullrequests(),
         store.loader,
+        filterPrNumbers,
       )
     allPulls.push(...pulls)
     allReviews.push(...reviews)

--- a/batch/github/fetch-repo.ts
+++ b/batch/github/fetch-repo.ts
@@ -12,7 +12,7 @@ export async function fetchRepo(
   repository: Selectable<TenantDB.Repositories>,
   integration: Pick<Selectable<TenantDB.Integrations>, 'privateToken'>,
   options: { refresh?: boolean; halt?: boolean } = {},
-) {
+): Promise<{ updatedPrNumbers: number[] }> {
   const { refresh = false, halt = false } = options
   invariant(repository.repo, 'repo not specified')
   invariant(repository.owner, 'owner not specified')
@@ -39,7 +39,7 @@ export async function fetchRepo(
 
   if (halt) {
     logger.fatal('halted')
-    return
+    return { updatedPrNumbers: [] }
   }
 
   // 全タグ情報をダウンロード
@@ -55,11 +55,12 @@ export async function fetchRepo(
   const allPullRequests = await fetcher.pullrequests()
   logger.info(`fetched ${allPullRequests.length} PRs.`)
 
+  const updatedPrNumbers: number[] = []
   let processed = 0
   for (const pr of allPullRequests) {
     if (halt) {
       logger.fatal('halted')
-      return
+      return { updatedPrNumbers }
     }
 
     // refresh でなければ更新分のみ
@@ -92,6 +93,7 @@ export async function fetchRepo(
         discussions,
         timelineItems,
       })
+      updatedPrNumbers.push(pr.number)
     } catch (e) {
       logger.warn(
         `${pr.number} failed, skipping:`,
@@ -101,4 +103,5 @@ export async function fetchRepo(
   }
 
   logger.info('fetch completed: ', `${repository.owner}/${repository.repo}`)
+  return { updatedPrNumbers }
 }

--- a/batch/github/pullrequest.ts
+++ b/batch/github/pullrequest.ts
@@ -186,6 +186,7 @@ export const buildPullRequests = async (
   config: BuildConfig,
   pullrequests: ShapedGitHubPullRequest[],
   loaders: PullRequestLoaders,
+  filterPrNumbers?: Set<number>,
 ) => {
   // カンマ区切りの除外ユーザーリストをパース
   const customExcludedUsers = config.excludedUsers
@@ -217,6 +218,11 @@ export const buildPullRequests = async (
   const reviewResponses: AnalyzedReviewResponse[] = []
 
   for (const pr of pullrequests) {
+    // フィルタが指定されていれば、対象外PRをスキップ
+    if (filterPrNumbers && !filterPrNumbers.has(pr.number)) {
+      continue
+    }
+
     try {
       // 1. アーティファクト読み込み（I/O）
       const rawArtifacts = await loadPrArtifacts(pr, loaders)

--- a/batch/jobs/crawl.ts
+++ b/batch/jobs/crawl.ts
@@ -36,10 +36,14 @@ export const crawlJob = async () => {
       }
       const options = { refresh, halt: false }
 
-      // fetch
+      // fetch — 更新PR番号を収集
+      const updatedPrNumbers = new Map<string, Set<number>>()
       for (const repository of organization.repositories) {
         logger.info('fetch started...')
-        await fetchRepo(orgId, repository, integration, options)
+        const result = await fetchRepo(orgId, repository, integration, options)
+        if (result.updatedPrNumbers.length > 0) {
+          updatedPrNumbers.set(repository.id, new Set(result.updatedPrNumbers))
+        }
         logger.info('fetch completed.')
       }
 
@@ -53,6 +57,12 @@ export const crawlJob = async () => {
         logger.info('refresh flag consumed.')
       }
 
+      // 更新PRがなければ analyze をスキップ
+      if (!refresh && updatedPrNumbers.size === 0) {
+        logger.info('no updated PRs, skipping analyze.', orgId)
+        continue
+      }
+
       // analyze + upsert + export
       await analyzeAndUpsert({
         organization: {
@@ -61,6 +71,7 @@ export const crawlJob = async () => {
           repositories: organization.repositories,
           exportSetting: organization.exportSetting,
         },
+        updatedPrNumbers: refresh ? undefined : updatedPrNumbers,
       })
     }
 

--- a/batch/usecases/analyze-and-upsert.ts
+++ b/batch/usecases/analyze-and-upsert.ts
@@ -28,6 +28,8 @@ interface OrganizationForAnalyze {
 
 interface AnalyzeAndUpsertParams {
   organization: OrganizationForAnalyze
+  /** リポジトリID → 更新PR番号セット。undefined なら全件処理 */
+  updatedPrNumbers?: Map<string, Set<number>>
 }
 
 /**
@@ -35,6 +37,7 @@ interface AnalyzeAndUpsertParams {
  */
 export async function analyzeAndUpsert({
   organization,
+  updatedPrNumbers,
 }: AnalyzeAndUpsertParams) {
   const orgId = organization.id
 
@@ -44,6 +47,8 @@ export async function analyzeAndUpsert({
     orgId,
     organization.organizationSetting,
     organization.repositories,
+    undefined,
+    updatedPrNumbers,
   )
   logger.info('analyze completed.', orgId)
 


### PR DESCRIPTION
## Summary

- **fetchRepo** が更新されたPR番号を返すように変更。crawlJob がリポジトリごとに集約して analyzeAndUpsert に渡す
- **buildPullRequests** のリリース検出マップ構築は全PRから行い（軽量）、重い per-PR サイクルタイム計算は更新分だけに絞る
- 更新PRが0件の場合は analyzeAndUpsert 自体をスキップ
- CLI `upsert` コマンドや `refresh` リクエスト時は従来通り全件処理

## Test plan

- [x] `pnpm typecheck` パス
- [x] `pnpm test` 全143テストパス（新規4テスト含む）
- [x] フィルタなし vs 全PR番号指定で結果一致テスト
- [x] サブセットフィルタで個々のPR計算結果が全件処理時と一致するテスト
- [ ] デプロイ後、Grafana で30分ごとの CPU スパイクが低減されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added pull request filtering capability to focus analysis on specific PRs.
  * Introduced tracking of updated pull requests during repository processing.

* **Improvements**
  * Optimized processing to skip repositories with no updates when performing incremental refreshes.

* **Tests**
  * Added comprehensive test suite for pull request filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->