### PR TITLE
docs: README をセルフホスト向けに整理し O'Saasy ライセンスを追加

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,31 @@
+O'Saasy ライセンス
+Copyright © 2026, coji
+
+注記：日本語版を正本とします。英語訳は参考のためのものです。
+
+本ソフトウェアおよび関連するドキュメントファイル（以下「本ソフトウェア」）のコピーを取得するすべての人に対し、以下の条件に従い、本ソフトウェアを無制限に扱うことを無償で許可します。これには、本ソフトウェアのコピーを使用、複製、改変、統合、公開、配布、サブライセンス、および/または販売する権利、ならびに本ソフトウェアを提供された人にこれらを許可する権利が含まれます。
+
+上記の著作権表示およびこの許可通知は、本ソフトウェアのすべてのコピーまたは重要な部分に含めなければなりません。
+
+ライセンシーまたは下流の受領者は、本ソフトウェア（改変版または派生版を含む）を、ホスト型、マネージド型、または SaaS（Software-as-a-Service）製品もしくはクラウドサービスとして第三者に提供することにより、元のライセンサーと直接競合することはできません。ただし、当該サービスの主たる価値が本ソフトウェアの機能そのものである場合に限ります。
+
+本ソフトウェアは「現状のまま」提供され、商品性、特定目的への適合性、および非侵害についての保証を含むがこれに限定されない、明示的または黙示的ないかなる保証もありません。著作者または著作権者は、契約、不法行為、またはその他の行為に起因するかを問わず、本ソフトウェアまたは本ソフトウェアの使用もしくはその他の取引に起因または関連して生じるいかなる請求、損害、またはその他の責任についても責任を負いません。
+
+本契約は日本法に準拠し、これに従って解釈されます。紛争については、東京地方裁判所を専属的管轄裁判所とします。
+
+---
+
+O'Saasy License Agreement (Reference Translation)
+Copyright © 2026, coji
+
+Note: The Japanese version is the authoritative text. The English translation below is provided for reference only.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
+
+No licensee or downstream recipient may use the Software (including any modified or derivative versions) to directly compete with the original Licensor by offering it to third parties as a hosted, managed, or Software-as-a-Service (SaaS) product or cloud service where the primary value of the service is the functionality of the Software itself.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
+This Agreement shall be governed by and construed in accordance with the laws of Japan. Any disputes shall be subject to the exclusive jurisdiction of the Tokyo District Court.

--- a/README.md
+++ b/README.md
@@ -2,14 +2,7 @@
 
 Development productivity dashboard that tracks pull request cycle times from GitHub. Calculates coding time, pickup time, review time, and deploy time to help teams understand their development workflow.
 
-## Tech Stack
-
-- **Framework**: React Router v7 (SSR) + Express
-- **Database**: SQLite (multi-tenant, database-per-org) via Atlas + Kysely
-- **Auth**: better-auth with GitHub OAuth
-- **UI**: shadcn/ui + Tailwind CSS v4
-- **Testing**: Vitest + Playwright
-- **Hosting**: Fly.io
+Data is stored in SQLite with a multi-tenant (database-per-org) architecture.
 
 ## Setup
 
@@ -32,15 +25,15 @@ cp .env.example .env
 
 Edit `.env` with your values:
 
-| Variable                    | Description                                        |
-| --------------------------- | -------------------------------------------------- |
-| `DATABASE_URL`              | SQLite database path (e.g. `file:../data/data.db`) |
-| `BETTER_AUTH_SECRET`        | Secret for better-auth (min 32 chars)              |
-| `BETTER_AUTH_URL`           | App URL (e.g. `http://localhost:5173`)             |
-| `GITHUB_CLIENT_ID`          | GitHub App client ID                               |
-| `GITHUB_CLIENT_SECRET`      | GitHub App client secret                           |
-| `INTEGRATION_PRIVATE_TOKEN` | GitHub PAT for PR data fetching                    |
-| `GEMINI_API_KEY`            | Gemini API key for AI features                     |
+| Variable                    | Description                                        | Required |
+| --------------------------- | -------------------------------------------------- | -------- |
+| `DATABASE_URL`              | SQLite database path (e.g. `file:../data/data.db`) | Yes      |
+| `BETTER_AUTH_SECRET`        | Secret for better-auth (min 32 chars)              | Yes      |
+| `BETTER_AUTH_URL`           | App URL (e.g. `http://localhost:5173`)             | Yes      |
+| `GITHUB_CLIENT_ID`          | GitHub App client ID                               | Yes      |
+| `GITHUB_CLIENT_SECRET`      | GitHub App client secret                           | Yes      |
+| `INTEGRATION_PRIVATE_TOKEN` | GitHub PAT for PR data fetching                    | Yes      |
+| `GEMINI_API_KEY`            | Gemini API key for PR classification               | No       |
 
 ### 3. Set up GitHub App
 
@@ -66,31 +59,22 @@ pnpm db:setup
 pnpm dev
 ```
 
-## Commands
+## Fetching PR Data
+
+UpFlow needs to fetch PR data from GitHub to display metrics. After setting up a repository in the dashboard, run:
 
 ```bash
-pnpm dev          # Start dev server with HMR
-pnpm build        # Build for production
-pnpm start        # Run production server
-pnpm test         # Run unit tests
-pnpm test:e2e     # Run E2E tests
-pnpm typecheck    # Type checking
-pnpm lint         # Lint (Biome)
-pnpm format       # Format check (Prettier)
-pnpm validate     # Full validation pipeline
-pnpm db:setup     # Reset database with seed data
-pnpm db:migrate   # Generate migration from schema changes
-pnpm db:apply     # Apply migrations
-pnpm db:generate  # Generate Kysely types
+pnpm tsx batch/cli.ts crawl <org-id>
 ```
+
+In production, `crawl` runs automatically every hour.
 
 ## Authentication
 
-- **GitHub OAuth only**: Login requires the user's GitHub login to be in `companyGithubUsers` with `isActive=1`
-- **Batch auto-registration**: PR authors and reviewers are automatically added to `companyGithubUsers` as inactive (`isActive=0`). An admin enables them via the Active toggle in Settings > GitHub Users
+- **GitHub OAuth only**: Login requires the user's GitHub login to be registered in the org's GitHub Users list with Active status
 - **First-user bootstrap**: On a fresh database with no users, the first GitHub login is allowed unconditionally and promoted to super admin
-- On login, users are automatically added as members to orgs where their GitHub login is registered and active
+- **Auto-registration**: PR authors and reviewers are automatically added as inactive GitHub users during crawl. An admin enables them via Settings > GitHub Users
 
 ## License
 
-Private
+[O'Saasy License](./LICENSE) — 自由に使用・改変・配布できますが、本ソフトウェアの機能そのものを主たる価値とする競合 SaaS の提供は禁止されています。

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "upflow",
   "private": true,
+  "license": "SEE LICENSE IN LICENSE",
   "sideEffects": false,
   "type": "module",
   "scripts": {


### PR DESCRIPTION
## Summary
- README から Tech Stack / Commands セクションを削除（package.json / CLAUDE.md と重複し腐りやすい）
- Fetching PR Data セクションを追加（crawl の初回実行 + 本番は毎時自動）
- O'Saasy ライセンス（MIT + 競合 SaaS 禁止条項）を LICENSE ファイルとして追加
- package.json に `license` フィールドを追加

## Test plan
- [ ] README の内容が正確であることを目視確認
- [ ] LICENSE ファイルの内容を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **ドキュメント**
  * ライセンス利用規約（O'Saasy ライセンス）を追加しました
  * README を更新し、環境変数要件、データストレージモデル、認証プロセスに関する情報を明記しました

* **その他**
  * ライセンスメタデータを package.json に追加しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->