### PR TITLE
refactor: replace all manual route URLs with type-safe href()

### DIFF
--- a/app/components/layout/nav-config.ts
+++ b/app/components/layout/nav-config.ts
@@ -7,6 +7,7 @@ import {
   RocketIcon,
   SettingsIcon,
 } from 'lucide-react'
+import { href } from 'react-router'
 import type { NavGroupProps } from './types'
 
 export function getNavConfig(orgSlug: string): NavGroupProps[] {
@@ -16,7 +17,7 @@ export function getNavConfig(orgSlug: string): NavGroupProps[] {
       items: [
         {
           title: 'Review Stacks',
-          url: `/${orgSlug}/workload`,
+          url: href('/:orgSlug/workload', { orgSlug }),
           icon: LayersIcon,
         },
       ],
@@ -26,17 +27,17 @@ export function getNavConfig(orgSlug: string): NavGroupProps[] {
       items: [
         {
           title: 'Ongoing',
-          url: `/${orgSlug}/throughput/ongoing`,
+          url: href('/:orgSlug/throughput/ongoing', { orgSlug }),
           icon: CircleDotIcon,
         },
         {
           title: 'Merged',
-          url: `/${orgSlug}/throughput/merged`,
+          url: href('/:orgSlug/throughput/merged', { orgSlug }),
           icon: GitMergeIcon,
         },
         {
           title: 'Deployed',
-          url: `/${orgSlug}/throughput/deployed`,
+          url: href('/:orgSlug/throughput/deployed', { orgSlug }),
           icon: RocketIcon,
         },
       ],
@@ -46,12 +47,12 @@ export function getNavConfig(orgSlug: string): NavGroupProps[] {
       items: [
         {
           title: 'Review Bottleneck',
-          url: `/${orgSlug}/analysis/reviews`,
+          url: href('/:orgSlug/analysis/reviews', { orgSlug }),
           icon: FunnelIcon,
         },
         {
           title: 'Feedbacks',
-          url: `/${orgSlug}/analysis/feedbacks`,
+          url: href('/:orgSlug/analysis/feedbacks', { orgSlug }),
           icon: NotebookPenIcon,
         },
       ],
@@ -62,7 +63,7 @@ export function getNavConfig(orgSlug: string): NavGroupProps[] {
       items: [
         {
           title: 'Settings',
-          url: `/${orgSlug}/settings`,
+          url: href('/:orgSlug/settings', { orgSlug }),
           icon: SettingsIcon,
         },
       ],

--- a/app/components/layout/org-switcher.tsx
+++ b/app/components/layout/org-switcher.tsx
@@ -1,5 +1,5 @@
 import { ChevronsUpDown } from 'lucide-react'
-import { useNavigate } from 'react-router'
+import { href, useNavigate } from 'react-router'
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -72,7 +72,9 @@ export function OrgSwitcher({
             {organizations.map((org) => (
               <DropdownMenuItem
                 key={org.id}
-                onClick={() => navigate(`/${org.slug ?? org.id}`)}
+                onClick={() =>
+                  navigate(href('/:orgSlug', { orgSlug: org.slug ?? org.id }))
+                }
                 className="gap-2 p-2"
               >
                 <div className="flex size-6 items-center justify-center rounded-sm border text-xs font-bold">

--- a/app/components/size-badge-popover.tsx
+++ b/app/components/size-badge-popover.tsx
@@ -5,7 +5,7 @@ import {
   SparklesIcon,
 } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
-import { useFetcher, useParams } from 'react-router'
+import { href, useFetcher, useParams } from 'react-router'
 import { Badge, Button } from '~/app/components/ui'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import {
@@ -255,7 +255,9 @@ export function SizeBadgePopover({
                 const fd = buildFormData(selectedSize)
                 draftFetcher.submit(fd, {
                   method: 'post',
-                  action: `/${orgSlug}/draft-feedback-reason`,
+                  action: href('/:orgSlug/draft-feedback-reason', {
+                    orgSlug: orgSlug!,
+                  }),
                 })
               }}
             >
@@ -277,7 +279,9 @@ export function SizeBadgePopover({
                 fd.set('reason', reasonText)
                 fetcher.submit(fd, {
                   method: 'post',
-                  action: `/${orgSlug}/pr-size-feedback`,
+                  action: href('/:orgSlug/pr-size-feedback', {
+                    orgSlug: orgSlug!,
+                  }),
                 })
               }}
             >

--- a/app/middleware/org-admin.ts
+++ b/app/middleware/org-admin.ts
@@ -1,4 +1,4 @@
-import { redirect } from 'react-router'
+import { href, redirect } from 'react-router'
 import { isOrgAdmin } from '~/app/libs/member-role'
 import type { Route } from '../routes/$orgSlug/settings/+types/_layout'
 import { orgContext } from './context'
@@ -9,7 +9,7 @@ export const orgAdminMiddleware: Route.MiddlewareFunction = (
 ) => {
   const { membership } = context.get(orgContext)
   if (!isOrgAdmin(membership.role)) {
-    throw redirect(`/${params.orgSlug}`)
+    throw redirect(href('/:orgSlug', { orgSlug: params.orgSlug }))
   }
   return next()
 }

--- a/app/routes/$orgSlug/_index/index.tsx
+++ b/app/routes/$orgSlug/_index/index.tsx
@@ -1,7 +1,9 @@
-import { redirect } from 'react-router'
+import { href, redirect } from 'react-router'
 import type { Route } from './+types/index'
 
 export const loader = ({ request, params }: Route.LoaderArgs) => {
   const { search } = new URL(request.url)
-  return redirect(`/${params.orgSlug}/workload${search}`)
+  return redirect(
+    `${href('/:orgSlug/workload', { orgSlug: params.orgSlug })}${search}`,
+  )
 }

--- a/app/routes/$orgSlug/_layout.tsx
+++ b/app/routes/$orgSlug/_layout.tsx
@@ -1,4 +1,4 @@
-import { Outlet, useMatches } from 'react-router'
+import { Outlet, href, useMatches } from 'react-router'
 import { AppSidebar } from '~/app/components/layout/app-sidebar'
 import { Header } from '~/app/components/layout/header'
 import { Main } from '~/app/components/layout/main'
@@ -29,7 +29,7 @@ export const handle = {
     params: { orgSlug: string },
   ) => ({
     label: data.organization.name,
-    to: `/${params.orgSlug}`,
+    to: href('/:orgSlug', { orgSlug: params.orgSlug }),
   }),
 }
 

--- a/app/routes/$orgSlug/analysis/_layout.tsx
+++ b/app/routes/$orgSlug/analysis/_layout.tsx
@@ -1,10 +1,10 @@
-import { Outlet } from 'react-router'
+import { Outlet, href } from 'react-router'
 import type { RouteHandle } from '~/app/routes/$orgSlug/_layout'
 
 export const handle: RouteHandle = {
   breadcrumb: (_data: unknown, params?: Record<string, string>) => ({
     label: 'Analysis',
-    to: `/${params?.orgSlug}/analysis/reviews`,
+    to: href('/:orgSlug/analysis/reviews', { orgSlug: params?.orgSlug ?? '' }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/_layout.tsx
+++ b/app/routes/$orgSlug/settings/_layout.tsx
@@ -9,7 +9,7 @@ import {
   SettingsIcon,
   UsersIcon,
 } from 'lucide-react'
-import { Outlet } from 'react-router'
+import { Outlet, href } from 'react-router'
 import {
   PageHeader,
   PageHeaderDescription,
@@ -25,7 +25,7 @@ import type { Route } from './+types/_layout'
 export const handle: RouteHandle = {
   breadcrumb: (_data: unknown, params?: Record<string, string>) => ({
     label: 'Settings',
-    to: `/${params?.orgSlug}/settings`,
+    to: href('/:orgSlug/settings', { orgSlug: params?.orgSlug ?? '' }),
   }),
 }
 
@@ -42,47 +42,47 @@ export default function SettingsLayout({
     {
       title: 'General',
       icon: <SettingsIcon size={18} />,
-      href: `/${orgSlug}/settings`,
+      href: href('/:orgSlug/settings', { orgSlug }),
     },
     {
       title: 'Integration',
       icon: <PlugIcon size={18} />,
-      href: `/${orgSlug}/settings/integration`,
+      href: href('/:orgSlug/settings/integration', { orgSlug }),
     },
     {
       title: 'Members',
       icon: <UsersIcon size={18} />,
-      href: `/${orgSlug}/settings/members`,
+      href: href('/:orgSlug/settings/members', { orgSlug }),
     },
     {
       title: 'Repositories',
       icon: <GitPullRequestIcon size={18} />,
-      href: `/${orgSlug}/settings/repositories`,
+      href: href('/:orgSlug/settings/repositories', { orgSlug }),
     },
     {
       title: 'Teams',
       icon: <GroupIcon size={18} />,
-      href: `/${orgSlug}/settings/teams`,
+      href: href('/:orgSlug/settings/teams', { orgSlug }),
     },
     {
       title: 'GitHub Users',
       icon: <GithubIcon size={18} />,
-      href: `/${orgSlug}/settings/github-users`,
+      href: href('/:orgSlug/settings/github-users', { orgSlug }),
     },
     {
       title: 'Export',
       icon: <FileSpreadsheetIcon size={18} />,
-      href: `/${orgSlug}/settings/export`,
+      href: href('/:orgSlug/settings/export', { orgSlug }),
     },
     {
       title: 'Data Management',
       icon: <DatabaseIcon size={18} />,
-      href: `/${orgSlug}/settings/data-management`,
+      href: href('/:orgSlug/settings/data-management', { orgSlug }),
     },
     {
       title: 'Danger Zone',
       icon: <AlertTriangleIcon size={18} />,
-      href: `/${orgSlug}/settings/danger`,
+      href: href('/:orgSlug/settings/danger', { orgSlug }),
     },
   ]
 

--- a/app/routes/$orgSlug/settings/danger/index.tsx
+++ b/app/routes/$orgSlug/settings/danger/index.tsx
@@ -1,5 +1,5 @@
 import { parseWithZod } from '@conform-to/zod/v4'
-import { redirect } from 'react-router'
+import { href, redirect } from 'react-router'
 import { orgContext } from '~/app/middleware/context'
 import ContentSection from '../+components/content-section'
 import { DeleteOrganization } from '../_index/+forms/delete-organization'
@@ -11,7 +11,7 @@ import type { Route } from './+types/index'
 export const handle = {
   breadcrumb: (_data: unknown, params: { orgSlug: string }) => ({
     label: 'Danger Zone',
-    to: `/${params.orgSlug}/settings/danger`,
+    to: href('/:orgSlug/settings/danger', { orgSlug: params.orgSlug }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/data-management/index.tsx
+++ b/app/routes/$orgSlug/settings/data-management/index.tsx
@@ -27,7 +27,7 @@ import type { Route } from './+types/index'
 export const handle = {
   breadcrumb: (_data: unknown, params: { orgSlug: string }) => ({
     label: 'Data Management',
-    to: `/${params.orgSlug}/settings/data-management`,
+    to: href('/:orgSlug/settings/data-management', { orgSlug: params.orgSlug }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/export/index.tsx
+++ b/app/routes/$orgSlug/settings/export/index.tsx
@@ -1,4 +1,5 @@
 import { parseWithZod } from '@conform-to/zod/v4'
+import { href } from 'react-router'
 import { dataWithSuccess } from 'remix-toast'
 import { orgContext } from '~/app/middleware/context'
 import ContentSection from '../+components/content-section'
@@ -11,7 +12,7 @@ import type { Route } from './+types/index'
 export const handle = {
   breadcrumb: (_data: unknown, params: { orgSlug: string }) => ({
     label: 'Export',
-    to: `/${params.orgSlug}/settings/export`,
+    to: href('/:orgSlug/settings/export', { orgSlug: params.orgSlug }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/github-users._index/index.tsx
+++ b/app/routes/$orgSlug/settings/github-users._index/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { data } from 'react-router'
+import { data, href } from 'react-router'
 import { match } from 'ts-pattern'
 import { z } from 'zod'
 import { useTimezone } from '~/app/hooks/use-timezone'
@@ -27,7 +27,7 @@ import { listFilteredGithubUsers } from './queries.server'
 export const handle = {
   breadcrumb: (_data: unknown, params: { orgSlug: string }) => ({
     label: 'GitHub Users',
-    to: `/${params.orgSlug}/settings/github-users`,
+    to: href('/:orgSlug/settings/github-users', { orgSlug: params.orgSlug }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/integration/index.tsx
+++ b/app/routes/$orgSlug/settings/integration/index.tsx
@@ -1,4 +1,5 @@
 import { parseWithZod } from '@conform-to/zod/v4'
+import { href } from 'react-router'
 import { dataWithSuccess } from 'remix-toast'
 import { orgContext } from '~/app/middleware/context'
 import ContentSection from '../+components/content-section'
@@ -11,7 +12,7 @@ import type { Route } from './+types/index'
 export const handle = {
   breadcrumb: (_data: unknown, params: { orgSlug: string }) => ({
     label: 'Integration',
-    to: `/${params.orgSlug}/settings/integration`,
+    to: href('/:orgSlug/settings/integration', { orgSlug: params.orgSlug }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/members/index.tsx
+++ b/app/routes/$orgSlug/settings/members/index.tsx
@@ -1,5 +1,5 @@
 import { useMemo } from 'react'
-import { data } from 'react-router'
+import { data, href } from 'react-router'
 import { match } from 'ts-pattern'
 import { z } from 'zod'
 import { useTimezone } from '~/app/hooks/use-timezone'
@@ -20,7 +20,7 @@ import { listFilteredMembers } from './queries.server'
 export const handle = {
   breadcrumb: (_data: unknown, params: { orgSlug: string }) => ({
     label: 'Members',
-    to: `/${params.orgSlug}/settings/members`,
+    to: href('/:orgSlug/settings/members', { orgSlug: params.orgSlug }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/repositories._index/+components/data-table-toolbar.tsx
+++ b/app/routes/$orgSlug/settings/repositories._index/+components/data-table-toolbar.tsx
@@ -1,5 +1,5 @@
 import { PlusIcon, XIcon } from 'lucide-react'
-import { Link } from 'react-router'
+import { Link, href } from 'react-router'
 import { SearchInput } from '~/app/components/search-input'
 import { TeamFilter } from '~/app/components/team-filter'
 import { Button } from '~/app/components/ui/button'
@@ -39,7 +39,7 @@ export function DataTableToolbar({ teams, orgSlug }: DataTableToolbarProps) {
         )}
       </div>
       <Button asChild>
-        <Link to={`/${orgSlug}/settings/repositories/add`}>
+        <Link to={href('/:orgSlug/settings/repositories/add', { orgSlug })}>
           <PlusIcon className="h-4 w-4" />
           Add
         </Link>

--- a/app/routes/$orgSlug/settings/repositories._index/+components/repo-row-actions.tsx
+++ b/app/routes/$orgSlug/settings/repositories._index/+components/repo-row-actions.tsx
@@ -6,7 +6,7 @@ import {
   TrashIcon,
 } from 'lucide-react'
 import { useState } from 'react'
-import { Link, useFetcher } from 'react-router'
+import { Link, href, useFetcher } from 'react-router'
 import { ConfirmDialog } from '~/app/components/confirm-dialog'
 import { Button } from '~/app/components/ui/button'
 import {
@@ -43,13 +43,23 @@ export function RepoRowActions({
           <DropdownMenuLabel>Actions</DropdownMenuLabel>
           <DropdownMenuSeparator />
           <DropdownMenuItem asChild>
-            <Link to={`/${orgSlug}/settings/repositories/${repo.id}`}>
+            <Link
+              to={href('/:orgSlug/settings/repositories/:repository', {
+                orgSlug,
+                repository: repo.id,
+              })}
+            >
               <EyeIcon className="mr-2 h-4 w-4" />
               Pull Requests
             </Link>
           </DropdownMenuItem>
           <DropdownMenuItem asChild>
-            <Link to={`/${orgSlug}/settings/repositories/${repo.id}/settings`}>
+            <Link
+              to={href('/:orgSlug/settings/repositories/:repository/settings', {
+                orgSlug,
+                repository: repo.id,
+              })}
+            >
               <SettingsIcon className="mr-2 h-4 w-4" />
               Settings
             </Link>
@@ -73,7 +83,10 @@ export function RepoRowActions({
         confirmText="Delete"
         destructive
         fetcher={deleteFetcher}
-        action={`/${orgSlug}/settings/repositories/${repo.id}/delete`}
+        action={href('/:orgSlug/settings/repositories/:repository/delete', {
+          orgSlug,
+          repository: repo.id,
+        })}
       />
     </>
   )

--- a/app/routes/$orgSlug/settings/repositories.add/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories.add/index.tsx
@@ -3,6 +3,7 @@ import { parseWithZod } from '@conform-to/zod/v4'
 import { ChevronRightIcon, ChevronsLeftIcon, RefreshCwIcon } from 'lucide-react'
 import {
   Form,
+  href,
   isRouteErrorResponse,
   redirect,
   useRouteError,
@@ -57,7 +58,7 @@ export const loader = async ({
     searchParams.delete('refresh')
     clearAllCache()
     throw redirect(
-      `/${params.orgSlug}/settings/repositories/add?${searchParams.toString()}`,
+      `${href('/:orgSlug/settings/repositories/add', { orgSlug: params.orgSlug })}?${searchParams.toString()}`,
     )
   }
 

--- a/app/routes/$orgSlug/settings/repositories/$repository/$pull/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories/$repository/$pull/index.tsx
@@ -1,7 +1,7 @@
 import { zx } from '@coji/zodix/v4'
 import { createPatch } from 'diff'
 import { useEffect, useMemo, useRef } from 'react'
-import { useFetcher, useRevalidator } from 'react-router'
+import { href, useFetcher, useRevalidator } from 'react-router'
 import { match } from 'ts-pattern'
 import { z } from 'zod'
 import { Badge, Button, HStack, Heading, Stack } from '~/app/components/ui'
@@ -32,7 +32,11 @@ export const handle = {
     params: { orgSlug: string; repository: string; pull: string },
   ) => ({
     label: `#${data.pull?.number}`,
-    to: `/${params.orgSlug}/settings/repositories/${params.repository}/${params.pull}`,
+    to: href('/:orgSlug/settings/repositories/:repository/:pull', {
+      orgSlug: params.orgSlug,
+      repository: params.repository,
+      pull: params.pull,
+    }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/repositories/$repository/_index/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories/$repository/_index/index.tsx
@@ -1,5 +1,5 @@
 import { zx } from '@coji/zodix/v4'
-import { Link } from 'react-router'
+import { Link, href } from 'react-router'
 import { z } from 'zod'
 import {
   Table,
@@ -61,7 +61,14 @@ export default function RepositoryPullsIndexPage({
                   >
                     <Link
                       className="underline"
-                      to={`/${params.orgSlug}/settings/repositories/${repositoryId}/${pull.number}`}
+                      to={href(
+                        '/:orgSlug/settings/repositories/:repository/:pull',
+                        {
+                          orgSlug: params.orgSlug,
+                          repository: repositoryId,
+                          pull: String(pull.number),
+                        },
+                      )}
                     >
                       {pull.title}
                     </Link>

--- a/app/routes/$orgSlug/settings/repositories/$repository/_layout.tsx
+++ b/app/routes/$orgSlug/settings/repositories/$repository/_layout.tsx
@@ -1,5 +1,5 @@
 import { zx } from '@coji/zodix/v4'
-import { Outlet } from 'react-router'
+import { Outlet, href } from 'react-router'
 import { z } from 'zod'
 import { orgContext } from '~/app/middleware/context'
 import type { Route } from './+types/_layout'
@@ -11,7 +11,10 @@ export const handle = {
     params: { orgSlug: string; repository: string },
   ) => ({
     label: `${data.repository.owner}/${data.repository.repo}`,
-    to: `/${params.orgSlug}/settings/repositories/${params.repository}`,
+    to: href('/:orgSlug/settings/repositories/:repository', {
+      orgSlug: params.orgSlug,
+      repository: params.repository,
+    }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/repositories/$repository/delete/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories/$repository/delete/index.tsx
@@ -1,6 +1,6 @@
 import { zx } from '@coji/zodix/v4'
 import { getFormProps, useForm } from '@conform-to/react'
-import { Form, Link, redirect, useNavigation } from 'react-router'
+import { Form, Link, href, redirect, useNavigation } from 'react-router'
 import { z } from 'zod'
 import { Button, HStack, Input, Label, Stack } from '~/app/components/ui'
 import { orgContext } from '~/app/middleware/context'
@@ -35,7 +35,9 @@ export const action = async ({ params, context }: Route.ActionArgs) => {
 
   await deleteRepository(organization.id, repositoryId)
 
-  return redirect(`/${organization.slug}/settings/repositories`)
+  return redirect(
+    href('/:orgSlug/settings/repositories', { orgSlug: organization.slug! }),
+  )
 }
 
 export default function DeleteRepositoryPage({
@@ -72,7 +74,11 @@ export default function DeleteRepositoryPage({
             Delete
           </Button>
           <Button asChild variant="ghost">
-            <Link to={`/${organization.slug}/settings/repositories`}>
+            <Link
+              to={href('/:orgSlug/settings/repositories', {
+                orgSlug: organization.slug!,
+              })}
+            >
               Cancel
             </Link>
           </Button>

--- a/app/routes/$orgSlug/settings/repositories/$repository/settings/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories/$repository/settings/index.tsx
@@ -6,7 +6,7 @@ import {
   useForm,
 } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod/v4'
-import { Form, Link, data, redirect, useNavigation } from 'react-router'
+import { Form, Link, data, href, redirect, useNavigation } from 'react-router'
 import { match } from 'ts-pattern'
 import { z } from 'zod'
 import { AppProviderBadge } from '~/app/components'
@@ -82,7 +82,9 @@ export const action = async ({
 
   await updateRepository(organization.id, repositoryId, submission.value)
 
-  return redirect(`/${organization.slug}/settings/repositories`)
+  return redirect(
+    href('/:orgSlug/settings/repositories', { orgSlug: organization.slug! }),
+  )
 }
 
 const GithubRepositoryForm = ({
@@ -156,7 +158,11 @@ const GithubRepositoryForm = ({
             Update
           </Button>
           <Button asChild variant="ghost">
-            <Link to={`/${organization.slug}/settings/repositories`}>
+            <Link
+              to={href('/:orgSlug/settings/repositories', {
+                orgSlug: organization.slug!,
+              })}
+            >
               Cancel
             </Link>
           </Button>

--- a/app/routes/$orgSlug/settings/repositories/_layout.tsx
+++ b/app/routes/$orgSlug/settings/repositories/_layout.tsx
@@ -1,9 +1,9 @@
-import { Outlet } from 'react-router'
+import { Outlet, href } from 'react-router'
 
 export const handle = {
   breadcrumb: (_data: unknown, params: { orgSlug: string }) => ({
     label: 'Repositories',
-    to: `/${params.orgSlug}/settings/repositories`,
+    to: href('/:orgSlug/settings/repositories', { orgSlug: params.orgSlug }),
   }),
 }
 

--- a/app/routes/$orgSlug/settings/teams._index/index.tsx
+++ b/app/routes/$orgSlug/settings/teams._index/index.tsx
@@ -1,6 +1,6 @@
 import { PlusIcon, TrashIcon } from 'lucide-react'
 import { useState } from 'react'
-import { data, useFetcher } from 'react-router'
+import { data, href, useFetcher } from 'react-router'
 import { match } from 'ts-pattern'
 import { z } from 'zod'
 import { ConfirmDialog } from '~/app/components/confirm-dialog'
@@ -23,7 +23,7 @@ import { listTeams } from './queries.server'
 export const handle = {
   breadcrumb: (_data: unknown, params: { orgSlug: string }) => ({
     label: 'Teams',
-    to: `/${params.orgSlug}/settings/teams`,
+    to: href('/:orgSlug/settings/teams', { orgSlug: params.orgSlug }),
   }),
 }
 

--- a/app/routes/$orgSlug/throughput/_layout.tsx
+++ b/app/routes/$orgSlug/throughput/_layout.tsx
@@ -1,10 +1,10 @@
-import { Outlet } from 'react-router'
+import { Outlet, href } from 'react-router'
 import type { RouteHandle } from '~/app/routes/$orgSlug/_layout'
 
 export const handle: RouteHandle = {
   breadcrumb: (_data: unknown, params?: Record<string, string>) => ({
     label: 'Throughput',
-    to: `/${params?.orgSlug}/throughput/merged`,
+    to: href('/:orgSlug/throughput/merged', { orgSlug: params?.orgSlug ?? '' }),
   }),
 }
 

--- a/app/routes/$orgSlug/workload/_layout.tsx
+++ b/app/routes/$orgSlug/workload/_layout.tsx
@@ -1,10 +1,10 @@
-import { Outlet } from 'react-router'
+import { Outlet, href } from 'react-router'
 import type { RouteHandle } from '~/app/routes/$orgSlug/_layout'
 
 export const handle: RouteHandle = {
   breadcrumb: (_data: unknown, params?: Record<string, string>) => ({
     label: 'Workload',
-    to: `/${params?.orgSlug}/workload`,
+    to: href('/:orgSlug/workload', { orgSlug: params?.orgSlug ?? '' }),
   }),
 }
 

--- a/app/routes/_index.tsx
+++ b/app/routes/_index.tsx
@@ -1,4 +1,4 @@
-import { redirect } from 'react-router'
+import { href, redirect } from 'react-router'
 import { getFirstOrganization, getSession } from '~/app/libs/auth.server'
 import type { Route } from './+types/_index'
 
@@ -10,7 +10,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 
   const firstOrg = await getFirstOrganization(session.user.id)
   if (firstOrg) {
-    throw redirect(`/${firstOrg.slug}`)
+    throw redirect(href('/:orgSlug', { orgSlug: firstOrg.slug! }))
   }
 
   throw redirect('/no-org')

--- a/app/routes/admin/_index/index.tsx
+++ b/app/routes/admin/_index/index.tsx
@@ -46,7 +46,11 @@ const AdminOrganizationIndex = ({
                   <TableCell>{organization.slug}</TableCell>
                   <TableCell>
                     <Button asChild size="sm" variant="link">
-                      <Link to={`/${organization.slug}/settings`}>
+                      <Link
+                        to={href('/:orgSlug/settings', {
+                          orgSlug: organization.slug!,
+                        })}
+                      >
                         Settings
                       </Link>
                     </Button>

--- a/app/routes/admin/create.tsx
+++ b/app/routes/admin/create.tsx
@@ -46,7 +46,7 @@ export const action = async ({ request }: Route.ActionArgs) => {
       ...submission.value,
       creatorUserId: user.id,
     })
-    return redirect(`/${organization.slug}`)
+    return redirect(href('/:orgSlug', { orgSlug: organization.slug }))
   } catch (e) {
     return {
       lastResult: submission.reply({

--- a/app/routes/resources/organization.tsx
+++ b/app/routes/resources/organization.tsx
@@ -63,7 +63,9 @@ export const OrganizationSwitcher = ({
         {fetcher.data?.organizations.map((organization) => (
           <DropdownMenuGroup key={organization.id}>
             <DropdownMenuItem asChild>
-              <Link to={`/${organization.slug}`}>{organization.name}</Link>
+              <Link to={href('/:orgSlug', { orgSlug: organization.slug! })}>
+                {organization.name}
+              </Link>
             </DropdownMenuItem>
           </DropdownMenuGroup>
         ))}


### PR DESCRIPTION
## Summary

全46箇所の手動構築ルートURLを React Router v7 の `href()` に統一。ルートパスやパラメータ名が変更されたらコンパイル時にエラーで検出できるようになる。

## Before / After

```typescript
// Before — 文字列テンプレートリテラル (実行時まで間違いに気づかない)
to: \`/\${params.orgSlug}/settings/repositories/\${params.repository}\`
redirect(\`/\${organization.slug}/settings/repositories\`)

// After — 型安全 (コンパイル時にルートの存在とパラメータ名を検証)
to: href('/:orgSlug/settings/repositories/:repository', { orgSlug: params.orgSlug, repository: params.repository })
redirect(href('/:orgSlug/settings/repositories', { orgSlug: organization.slug! }))
```

## Categories (46 total)

| Category | Count | Example |
|----------|-------|---------|
| Breadcrumb `to` | 15 | `to: href('/:orgSlug/settings', ...)` |
| Nav config `url` | 7 | `url: href('/:orgSlug/workload', ...)` |
| Settings sidebar `href` | 9 | `href: href('/:orgSlug/settings/teams', ...)` |
| Link `to` | 5 | `to={href('/:orgSlug/settings/repositories/:repository', ...)}` |
| redirect() | 6 | `redirect(href('/:orgSlug', ...))` |
| fetcher `action` | 3 | `action: href('/:orgSlug/pr-size-feedback', ...)` |
| navigate() | 1 | `navigate(href('/:orgSlug', ...))` |

Closes #183

## Test plan

- [ ] `pnpm validate` passes (196 tests)
- [ ] 全ページのナビゲーション・breadcrumb が正常に動作する
- [ ] リダイレクトが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)