### PR TITLE
fix: add page descriptions and improve stacks chart layout

### DIFF
--- a/app/routes/$orgSlug/deployed/index.tsx
+++ b/app/routes/$orgSlug/deployed/index.tsx
@@ -6,6 +6,7 @@ import { AppDataTable } from '~/app/components'
 import {
   PageHeader,
   PageHeaderActions,
+  PageHeaderDescription,
   PageHeaderHeading,
   PageHeaderTitle,
 } from '~/app/components/layout/page-header'
@@ -99,6 +100,9 @@ export default function DeployedPage({
       <PageHeader>
         <PageHeaderHeading>
           <PageHeaderTitle>Deployed</PageHeaderTitle>
+          <PageHeaderDescription>
+            Pull requests deployed this week with cycle time metrics.
+          </PageHeaderDescription>
         </PageHeaderHeading>
         <PageHeaderActions>
           <TeamFilter teams={teams} />

--- a/app/routes/$orgSlug/merged/index.tsx
+++ b/app/routes/$orgSlug/merged/index.tsx
@@ -6,6 +6,7 @@ import { AppDataTable } from '~/app/components'
 import {
   PageHeader,
   PageHeaderActions,
+  PageHeaderDescription,
   PageHeaderHeading,
   PageHeaderTitle,
 } from '~/app/components/layout/page-header'
@@ -99,6 +100,9 @@ export default function OrganizationIndex({
       <PageHeader>
         <PageHeaderHeading>
           <PageHeaderTitle>Merged</PageHeaderTitle>
+          <PageHeaderDescription>
+            Pull requests merged this week with cycle time metrics.
+          </PageHeaderDescription>
         </PageHeaderHeading>
         <PageHeaderActions>
           <TeamFilter teams={teams} />

--- a/app/routes/$orgSlug/ongoing/index.tsx
+++ b/app/routes/$orgSlug/ongoing/index.tsx
@@ -6,6 +6,7 @@ import { AppDataTable } from '~/app/components'
 import {
   PageHeader,
   PageHeaderActions,
+  PageHeaderDescription,
   PageHeaderHeading,
   PageHeaderTitle,
 } from '~/app/components/layout/page-header'
@@ -65,6 +66,9 @@ export default function OngoingPage({
       <PageHeader>
         <PageHeaderHeading>
           <PageHeaderTitle>Ongoing</PageHeaderTitle>
+          <PageHeaderDescription>
+            Pull requests currently in progress.
+          </PageHeaderDescription>
         </PageHeaderHeading>
         <PageHeaderActions>
           <TeamFilter teams={teams} />

--- a/app/routes/$orgSlug/stacks/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/stacks/+components/team-stacks-chart.tsx
@@ -435,38 +435,6 @@ export function TeamStacksChart({ data }: { data: TeamStacksData }) {
         <ColorModeContext value={colorMode}>
           <HoverSourceColumnContext value={hoverSourceColumn}>
             <div className="space-y-4">
-              <div className="flex items-start justify-between gap-4">
-                <div className="space-y-2">
-                  <p className="text-muted-foreground text-sm">
-                    Each block = 1 open PR. The dashed line marks the personal
-                    limit ({personalLimit}). Blocks past the line signal
-                    individual overload.
-                  </p>
-                  <Legend mode={colorMode} />
-                </div>
-                <ToggleGroup
-                  type="single"
-                  value={colorMode}
-                  onValueChange={(v) => {
-                    if (v) setColorMode(v as ColorMode)
-                  }}
-                  size="sm"
-                  className="bg-muted shrink-0 rounded-lg p-0.5"
-                >
-                  <ToggleGroupItem
-                    value="age"
-                    className="data-[state=on]:bg-background rounded-md data-[state=on]:shadow-sm"
-                  >
-                    Age
-                  </ToggleGroupItem>
-                  <ToggleGroupItem
-                    value="size"
-                    className="data-[state=on]:bg-background rounded-md data-[state=on]:shadow-sm"
-                  >
-                    Size
-                  </ToggleGroupItem>
-                </ToggleGroup>
-              </div>
               {/* Dimming via DOM classes: .pr-hovering dims all buttons,
                 .pr-match + :hover exclude the matched/hovered ones */}
               <div
@@ -485,6 +453,37 @@ export function TeamStacksChart({ data }: { data: TeamStacksData }) {
                   showAuthor
                   unassignedPRs={unassignedPRs}
                 />
+              </div>
+              <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
+                <div className="flex items-center gap-3">
+                  <ToggleGroup
+                    type="single"
+                    value={colorMode}
+                    onValueChange={(v) => {
+                      if (v) setColorMode(v as ColorMode)
+                    }}
+                    size="sm"
+                    className="bg-muted shrink-0 rounded-lg p-0.5"
+                  >
+                    <ToggleGroupItem
+                      value="age"
+                      className="data-[state=on]:bg-background rounded-md data-[state=on]:shadow-sm"
+                    >
+                      Age
+                    </ToggleGroupItem>
+                    <ToggleGroupItem
+                      value="size"
+                      className="data-[state=on]:bg-background rounded-md data-[state=on]:shadow-sm"
+                    >
+                      Size
+                    </ToggleGroupItem>
+                  </ToggleGroup>
+                  <Legend mode={colorMode} />
+                </div>
+                <p className="text-muted-foreground text-xs">
+                  1 block = 1 PR. Dashed line = personal limit ({personalLimit}
+                  ).
+                </p>
               </div>
               {insight && (
                 <p className="text-muted-foreground text-center text-sm">

--- a/app/routes/$orgSlug/stacks/index.tsx
+++ b/app/routes/$orgSlug/stacks/index.tsx
@@ -1,6 +1,7 @@
 import {
   PageHeader,
   PageHeaderActions,
+  PageHeaderDescription,
   PageHeaderHeading,
   PageHeaderTitle,
 } from '~/app/components/layout/page-header'
@@ -59,10 +60,13 @@ clientLoader.hydrate = true as const
 
 export function HydrateFallback() {
   return (
-    <Stack gap="6">
+    <Stack>
       <PageHeader>
         <PageHeaderHeading>
           <PageHeaderTitle>Review Stacks</PageHeaderTitle>
+          <PageHeaderDescription>
+            Monitor review workload balance across team members.
+          </PageHeaderDescription>
         </PageHeaderHeading>
       </PageHeader>
     </Stack>
@@ -73,10 +77,13 @@ export default function ReviewStacksPage({
   loaderData: { teams, teamStacks },
 }: Route.ComponentProps) {
   return (
-    <Stack gap="6">
+    <Stack>
       <PageHeader>
         <PageHeaderHeading>
           <PageHeaderTitle>Review Stacks</PageHeaderTitle>
+          <PageHeaderDescription>
+            Monitor review workload balance across team members.
+          </PageHeaderDescription>
         </PageHeaderHeading>
         <PageHeaderActions>
           <TeamFilter teams={teams} />


### PR DESCRIPTION
## Summary

ダッシュボード4ページに PageHeaderDescription を追加し、Review Stacks チャートのレイアウトを改善。

## Changes

### Page Descriptions
| Page | Description |
|------|-------------|
| Review Stacks | Monitor review workload balance across team members. |
| Ongoing | Pull requests currently in progress. |
| Merged | Pull requests merged this week with cycle time metrics. |
| Deployed | Pull requests deployed this week with cycle time metrics. |

### Review Stacks Chart Layout

**Before:**
```
[説明テキスト + 凡例]          [Age/Size]
[チャート]
[insight]
```

**After:**
```
[チャート]
[Age|Size] [凡例 ● ● ● ●]    [1 block = 1 PR. Dashed line = ...]
[insight]
```

- チャートを最上部に配置（コンテンツファースト）
- 凡例・トグル・注釈をチャート下にまとめ
- トグルを凡例の左に固定（Age/Size 切り替えで位置がずれない）
- 注釈を `text-xs` に縮小

## Related

- #179 — 全ページのレイアウト統一 (follow-up)

## Test plan

- [ ] 4ページすべてでタイトル下に description が表示される
- [ ] Review Stacks チャートの凡例・トグル・注釈がチャート下に表示される
- [ ] Age/Size トグルが切り替えても位置が安定している
- [ ] `pnpm validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added descriptive text to page headers across deployed, merged, ongoing, and stacks sections to clarify metrics and pull request information
  * Reorganized controls in stacks view, repositioning the legend and color-mode switcher below the chart for improved layout

<!-- end of auto-generated comment: release notes by coderabbit.ai -->