### PR TITLE
fix: remove ghost reviewer records when reviewers are removed

### DIFF
--- a/batch/github/__tests__/buildPullRequests-filter.test.ts
+++ b/batch/github/__tests__/buildPullRequests-filter.test.ts
@@ -294,4 +294,15 @@ describe('buildPullRequests filter', () => {
     expect(pr2All?.releasedAt).toBe('2024-01-08T00:00:00Z')
     expect(pr2Filtered).toEqual(pr2All)
   })
+
+  test('reviewer が 0 人の PR でも reviewers エントリが生成される', async () => {
+    // PR#3 は reviewers: [] (basePr デフォルト)
+    const result = await buildPullRequests(config, prs, mockLoaders)
+
+    // reviewer が 0 人でも reviewers 配列に PR のエントリがある
+    // → batchReplacePullRequestReviewers で古い reviewer レコードが DELETE される
+    const pr3Reviewers = result.reviewers.find((r) => r.pullRequestNumber === 3)
+    expect(pr3Reviewers).toBeDefined()
+    expect(pr3Reviewers?.reviewers).toEqual([])
+  })
 })

--- a/batch/github/pullrequest.ts
+++ b/batch/github/pullrequest.ts
@@ -282,19 +282,20 @@ export const buildPullRequests = async (
 
       // 8. レビュアー（レビュー依頼先）情報を収集
       //    timeline_items から requestedAt を補完する
+      //    reviewer が 0 人でも push して、removed された reviewer の DB レコードを削除させる
       const prReviewers = pr.reviewers ?? []
-      if (prReviewers.length > 0) {
-        const timelineItems = await loaders.timelineItems(pr.number)
-        const requestedAtMap = buildRequestedAtMap(timelineItems)
-        reviewers.push({
-          pullRequestNumber: pr.number,
-          repositoryId: config.repositoryId,
-          reviewers: prReviewers.map((r) => ({
-            ...r,
-            requestedAt: requestedAtMap.get(r.login) ?? r.requestedAt,
-          })),
-        })
-      }
+      const requestedAtMap =
+        prReviewers.length > 0
+          ? buildRequestedAtMap(await loaders.timelineItems(pr.number))
+          : new Map<string, string>()
+      reviewers.push({
+        pullRequestNumber: pr.number,
+        repositoryId: config.repositoryId,
+        reviewers: prReviewers.map((r) => ({
+          ...r,
+          requestedAt: requestedAtMap.get(r.login) ?? r.requestedAt,
+        })),
+      })
     } catch (e) {
       logger.error(
         'analyze failure:',


### PR DESCRIPTION
## Summary
- reviewer が全員 approve 済み等で `reviewRequests` から外れた場合、`pull_request_reviewers` テーブルの古いレコードが削除されずに残り続けるバグを修正
- `buildPullRequests` で reviewer が 0 人でも常にエントリを emit し、`batchReplacePullRequestReviewers` の DELETE が走るようにした

## Background
全員 APPROVED 済みで GitHub API の `reviewRequests` が空なのに、DB にゴーストレコードが残っているケースを発見。表示上は `requested_at IS NOT NULL` フィルタで影響なかったが、データの正確性を担保するために修正。

## Test plan
- [x] 既存テスト 208 件通過
- [x] reviewer 0 人のケースのテスト追加
- [ ] `recalculate` 実行後にゴーストレコードが消えることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)