### PR TITLE
fix: add breadcrumbs to Review Stacks pages

### DIFF
--- a/app/routes/$orgSlug/stacks/$login/index.tsx
+++ b/app/routes/$orgSlug/stacks/$login/index.tsx
@@ -31,6 +31,12 @@ import {
 } from './+functions/queries.server'
 import type { Route } from './+types/index'
 
+export const handle = {
+  breadcrumb: (data: Awaited<ReturnType<typeof loader>>) => ({
+    label: data.user.displayName ?? data.user.login,
+  }),
+}
+
 export const loader = async ({
   request,
   params,

--- a/app/routes/$orgSlug/stacks/_layout.tsx
+++ b/app/routes/$orgSlug/stacks/_layout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router'
+import type { RouteHandle } from '~/app/routes/$orgSlug/_layout'
+
+export const handle: RouteHandle = {
+  breadcrumb: (_data: unknown, params?: Record<string, string>) => ({
+    label: 'Review Stacks',
+    to: `/${params?.orgSlug}/stacks`,
+  }),
+}
+
+export default function StacksLayout() {
+  return <Outlet />
+}


### PR DESCRIPTION
## Summary

Review Stacks ページに breadcrumb を追加。

## Before / After

**Before** (個人ページ):
```
TechTalk > Alice Chen
```
「Review Stacks」がない

**After**:
```
TechTalk > Review Stacks              (一覧ページ)
TechTalk > Review Stacks > Alice Chen (個人ページ)
```

## Approach

`stacks/_layout.tsx` を新規作成して「Review Stacks」breadcrumb をルートマッチチェーンに追加。settings が `settings/_layout.tsx` で同じパターンを使っているのに合わせた。

breadcrumb を `$login/index.tsx` に直接ハードコードする方法（hack）ではなく、レイアウトルートで提供することで:
- 将来 stacks 配下にルートが増えても自動的に breadcrumb が継承される
- React Router の route hierarchy と一致する

## Test plan

- [ ] `/stacks` で `Organization > Review Stacks` が表示される
- [ ] `/stacks/:login` で `Organization > Review Stacks > Display Name` が表示される
- [ ] `pnpm validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced breadcrumb navigation now dynamically displays user information in the stacks section
  * Improved navigation hierarchy for better organization of the stacks review workflow

<!-- end of auto-generated comment: release notes by coderabbit.ai -->