### PR TITLE
fix: Sentry のボット/スキャナーノイズをフィルタ

### DIFF
--- a/app/entry.server.tsx
+++ b/app/entry.server.tsx
@@ -13,8 +13,16 @@ const sentryHandleError = Sentry.createSentryHandleError({
 })
 
 export const handleError: typeof sentryHandleError = (error, ctx) => {
-  // Skip reporting 404s to Sentry (bot/scanner noise)
+  // Skip react-router internal errors (bot/scanner 404s, missing-loader 400s)
   if (error instanceof Response && error.status === 404) return
+  if (
+    error instanceof Error &&
+    'status' in error &&
+    'internal' in error &&
+    ((error as { status: number }).status === 404 ||
+      (error as { status: number }).status === 400)
+  )
+    return
   sentryHandleError(error, ctx)
 }
 

--- a/app/routes/api.github.webhook.ts
+++ b/app/routes/api.github.webhook.ts
@@ -2,6 +2,10 @@ import { verifyWebhookSignature } from '~/app/libs/webhook-verify.server'
 import { processGithubWebhookPayload } from '~/app/services/github-webhook.server'
 import type { Route } from './+types/api.github.webhook'
 
+export const loader = () => {
+  return new Response('Method Not Allowed', { status: 405 })
+}
+
 export const action = async ({ request }: Route.ActionArgs) => {
   if (request.method !== 'POST') {
     return new Response('Method Not Allowed', { status: 405 })

--- a/instrument.server.mjs
+++ b/instrument.server.mjs
@@ -13,5 +13,18 @@ if (dsn) {
     dsn,
     sendDefaultPii: true,
     tracesSampleRate: parseSampleRate(process.env.SENTRY_TRACES_SAMPLE_RATE),
+    beforeSend(event) {
+      // Filter out react-router internal errors (404 bot/scanner noise, 400 missing loader)
+      const serialized = event.extra?.__serialized__
+      if (
+        serialized &&
+        typeof serialized === 'object' &&
+        serialized.internal === true &&
+        (serialized.status === 404 || serialized.status === 400)
+      ) {
+        return null
+      }
+      return event
+    },
   })
 }


### PR DESCRIPTION
## Summary
- `beforeSend` で react-router internal エラー (404/400) を Sentry に送信しないようフィルタ
- `handleError` で Error オブジェクトの internal 404/400 も早期フィルタ（Sentry イベント生成コストを回避）
- webhook ルートに `loader` を追加し GET リクエストに 405 を返す（missing loader エラー解消）

## Background
Sentry 導入後、ボット/スキャナーによる `.php` パスへのアクセス（UPFLOW-3: 382件）や webhook への GET リクエスト（UPFLOW-7）がノイズとして大量に記録されていた。

## Test plan
- [x] `pnpm validate` 通過（lint, format, typecheck, build, test）
- [ ] デプロイ後 Sentry で新規ノイズイベントが発生しないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **バグ修正**
  * エラー報告の精度を向上させました。特定のルーティングエラー（404、400 ステータス）が不要な通知を発生させない改善を実施
  * GitHub Webhook API エンドポイントのセキュリティを強化し、不正なリクエストメソッドに対する保護を追加

<!-- end of auto-generated comment: release notes by coderabbit.ai -->