### PR TITLE
fix: prevent healthcheck failure during heavy batch processing

### DIFF
--- a/app/services/durably.server.ts
+++ b/app/services/durably.server.ts
@@ -14,6 +14,8 @@ function createDurablyInstance() {
   return createDurably({
     dialect,
     retainRuns: '7d',
+    leaseMs: 300_000, // 5 minutes (default 30s is too short for large orgs)
+    leaseRenewIntervalMs: 30_000,
     jobs: {
       crawl: crawlJob,
       recalculate: recalculateJob,

--- a/batch/github/pullrequest.ts
+++ b/batch/github/pullrequest.ts
@@ -217,10 +217,16 @@ export const buildPullRequests = async (
   const reviewers: AnalyzedReviewer[] = []
   const reviewResponses: AnalyzedReviewResponse[] = []
 
+  let processed = 0
   for (const pr of pullrequests) {
     // フィルタが指定されていれば、対象外PRをスキップ
     if (filterPrNumbers && !filterPrNumbers.has(pr.number)) {
       continue
+    }
+
+    // Yield to event loop periodically to prevent blocking healthchecks
+    if (++processed % 50 === 0) {
+      await new Promise<void>((r) => setTimeout(r, 0))
     }
 
     try {

--- a/fly.toml
+++ b/fly.toml
@@ -38,14 +38,14 @@ swap_size_mb = 512
     soft_limit = 20
 
   [[services.tcp_checks]]
-    interval = "15s"
-    timeout = "2s"
-    grace_period = "1s"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "5s"
 
   [[services.http_checks]]
-    interval = "15s"
-    timeout = "2s"
-    grace_period = "10s"
+    interval = "30s"
+    timeout = "5s"
+    grace_period = "30s"
     method = "get"
     path = "/healthcheck"
     protocol = "http"


### PR DESCRIPTION
## Problem

本番の最弱 Fly インスタンスで recalculate/crawl を実行すると、CPU 集約処理がイベントループをブロックして healthcheck に応答できず、サーバーが再起動される。

## Root Cause

`buildPullRequests` は `preloadAll()` で全 raw データを同期的にロードした後、PR ループ内でも同期的に処理する。数百 PR で数秒間イベントループが止まり、2 秒タイムアウトの healthcheck が失敗。

## Fixes

1. **fly.toml**: ヘルスチェック間隔 15s→30s、タイムアウト 2s→5s
2. **buildPullRequests**: 50 PR ごとに `setTimeout(0)` で yield
3. **durably**: leaseMs を 30s→5分に延長

## Test plan

- [x] `pnpm validate` passes
- [ ] 本番デプロイ後に Recalculate が healthcheck 失敗なく完了

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)