### PR TITLE
fix: Sentry に 404 エラーをレポートしないようフィルタリング

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -8,9 +8,15 @@ import type { AppLoadContext, EntryContext } from 'react-router'
 import { ServerRouter } from 'react-router'
 import '~/app/libs/dotenv.server'
 
-export const handleError = Sentry.createSentryHandleError({
+const sentryHandleError = Sentry.createSentryHandleError({
   logErrors: false,
 })
+
+export const handleError: typeof sentryHandleError = (error, ctx) => {
+  // Skip reporting 404s to Sentry (bot/scanner noise)
+  if (error instanceof Response && error.status === 404) return
+  sentryHandleError(error, ctx)
+}
 
 export const streamTimeout = 30000
 


### PR DESCRIPTION
## Summary
- ボット・脆弱性スキャナーが存在しない URL（`.php` 等）にアクセスした際の 404 が Sentry にノイズとして報告されていた問題を修正
- `entry.server.tsx` の `handleError` で `Response` status 404 をフィルタリング

## Test plan
- [ ] `pnpm validate` pass
- [ ] Sentry に 404 エラーが新たに報告されないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * 404エラーのエラーレポート処理を最適化しました。これにより、エラーログの精度が向上し、重要なエラーへの対応がより効率的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->