### PR TITLE
feat: PR一覧取得を軽量クエリ + 早期打ち切りに最適化する

### DIFF
--- a/app/services/jobs/crawl.server.ts
+++ b/app/services/jobs/crawl.server.ts
@@ -97,9 +97,9 @@ export const crawlJob = defineJob({
 
       // Step 2c: Fetch lightweight PR list (number + updatedAt only)
       const prNumberSet = input.prNumbers ? new Set(input.prNumbers) : null
-      const prsToFetch = prNumberSet
-        ? // --pr 指定時: リスト取得をスキップ
-          (input.prNumbers?.map((n) => ({ number: n, updatedAt: '' })) ?? [])
+      const prsToFetch: Array<{ number: number }> = prNumberSet
+        ? // --pr 指定時: リスト取得をスキップし、指定番号だけ処理する
+          (input.prNumbers?.map((n) => ({ number: n })) ?? [])
         : await step.run(`fetch-prs:${repoLabel}`, async () => {
             step.progress(i + 1, repoCount, `Fetching PR list: ${repoLabel}...`)
             const stopBefore =

--- a/batch/github/fetcher.ts
+++ b/batch/github/fetcher.ts
@@ -1097,6 +1097,7 @@ export const createFetcher = ({ owner, repo, octokit }: createFetcherProps) => {
       let stopped = false
       for (const node of pullRequests.nodes) {
         if (!node) continue
+        // ISO 8601 UTC 文字列同士なので lexicographic 比較 = 時系列比較
         if (stopBefore && node.updatedAt < stopBefore) {
           stopped = true
           break


### PR DESCRIPTION
## Summary

- PR一覧取得を `number` + `updatedAt` のみの軽量クエリに変更（body, assignees, reviewRequests 等を除去）
- `orderBy: UPDATED_AT DESC` + 早期打ち切りで、通常 crawl の一覧取得が 76+ API コール → 1ページで完了
- PR メタデータは detail fetch 時に個別取得（`pullrequest(number)` 新設、commits/reviews 等と並行実行）
- `shapePullRequestNode()` を抽出して PR ノード変換ロジックを共通化
- `--pr` 指定時は一覧取得を完全スキップ

Closes #264

## Test plan

- [x] `pnpm validate` が通る
- [x] JTC org で `crawl --pr 8945` が動作する（一覧取得スキップ、個別 PR 取得成功）
- [x] JTC org で通常 `crawl` が動作する（軽量リストで82件検出、detail fetch 成功）
- [ ] `crawl --refresh` で全件取得が動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **パフォーマンス改善**
  * プルリクエスト取得処理を最適化しました。APIクエリをより効率的に構成し、不要なデータ転送を削減することで、全体的なレスポンスパフォーマンスを向上させました。大量のプルリクエストを扱う際の処理がより高速になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->