### PR TITLE
fix: スプレッドシート export が差分 PR のみで上書きされる問題を修正

### DIFF
--- a/app/services/jobs/shared-steps.server.ts
+++ b/app/services/jobs/shared-steps.server.ts
@@ -6,16 +6,9 @@ import type { Selectable } from 'kysely'
 import { clearOrgCache } from '~/app/services/cache.server'
 import type { TenantDB } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
-import {
-  exportPulls,
-  exportReviewResponses,
-} from '~/batch/bizlogic/export-spreadsheet'
-import { upsertAnalyzedData } from '~/batch/db'
-import type {
-  AnalyzedReview,
-  AnalyzedReviewResponse,
-  AnalyzedReviewer,
-} from '~/batch/github/types'
+import { exportPulls } from '~/batch/bizlogic/export-spreadsheet'
+import { getPullRequestReport, upsertAnalyzedData } from '~/batch/db'
+import type { AnalyzedReview, AnalyzedReviewer } from '~/batch/github/types'
 
 import type { SqliteBusyEvent } from './run-in-worker'
 import { runAnalyzeInWorker } from './run-in-worker'
@@ -24,7 +17,6 @@ interface AnalyzeResult {
   pulls: Selectable<TenantDB.PullRequests>[]
   reviews: AnalyzedReview[]
   reviewers: AnalyzedReviewer[]
-  reviewResponses: AnalyzedReviewResponse[]
   botUsers: string[]
 }
 
@@ -108,7 +100,6 @@ export async function analyzeAndFinalizeSteps(
   const allPulls: Selectable<TenantDB.PullRequests>[] = []
   const allReviews: AnalyzedReview[] = []
   const allReviewers: AnalyzedReviewer[] = []
-  const allReviewResponses: AnalyzedReviewResponse[] = []
   const allBotUsers = new Set<string>()
   const sqliteBusyEvents: SqliteBusyEvent[] = []
 
@@ -142,7 +133,6 @@ export async function analyzeAndFinalizeSteps(
     allPulls.push(...result.pulls)
     allReviews.push(...result.reviews)
     allReviewers.push(...result.reviewers)
-    allReviewResponses.push(...result.reviewResponses)
     for (const login of result.botUsers) allBotUsers.add(login)
   }
 
@@ -168,8 +158,12 @@ export async function analyzeAndFinalizeSteps(
       await runTimedStep(step, 'export', async () => {
         step.progress(0, 0, 'Exporting to spreadsheet...')
         try {
-          await exportPulls(exportSetting, allPulls)
-          await exportReviewResponses(exportSetting, allReviewResponses)
+          // Export ALL pull requests from DB, not just the ones analyzed in this run.
+          // sheet.paste() overwrites the entire sheet, so we must always export full data.
+          const allPullsFromDb = await getPullRequestReport(orgId)
+          await exportPulls(exportSetting, allPullsFromDb)
+          // TODO: reviewResponses は差分データしか持っていないため全件 export できない。
+          // DB に永続化してから全件 export に対応する。
         } catch (e) {
           step.log.warn(`Export failed: ${e instanceof Error ? e.message : e}`)
         }

--- a/batch/bizlogic/export-spreadsheet.ts
+++ b/batch/bizlogic/export-spreadsheet.ts
@@ -9,18 +9,31 @@ const escapeTabString = (str: string) => {
 
 const tz = 'Asia/Tokyo'
 
-/** ReviewResponse の型定義 */
-interface ReviewResponse {
+interface ExportPullRequest {
   repo: string
-  number: string
+  number: number
+  sourceBranch: string
+  targetBranch: string
+  state: string
   author: string
-  createdAt: string
-  responseTime: number
+  title: string
+  url: string
+  codingTime: number | null
+  pickupTime: number | null
+  reviewTime: number | null
+  deployTime: number | null
+  totalTime: number | null
+  firstCommittedAt: string | null
+  pullRequestCreatedAt: string | null
+  firstReviewedAt: string | null
+  mergedAt: string | null
+  releasedAt: string | null
+  updatedAt: string | null
 }
 
 export async function exportPulls(
   exportSetting: Selectable<TenantDB.ExportSettings>,
-  pullrequests: Selectable<TenantDB.PullRequests>[],
+  pullrequests: ExportPullRequest[],
 ): Promise<void> {
   const sheet = createSheetApi({
     spreadsheetId: exportSetting.sheetId,
@@ -74,37 +87,6 @@ export async function exportPulls(
         mergedAt: timeFormatTz(pr.mergedAt, tz),
         releasedAt: timeFormatTz(pr.releasedAt, tz),
         updatedAt: timeFormatTz(pr.updatedAt, tz),
-      }).join('\t')
-    }),
-  ].join('\n')
-
-  await sheet.paste(data)
-}
-
-export async function exportReviewResponses(
-  exportSetting: Selectable<TenantDB.ExportSettings>,
-  reviewResponses: ReviewResponse[],
-): Promise<void> {
-  const sheet = createSheetApi({
-    spreadsheetId: exportSetting.sheetId,
-    sheetTitle: 'reviewres',
-    clientEmail: exportSetting.clientEmail,
-    privateKey: exportSetting.privateKey,
-  })
-  const header = ['repo', 'number', 'author', 'createdAt', 'responseTime'].join(
-    '\t',
-  )
-
-  const data = [
-    header,
-    ...reviewResponses.map((res) => {
-      // １行タブ区切り x 改行区切りで全行まとめてペースト
-      return Object.values({
-        repo: res.repo,
-        number: res.number,
-        author: res.author,
-        createdAt: timeFormatTz(res.createdAt, tz),
-        responseTime: res.responseTime,
       }).join('\t')
     }),
   ].join('\n')

--- a/batch/db/queries.ts
+++ b/batch/db/queries.ts
@@ -8,7 +8,27 @@ export const getPullRequestReport = async (organizationId: OrganizationId) => {
     .selectFrom('pullRequests')
     .innerJoin('repositories', 'pullRequests.repositoryId', 'repositories.id')
     .orderBy('mergedAt', 'desc')
-    .selectAll('pullRequests')
+    .select([
+      'pullRequests.repo',
+      'pullRequests.number',
+      'pullRequests.sourceBranch',
+      'pullRequests.targetBranch',
+      'pullRequests.state',
+      'pullRequests.author',
+      'pullRequests.title',
+      'pullRequests.url',
+      'pullRequests.codingTime',
+      'pullRequests.pickupTime',
+      'pullRequests.reviewTime',
+      'pullRequests.deployTime',
+      'pullRequests.totalTime',
+      'pullRequests.firstCommittedAt',
+      'pullRequests.pullRequestCreatedAt',
+      'pullRequests.firstReviewedAt',
+      'pullRequests.mergedAt',
+      'pullRequests.releasedAt',
+      'pullRequests.updatedAt',
+    ])
     .execute()
 }
 


### PR DESCRIPTION
## Summary

- `sheet.paste()` がシート全体を削除→貼り付けするため、差分 crawl 時に更新された PR だけで rawdata シートが上書きされていた
- export ステップで DB から全 PR を取得して export するように修正
- `exportReviewResponses` は差分データしか持たないため一旦停止（DB 永続化後に対応予定）
- `getPullRequestReport` を `selectAll` → 必要 19 カラムのみに絞り込み

## Test plan

- [ ] デプロイ後、iris org の crawl が走った後にスプシ rawdata を確認し全 PR が出力されていること
- [ ] reviewres シートは更新されなくなることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * プルリクエストのエクスポートがデータベースから完全なデータセットを取得するようになり、シート全体の置換動作を保証しました。

* **改善**
  * プルリクエストのエクスポートに、ソースブランチ、ターゲットブランチ、状態、タイトル、URL、複数のタイムスタンプと期間情報など、より詳細な情報が含まれるようになりました。
  * レビューレスポンスのエクスポート機能を削除しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->