### PR TITLE
feat: crawl --pr に --repo を必須化し対象リポのみ処理する

### DIFF
--- a/app/services/jobs/crawl.server.ts
+++ b/app/services/jobs/crawl.server.ts
@@ -20,6 +20,7 @@ export const crawlJob = defineJob({
     organizationId: z.string(),
     refresh: z.boolean().default(false),
     prNumbers: z.array(z.number()).optional(),
+    repoName: z.string().optional(),
   }),
   output: z.object({
     fetchedRepos: z.number(),
@@ -53,14 +54,18 @@ export const crawlJob = defineJob({
       githubAppLink: fullOrg.githubAppLink,
     })
 
-    const repoCount = organization.repositories.length
     const updatedPrNumbers = new Map<string, Set<number>>()
 
     const FETCH_ALL_SENTINEL = '2000-01-01T00:00:00Z'
 
     // Step 2: Fetch per repo
-    for (let i = 0; i < organization.repositories.length; i++) {
-      const repo = organization.repositories[i]
+    const targetRepos = input.repoName
+      ? organization.repositories.filter((r) => r.repo === input.repoName)
+      : organization.repositories
+    const repoCount = targetRepos.length
+
+    for (let i = 0; i < targetRepos.length; i++) {
+      const repo = targetRepos[i]
       const repoLabel = `${repo.owner}/${repo.repo}`
 
       const store = createStore({

--- a/batch/cli.ts
+++ b/batch/cli.ts
@@ -1,4 +1,5 @@
 import { cli, command } from 'cleye'
+import consola from 'consola'
 import 'dotenv/config'
 import {
   captureExceptionToSentry,
@@ -22,7 +23,12 @@ const crawl = command(
       },
       pr: {
         type: [Number],
-        description: 'Specific PR numbers to refresh (e.g. --pr 123 --pr 456)',
+        description:
+          'Specific PR numbers to refresh (requires --repo). e.g. --repo falcon9 --pr 123',
+      },
+      repo: {
+        type: String,
+        description: 'Repository name to target (required with --pr)',
       },
     },
     help: {
@@ -32,10 +38,16 @@ const crawl = command(
   },
   async (argv) => {
     const { crawlCommand } = await import('./commands/crawl')
+    const prNumbers = argv.flags.pr?.length ? argv.flags.pr : undefined
+    if (prNumbers && !argv.flags.repo) {
+      consola.error('--repo is required when using --pr')
+      process.exit(1)
+    }
     await crawlCommand({
       organizationId: argv._.organizationId,
       refresh: argv.flags.refresh,
-      prNumbers: argv.flags.pr?.length ? argv.flags.pr : undefined,
+      prNumbers,
+      repoName: argv.flags.repo,
     })
   },
 )

--- a/batch/commands/crawl.ts
+++ b/batch/commands/crawl.ts
@@ -7,12 +7,14 @@ interface CrawlCommandProps {
   organizationId?: string
   refresh: boolean
   prNumbers?: number[]
+  repoName?: string
 }
 
 export async function crawlCommand({
   organizationId,
   refresh,
   prNumbers,
+  repoName,
 }: CrawlCommandProps) {
   const result = await requireOrganization(organizationId)
   if (!result) return
@@ -20,15 +22,15 @@ export async function crawlCommand({
   const { orgId } = result
 
   try {
-    const prLabel = prNumbers
-      ? ` (PRs: ${prNumbers.join(', ')})`
-      : refresh
-        ? ' (full refresh)'
-        : ''
-    consola.info(`Starting crawl for ${orgId}${prLabel}...`)
+    const labels: string[] = []
+    if (repoName) labels.push(`repo: ${repoName}`)
+    if (prNumbers) labels.push(`PRs: ${prNumbers.join(', ')}`)
+    if (refresh) labels.push('full refresh')
+    const label = labels.length > 0 ? ` (${labels.join(', ')})` : ''
+    consola.info(`Starting crawl for ${orgId}${label}...`)
 
     const { output } = await durably.jobs.crawl.triggerAndWait(
-      { organizationId: orgId, refresh, prNumbers },
+      { organizationId: orgId, refresh, prNumbers, repoName },
       {
         concurrencyKey: `crawl:${orgId}`,
         labels: { organizationId: orgId },


### PR DESCRIPTION
## Summary

- `--pr` 使用時に `--repo` を必須化し、指定リポのみ処理するように変更
- 全リポを巡回して 404 になる無駄な API コールを排除

```bash
# Before: 全3リポで PR#8945 を試みて 2リポで 404
crawl <org-id> --pr 8945

# After: falcon9 だけ処理
crawl <org-id> --repo falcon9 --pr 8945
```

Closes #267

## Test plan

- [x] `pnpm validate` が通る
- [x] `--repo falcon9 --pr 8945` で 1 repos, 1 PRs と表示される
- [x] `--pr 8945` のみ（`--repo` なし）でエラーメッセージが出る

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * クローリング対象を特定のリポジトリに限定できるようになりました。
  * プルリクエスト番号を指定する際は、リポジトリの指定が必須となります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->