### PR TITLE
fix: unify dashboard page layout and add missing breadcrumbs

### DIFF
--- a/app/routes/$orgSlug/deployed/index.tsx
+++ b/app/routes/$orgSlug/deployed/index.tsx
@@ -27,6 +27,10 @@ import { generateMarkdown } from './+functions/generate-markdown'
 import { getDeployedPullRequestReport } from './+functions/queries.server'
 import type { Route } from './+types/index'
 
+export const handle = {
+  breadcrumb: () => ({ label: 'Deployed' }),
+}
+
 export type PullRequest = Awaited<
   ReturnType<typeof getDeployedPullRequestReport>
 >[0]

--- a/app/routes/$orgSlug/feedbacks/_index/index.tsx
+++ b/app/routes/$orgSlug/feedbacks/_index/index.tsx
@@ -124,7 +124,7 @@ export default function FeedbacksPage({
   })
 
   return (
-    <Stack gap="6">
+    <Stack>
       <PageHeader>
         <PageHeaderHeading>
           <PageHeaderTitle>Feedbacks</PageHeaderTitle>
@@ -158,95 +158,99 @@ export default function FeedbacksPage({
         </PageHeaderActions>
       </PageHeader>
 
-      <FeedbackSummaryCards summary={summary} />
+      <div className="space-y-6">
+        <FeedbackSummaryCards summary={summary} />
 
-      <div className="space-y-4">
-        <div className="rounded-md border">
-          <Table>
-            <TableHeader>
-              {table.getHeaderGroups().map((headerGroup) => (
-                <TableRow key={headerGroup.id}>
-                  {headerGroup.headers.map((header) => {
-                    const canSort = header.column.getCanSort()
-                    const isSorted = sort.sort_by === header.column.id
-                    return (
-                      <TableHead
-                        key={header.id}
-                        className={canSort ? 'cursor-pointer select-none' : ''}
-                        onClick={
-                          canSort
-                            ? () => {
-                                if (isSorted) {
-                                  updateSort({
-                                    sort_by: header.column.id,
-                                    sort_order:
-                                      sort.sort_order === 'asc'
-                                        ? 'desc'
-                                        : 'asc',
-                                  })
-                                } else {
-                                  updateSort({
-                                    sort_by: header.column.id,
-                                    sort_order: 'desc',
-                                  })
+        <div className="space-y-4">
+          <div className="rounded-md border">
+            <Table>
+              <TableHeader>
+                {table.getHeaderGroups().map((headerGroup) => (
+                  <TableRow key={headerGroup.id}>
+                    {headerGroup.headers.map((header) => {
+                      const canSort = header.column.getCanSort()
+                      const isSorted = sort.sort_by === header.column.id
+                      return (
+                        <TableHead
+                          key={header.id}
+                          className={
+                            canSort ? 'cursor-pointer select-none' : ''
+                          }
+                          onClick={
+                            canSort
+                              ? () => {
+                                  if (isSorted) {
+                                    updateSort({
+                                      sort_by: header.column.id,
+                                      sort_order:
+                                        sort.sort_order === 'asc'
+                                          ? 'desc'
+                                          : 'asc',
+                                    })
+                                  } else {
+                                    updateSort({
+                                      sort_by: header.column.id,
+                                      sort_order: 'desc',
+                                    })
+                                  }
                                 }
-                              }
-                            : undefined
-                        }
-                      >
-                        <div className="flex items-center gap-1">
-                          {header.isPlaceholder
-                            ? null
-                            : flexRender(
-                                header.column.columnDef.header,
-                                header.getContext(),
-                              )}
-                          {canSort &&
-                            (isSorted ? (
-                              sort.sort_order === 'asc' ? (
-                                <ArrowUpIcon className="h-4 w-4" />
+                              : undefined
+                          }
+                        >
+                          <div className="flex items-center gap-1">
+                            {header.isPlaceholder
+                              ? null
+                              : flexRender(
+                                  header.column.columnDef.header,
+                                  header.getContext(),
+                                )}
+                            {canSort &&
+                              (isSorted ? (
+                                sort.sort_order === 'asc' ? (
+                                  <ArrowUpIcon className="h-4 w-4" />
+                                ) : (
+                                  <ArrowDownIcon className="h-4 w-4" />
+                                )
                               ) : (
-                                <ArrowDownIcon className="h-4 w-4" />
-                              )
-                            ) : (
-                              <ArrowUpDownIcon className="text-muted-foreground h-4 w-4" />
-                            ))}
-                        </div>
-                      </TableHead>
-                    )
-                  })}
-                </TableRow>
-              ))}
-            </TableHeader>
-            <TableBody>
-              {table.getRowModel().rows.length > 0 ? (
-                table.getRowModel().rows.map((row) => (
-                  <TableRow key={row.id}>
-                    {row.getVisibleCells().map((cell) => (
-                      <TableCell key={cell.id}>
-                        {flexRender(
-                          cell.column.columnDef.cell,
-                          cell.getContext(),
-                        )}
-                      </TableCell>
-                    ))}
+                                <ArrowUpDownIcon className="text-muted-foreground h-4 w-4" />
+                              ))}
+                          </div>
+                        </TableHead>
+                      )
+                    })}
                   </TableRow>
-                ))
-              ) : (
-                <TableRow>
-                  <TableCell
-                    colSpan={feedbackColumns.length}
-                    className="h-24 text-center"
-                  >
-                    No feedbacks found.
-                  </TableCell>
-                </TableRow>
-              )}
-            </TableBody>
-          </Table>
-        </div>
+                ))}
+              </TableHeader>
+              <TableBody>
+                {table.getRowModel().rows.length > 0 ? (
+                  table.getRowModel().rows.map((row) => (
+                    <TableRow key={row.id}>
+                      {row.getVisibleCells().map((cell) => (
+                        <TableCell key={cell.id}>
+                          {flexRender(
+                            cell.column.columnDef.cell,
+                            cell.getContext(),
+                          )}
+                        </TableCell>
+                      ))}
+                    </TableRow>
+                  ))
+                ) : (
+                  <TableRow>
+                    <TableCell
+                      colSpan={feedbackColumns.length}
+                      className="h-24 text-center"
+                    >
+                      No feedbacks found.
+                    </TableCell>
+                  </TableRow>
+                )}
+              </TableBody>
+            </Table>
+          </div>
 
-        <DataTablePagination pagination={pagination} />
+          <DataTablePagination pagination={pagination} />
+        </div>
       </div>
     </Stack>
   )

--- a/app/routes/$orgSlug/merged/index.tsx
+++ b/app/routes/$orgSlug/merged/index.tsx
@@ -27,6 +27,10 @@ import { generateMarkdown } from './+functions/generate-markdown'
 import { getMergedPullRequestReport } from './+functions/queries.server'
 import type { Route } from './+types/index'
 
+export const handle = {
+  breadcrumb: () => ({ label: 'Merged' }),
+}
+
 export type PullRequest = Awaited<
   ReturnType<typeof getMergedPullRequestReport>
 >[0]

--- a/app/routes/$orgSlug/reviews/index.tsx
+++ b/app/routes/$orgSlug/reviews/index.tsx
@@ -36,6 +36,10 @@ import {
 } from './+functions/queries.server'
 import type { Route } from './+types/index'
 
+export const handle = {
+  breadcrumb: () => ({ label: 'Review Bottleneck' }),
+}
+
 const PERIOD_OPTIONS = [
   { value: '1', label: '1 month' },
   { value: '3', label: '3 months' },
@@ -122,7 +126,7 @@ clientLoader.hydrate = true as const
 
 export function HydrateFallback() {
   return (
-    <Stack gap="6">
+    <Stack>
       <PageHeader>
         <PageHeaderHeading>
           <PageHeaderTitle>Review Bottleneck</PageHeaderTitle>
@@ -147,7 +151,7 @@ export default function ReviewsPage({
   const [, setSearchParams] = useSearchParams()
 
   return (
-    <Stack gap="6">
+    <Stack>
       <PageHeader>
         <PageHeaderHeading>
           <PageHeaderTitle>Review Bottleneck</PageHeaderTitle>
@@ -180,9 +184,11 @@ export default function ReviewsPage({
         </PageHeaderActions>
       </PageHeader>
 
-      <QueueTrendChart data={queueTrend} />
-      <WipCycleChart data={wipCycle} rawData={wipCycleLabeled} />
-      <PRSizeChart data={prSizes} rawData={prSizesRaw} />
+      <div className="space-y-6">
+        <QueueTrendChart data={queueTrend} />
+        <WipCycleChart data={wipCycle} rawData={wipCycleLabeled} />
+        <PRSizeChart data={prSizes} rawData={prSizesRaw} />
+      </div>
     </Stack>
   )
 }


### PR DESCRIPTION
## Summary

ダッシュボード6ページのレイアウトと breadcrumb を統一。

## Before / After

| ページ | Gap (Before) | Gap (After) | Breadcrumb (Before) | Breadcrumb (After) |
|--------|-------------|-------------|--------------------|--------------------|
| Review Stacks | default | default | あり | あり |
| Ongoing | default | default | あり | あり |
| Merged | default | default | **なし** | **あり** |
| Deployed | default | default | **なし** | **あり** |
| Review Bottleneck | **gap-6** | **default** | **なし** | **あり** |
| Feedbacks | **gap-6** | **default** | あり | あり |

## Changes

### Breadcrumbs
Merged, Deployed, Review Bottleneck に breadcrumb handle を追加。

### Layout
- 全ページのトップレベル `<Stack>` をデフォルト gap に統一
- PageHeader の `mb-4` がヘッダーとコンテンツ間のスペースを制御
- Reviews: 3チャートを `<div className="space-y-6">` でラップ（チャート間のスペースを維持）
- Feedbacks: サマリーカード + テーブルを同パターンでラップ

Closes #179

## Test plan

- [ ] 全6ページでヘッダーとコンテンツの間隔が統一されている
- [ ] Merged, Deployed, Review Bottleneck に breadcrumb が表示される
- [ ] Review Bottleneck のチャート間スペースが維持されている
- [ ] Feedbacks のカードとテーブル間スペースが維持されている
- [ ] `pnpm validate` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)