### PR TITLE
fix: 移行スクリプトのパス解決バグを修正

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,7 +11,7 @@
 # SENTRY_TRACES_SAMPLE_RATE=0
 # VITE_SENTRY_TRACES_SAMPLE_RATE=0
 
-DATABASE_URL="file:../data/data.db"
+UPFLOW_DATA_DIR=./data
 BETTER_AUTH_SECRET=your-better-auth-secret-at-least-32-chars
 GITHUB_CLIENT_ID=your-github-client-id
 GITHUB_CLIENT_SECRET=your-github-client-secret

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -105,6 +105,8 @@ jobs:
 
       - name: 🛠 Setup Database
         run: pnpm db:setup
+        env:
+          UPFLOW_DATA_DIR: ./data
 
       - name: 🔎 Check generated types are up to date
         run: |

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,6 @@ opensrc/
 
 # Sentry Config File
 .env.sentry-build-plugin
+data.db
+data.db-shm
+data.db-wal

--- a/Dockerfile
+++ b/Dockerfile
@@ -72,13 +72,12 @@ RUN SENTRY_DSN="$SENTRY_DSN" \
 # --- Production image ---
 FROM runtime-base
 
-ENV DATABASE_URL="file:/upflow/data/data.db?connection_limit=1"
 ENV UPFLOW_DATA_DIR="/upflow/data"
 ENV PORT="8080"
 ENV NODE_ENV="production"
 
 # add shortcut for connecting to database CLI
-RUN printf '#!/bin/sh\nset -x\nsqlite3 file:/upflow/data/data.db\n' > /usr/local/bin/database-cli && chmod +x /usr/local/bin/database-cli
+RUN printf '#!/bin/sh\nset -x\nsqlite3 "${UPFLOW_DATA_DIR}/data.db"\n' > /usr/local/bin/database-cli && chmod +x /usr/local/bin/database-cli
 
 WORKDIR /upflow
 

--- a/README.md
+++ b/README.md
@@ -25,15 +25,15 @@ cp .env.example .env
 
 Edit `.env` with your values:
 
-| Variable                    | Description                                        | Required |
-| --------------------------- | -------------------------------------------------- | -------- |
-| `DATABASE_URL`              | SQLite database path (e.g. `file:../data/data.db`) | Yes      |
-| `BETTER_AUTH_SECRET`        | Secret for better-auth (min 32 chars)              | Yes      |
-| `BETTER_AUTH_URL`           | App URL (e.g. `http://localhost:5173`)             | Yes      |
-| `GITHUB_CLIENT_ID`          | GitHub App client ID                               | Yes      |
-| `GITHUB_CLIENT_SECRET`      | GitHub App client secret                           | Yes      |
-| `INTEGRATION_PRIVATE_TOKEN` | GitHub PAT for PR data fetching                    | Yes      |
-| `GEMINI_API_KEY`            | Gemini API key for PR classification               | No       |
+| Variable                    | Description                            | Required |
+| --------------------------- | -------------------------------------- | -------- |
+| `UPFLOW_DATA_DIR`           | Data directory path (e.g. `./data`)    | Yes      |
+| `BETTER_AUTH_SECRET`        | Secret for better-auth (min 32 chars)  | Yes      |
+| `BETTER_AUTH_URL`           | App URL (e.g. `http://localhost:5173`) | Yes      |
+| `GITHUB_CLIENT_ID`          | GitHub App client ID                   | Yes      |
+| `GITHUB_CLIENT_SECRET`      | GitHub App client secret               | Yes      |
+| `INTEGRATION_PRIVATE_TOKEN` | GitHub PAT for PR data fetching        | Yes      |
+| `GEMINI_API_KEY`            | Gemini API key for PR classification   | No       |
 
 ### 3. Set up GitHub App
 

--- a/app/libs/auth.server.test.ts
+++ b/app/libs/auth.server.test.ts
@@ -1,5 +1,12 @@
-import { describe, expect, test } from 'vitest'
-import { safeRedirectTo } from './auth.server'
+import { mkdtempSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { describe, expect, test, vi } from 'vitest'
+
+vi.stubEnv('UPFLOW_DATA_DIR', mkdtempSync(path.join(tmpdir(), 'auth-test-')))
+
+// Import after env stub to avoid resolveDataDir() throwing
+const { safeRedirectTo } = await import('./auth.server')
 
 describe('safeRedirectTo', () => {
   test('returns the path when it starts with /', () => {

--- a/app/libs/dotenv.server.ts
+++ b/app/libs/dotenv.server.ts
@@ -1,7 +1,7 @@
 import { z } from 'zod'
 
 const envSchema = z.object({
-  DATABASE_URL: z.string(),
+  UPFLOW_DATA_DIR: z.string(),
   BETTER_AUTH_URL: z.string(),
   BETTER_AUTH_SECRET: z.string().min(32),
   GOOGLE_CLIENT_ID: z.string(),

--- a/app/libs/github-app-state.server.test.ts
+++ b/app/libs/github-app-state.server.test.ts
@@ -37,8 +37,7 @@ rawInit.exec(`
 `)
 rawInit.close()
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 describe('github-app-state', () => {
   const orgId = toOrgId('org-1')

--- a/app/libs/timezone.server.test.ts
+++ b/app/libs/timezone.server.test.ts
@@ -13,8 +13,7 @@ mkdirSync(testDir, { recursive: true })
 const testDbPath = path.join(testDir, 'data.db')
 writeFileSync(testDbPath, '')
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 function createTenantWithSettings(orgId: string, timezone?: string) {
   const dbPath = path.join(testDir, `tenant_${orgId}.db`)

--- a/app/routes/$orgSlug/settings/github-users._index/mutations.server.test.ts
+++ b/app/routes/$orgSlug/settings/github-users._index/mutations.server.test.ts
@@ -44,8 +44,7 @@ sharedDb.exec(`
 `)
 sharedDb.close()
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${sharedDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(sharedDbPath))
 
 let testCounter = 0
 function createFreshOrg(): OrganizationId {

--- a/app/routes/$orgSlug/settings/repositories._index/mutations.server.test.ts
+++ b/app/routes/$orgSlug/settings/repositories._index/mutations.server.test.ts
@@ -24,8 +24,7 @@ mkdirSync(testDir, { recursive: true })
 const testDbPath = path.join(testDir, 'data.db')
 writeFileSync(testDbPath, '')
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 let testCounter = 0
 function createFreshOrg(): {

--- a/app/routes/$orgSlug/settings/repositories/$repository/settings/+functions/mutations.server.test.ts
+++ b/app/routes/$orgSlug/settings/repositories/$repository/settings/+functions/mutations.server.test.ts
@@ -24,8 +24,7 @@ mkdirSync(testDir, { recursive: true })
 const testDbPath = path.join(testDir, 'data.db')
 writeFileSync(testDbPath, '')
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 let testCounter = 0
 function createFreshOrg(): {

--- a/app/routes/$orgSlug/settings/teams._index/mutations.server.test.ts
+++ b/app/routes/$orgSlug/settings/teams._index/mutations.server.test.ts
@@ -21,8 +21,7 @@ mkdirSync(testDir, { recursive: true })
 const testDbPath = path.join(testDir, 'data.db')
 writeFileSync(testDbPath, '')
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 let testCounter = 0
 function createFreshOrg(): OrganizationId {

--- a/app/routes/$orgSlug/workload/$login/+functions/queries.server.test.ts
+++ b/app/routes/$orgSlug/workload/$login/+functions/queries.server.test.ts
@@ -20,8 +20,7 @@ mkdirSync(testDir, { recursive: true })
 const testDbPath = path.join(testDir, 'data.db')
 writeFileSync(testDbPath, '')
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 let testCounter = 0
 function createFreshOrg(): OrganizationId {

--- a/app/services/db.server.ts
+++ b/app/services/db.server.ts
@@ -10,7 +10,11 @@ import {
   type Selectable,
   type Updateable,
 } from 'kysely'
+import path from 'node:path'
+import { resolveDataDir } from '~/db/data-dir'
 import type * as DB from './type'
+
+export { resolveDataDir }
 
 const debug = createDebug('app:db')
 const SQLITE_BUSY_TIMEOUT_MS = 5000
@@ -29,10 +33,7 @@ let sharedDbState: SharedDbState | undefined
 function getSharedDbState(): SharedDbState {
   if (sharedDbState) return sharedDbState
 
-  if (!process.env.DATABASE_URL) {
-    throw new Error('DATABASE_URL environment variable is required')
-  }
-  const filename = `${process.env.NODE_ENV === 'production' ? '' : '.'}${new URL(process.env.DATABASE_URL).pathname}`
+  const filename = path.join(resolveDataDir(), 'data.db')
   const database = new SQLite(filename)
   database.pragma('journal_mode = WAL')
   database.pragma(`busy_timeout = ${SQLITE_BUSY_TIMEOUT_MS}`)

--- a/app/services/github-webhook.server.test.ts
+++ b/app/services/github-webhook.server.test.ts
@@ -62,8 +62,7 @@ rawInit.exec(`
 `)
 rawInit.close()
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 describe('processGithubWebhookPayload', () => {
   const clearSpy = vi.spyOn(cache, 'clearOrgCache')

--- a/app/services/tenant-db.server.test.ts
+++ b/app/services/tenant-db.server.test.ts
@@ -17,10 +17,8 @@ mkdirSync(testDir, { recursive: true })
 const testDbPath = path.join(testDir, 'data.db')
 writeFileSync(testDbPath, '') // create empty shared DB file
 
-// getTenantDbPath uses: `${NODE_ENV === 'production' ? '' : '.'}${new URL(DATABASE_URL).pathname}`
-// In production mode, pathname is used as-is. Use production mode for predictable paths.
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+// getTenantDbPath uses: path.join(resolveDataDir(), `tenant_${orgId}.db`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 function createTestTenantDb(orgId: string): string {
   const dbPath = path.join(testDir, `tenant_${orgId}.db`)

--- a/app/services/tenant-db.server.ts
+++ b/app/services/tenant-db.server.ts
@@ -10,6 +10,7 @@ import { execFileSync } from 'node:child_process'
 import { existsSync, unlinkSync } from 'node:fs'
 import path from 'node:path'
 import type { OrganizationId } from '~/app/types/organization'
+import { resolveDataDir } from './db.server'
 import type * as TenantDB from './tenant-type'
 
 export type { TenantDB }
@@ -26,12 +27,7 @@ const tenantDbCache = new Map<
 >()
 
 function getTenantDbPath(organizationId: OrganizationId): string {
-  if (!process.env.DATABASE_URL) {
-    throw new Error('DATABASE_URL environment variable is required')
-  }
-  const sharedDbPath = `${process.env.NODE_ENV === 'production' ? '' : '.'}${new URL(process.env.DATABASE_URL).pathname}`
-  const dir = path.dirname(sharedDbPath)
-  return path.join(dir, `tenant_${organizationId}.db`)
+  return path.join(resolveDataDir(), `tenant_${organizationId}.db`)
 }
 
 function ensureTenantDb(organizationId: OrganizationId) {

--- a/batch/db/mutations.test.ts
+++ b/batch/db/mutations.test.ts
@@ -12,8 +12,7 @@ mkdirSync(testDir, { recursive: true })
 const testDbPath = path.join(testDir, 'data.db')
 writeFileSync(testDbPath, '')
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 const orgId = toOrgId(`test-org-${Date.now()}`)
 

--- a/batch/github/store.test.ts
+++ b/batch/github/store.test.ts
@@ -30,8 +30,7 @@ mkdirSync(testDir, { recursive: true })
 const testDbPath = path.join(testDir, 'data.db')
 writeFileSync(testDbPath, '')
 
-vi.stubEnv('NODE_ENV', 'production')
-vi.stubEnv('DATABASE_URL', `file://${testDbPath}`)
+vi.stubEnv('UPFLOW_DATA_DIR', path.dirname(testDbPath))
 
 afterAll(() => {
   vi.unstubAllEnvs()

--- a/db/apply-tenant-migrations.ts
+++ b/db/apply-tenant-migrations.ts
@@ -8,8 +8,9 @@ import { consola } from 'consola'
 import { execFileSync } from 'node:child_process'
 import { readdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { resolveDataDir } from './data-dir'
 
-const dataDir = './data'
+const dataDir = resolveDataDir()
 const migrationsDir = './db/migrations/tenant'
 
 function getTenantDbFiles(): string[] {

--- a/db/data-dir.ts
+++ b/db/data-dir.ts
@@ -1,0 +1,8 @@
+/** Resolve data directory from UPFLOW_DATA_DIR env var. Dependency-free. */
+export function resolveDataDir(): string {
+  const dir = process.env.UPFLOW_DATA_DIR
+  if (!dir) {
+    throw new Error('UPFLOW_DATA_DIR environment variable is required')
+  }
+  return dir
+}

--- a/db/migrate-integrations-to-shared.ts
+++ b/db/migrate-integrations-to-shared.ts
@@ -7,18 +7,9 @@ import { consola } from 'consola'
 import 'dotenv/config'
 import { existsSync, readdirSync } from 'node:fs'
 import { join } from 'node:path'
+import { resolveDataDir } from './data-dir'
 
-const dataDir = join(process.cwd(), 'data')
-
-function sharedDbFilePath(): string {
-  const url = process.env.DATABASE_URL ?? 'file:./data/data.db'
-  const pathname = new URL(url).pathname
-  const normalized =
-    process.env.NODE_ENV === 'production'
-      ? pathname
-      : `.${pathname.replace(/^\./, '')}`
-  return join(process.cwd(), normalized)
-}
+const dataDir = resolveDataDir()
 
 function hasTable(db: InstanceType<typeof Database>, name: string): boolean {
   const row = db
@@ -30,12 +21,11 @@ function hasTable(db: InstanceType<typeof Database>, name: string): boolean {
 }
 
 function migrate(): void {
-  const sharedPath = sharedDbFilePath()
+  const sharedPath = join(dataDir, 'data.db')
   if (!existsSync(sharedPath)) {
-    consola.info(
-      `Shared DB missing at ${sharedPath}; skipping integrations migration.`,
+    throw new Error(
+      `Shared DB not found at ${sharedPath}. Check UPFLOW_DATA_DIR (current: ${process.env.UPFLOW_DATA_DIR ?? '(unset)'}).`,
     )
-    return
   }
 
   const shared = new Database(sharedPath)

--- a/start.sh
+++ b/start.sh
@@ -7,10 +7,8 @@
 
 set -ex
 
-DB_URL='sqlite:///upflow/data/data.db'
-
 # 1. Apply shared DB migrations
-atlas migrate apply --env local --url "$DB_URL"
+atlas migrate apply --env local --url "sqlite://${UPFLOW_DATA_DIR}/data.db"
 
 # 2. Migrate integrations data from tenant DBs to shared DB (idempotent, safe to re-run)
 node build/db/migrate-integrations-to-shared.js


### PR DESCRIPTION
## Summary

- `path.join` で絶対パスが二重結合される問題を修正（`/upflow/upflow/data/data.db`）
- DB が見つからない場合は skip ではなく throw でプロセスを停止

## 背景

#245 のデプロイ時に、`DATABASE_URL=file:/upflow/data/data.db` の pathname を `path.join(process.cwd(), ...)` で結合したため、パスが `/upflow/upflow/data/data.db` になり DB が見つからなかった。スクリプトは「skip」として正常終了し、データがコピーされないまま tenant の integrations テーブルが削除された。

## Test plan

- [x] `pnpm validate` 全パス
- [x] 本番データは Web UI から手動復旧済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 共有データベースのパス解決ロジックを共通化するヘルパーを導入しました。これにより各処理から共有パス解決が利用可能になります。
* **バグ修正**
  * データベース移行時に共有ファイルが見つからない場合、詳細なエラーメッセージが表示され処理が停止するようになりました（パスと現在のデータベース設定を含む）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->