### PR TITLE
fix: active テナントで integration 未設定時に警告ログを出す

### DIFF
--- a/batch/job-scheduler.ts
+++ b/batch/job-scheduler.ts
@@ -22,7 +22,12 @@ export const createJobScheduler = () => {
 
         for (const org of organizations) {
           if (!org.organizationSetting?.isActive) continue
-          if (!org.integration) continue
+          if (!org.integration) {
+            logger.warn(
+              `org "${org.name}" (${org.slug}) is active but has no integration configured. Skipping crawl.`,
+            )
+            continue
+          }
 
           const orgId = org.id as OrganizationId
 


### PR DESCRIPTION
## Summary

- scheduler が active な org の integration 未設定を黙ってスキップしていた問題を修正
- `logger.warn` で org 名・slug 付きの警告メッセージを出力し、設定ミスを検知可能にした

closes #246

## Test plan

- [ ] `pnpm validate` pass
- [ ] integration 未設定の active org がある状態で scheduler を動かし、warn ログが出ることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **改善**
  * ジョブスケジューラーが、連携設定のない有効な組織を検出した場合に警告ログを記録するようになりました。これにより、設定に問題がある組織の特定が容易になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->