### PR TITLE
feat: リポジトリ追加時に初回 crawl を自動 trigger (#274)

### DIFF
--- a/app/routes/$orgSlug/settings/repositories.add/+functions/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.add/+functions/mutations.server.ts
@@ -40,5 +40,6 @@ export const addRepository = async (
         updatedAt: eb.ref('excluded.updatedAt'),
       })),
     )
-    .executeTakeFirst()
+    .returning('id')
+    .executeTakeFirstOrThrow()
 }

--- a/app/routes/$orgSlug/settings/repositories.add/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories.add/index.tsx
@@ -26,10 +26,13 @@ import {
   Stack,
 } from '~/app/components/ui'
 import { requireOrgOwner } from '~/app/libs/auth.server'
+import { captureExceptionToSentry } from '~/app/libs/sentry-node.server'
 import { orgContext } from '~/app/middleware/context'
 import { clearOrgCache, getOrgCachedData } from '~/app/services/cache.server'
+import { durably } from '~/app/services/durably.server'
 import { getGithubAppLink } from '~/app/services/github-integration-queries.server'
 import { resolveOctokitFromOrg } from '~/app/services/github-octokit.server'
+import { crawlRepoConcurrencyKey } from '~/app/services/jobs/concurrency-keys.server'
 import type { OrganizationId } from '~/app/types/organization'
 import ContentSection from '../+components/content-section'
 import { RepositoryItem, RepositoryList } from './+components'
@@ -211,18 +214,44 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
     return dataWithError({}, { message: 'Invalid form submission' })
   }
 
-  try {
-    await addRepository(organization.id, {
-      owner: submission.value.owner,
-      repo: submission.value.name,
-    })
-  } catch (e) {
+  const inserted = await addRepository(organization.id, {
+    owner: submission.value.owner,
+    repo: submission.value.name,
+  }).catch((e) => {
     console.error('Failed to add repository:', e)
+    return null
+  })
+  if (!inserted) {
     return dataWithError(
       {},
       { message: 'Failed to add repository. Please try again.' },
     )
   }
+
+  // Fire-and-forget: kick off an initial crawl so existing PRs appear without
+  // waiting for the hourly scheduled job. Failures must not fail the add.
+  durably.jobs.crawl
+    .trigger(
+      {
+        organizationId: organization.id,
+        refresh: false,
+        repositoryId: inserted.id,
+      },
+      {
+        concurrencyKey: crawlRepoConcurrencyKey(organization.id, inserted.id),
+        labels: { organizationId: organization.id },
+        coalesce: 'skip',
+      },
+    )
+    .catch((e) => {
+      captureExceptionToSentry(e, {
+        tags: { component: 'repositories.add', operation: 'crawl.trigger' },
+        extra: {
+          organizationId: organization.id,
+          repositoryId: inserted.id,
+        },
+      })
+    })
 
   return dataWithSuccess(
     {},

--- a/app/services/jobs/concurrency-keys.server.ts
+++ b/app/services/jobs/concurrency-keys.server.ts
@@ -1,3 +1,5 @@
 export const crawlConcurrencyKey = (orgId: string) => `crawl:${orgId}` as const
+export const crawlRepoConcurrencyKey = (orgId: string, repoId: string) =>
+  `crawl:${orgId}:${repoId}` as const
 export const processConcurrencyKey = (orgId: string) =>
   `process:${orgId}` as const

--- a/app/services/jobs/crawl.server.ts
+++ b/app/services/jobs/crawl.server.ts
@@ -71,7 +71,12 @@ export const crawlJob = defineJob({
       ? organization.repositories.filter((r) => r.id === input.repositoryId)
       : organization.repositories
     if (input.repositoryId && targetRepos.length === 0) {
-      throw new Error('repositoryId does not match any organization repository')
+      // Repository may have been deleted between trigger and run. Skip instead
+      // of throwing so transient races (e.g. add-then-remove) don't fail the job.
+      step.log.warn(
+        `repositoryId ${input.repositoryId} does not match any organization repository; skipping crawl`,
+      )
+      return { fetchedRepos: 0, pullCount: 0, failedRepos: [] }
     }
     const repoCount = targetRepos.length
 


### PR DESCRIPTION
## Summary

- リポジトリ追加直後に該当 repo 限定の crawl を fire-and-forget で trigger し、既存 PR データが自動で表示されるようにする
- concurrencyKey は per-repo (`crawl:${orgId}:${repoId}`) + `coalesce: 'skip'`。連続追加時に異なる repo の crawl が drop されず、同一 repo の重複クリックは安全に skip
- crawl.server.ts で `repositoryId` 不一致時を throw → `step.log.warn` + 早期 return に緩和。追加直後に削除された race でジョブが失敗しない

Closes #274

## 変更点

- `app/services/jobs/concurrency-keys.server.ts`: `crawlRepoConcurrencyKey(orgId, repoId)` を追加
- `app/services/jobs/crawl.server.ts`: `repositoryId` 不一致を warn + 早期 return
- `app/routes/$orgSlug/settings/repositories.add/+functions/mutations.server.ts`: `addRepository` が `.returning('id')` で挿入 id を返す
- `app/routes/$orgSlug/settings/repositories.add/index.tsx`: add 成功後に crawl trigger（fire-and-forget、失敗は Sentry へ）

## Test plan

- [ ] リポジトリ追加後、既存 PR データが自動で取得されることを確認
- [ ] 同一リポを連続クリック時、2 回目以降の trigger が skip されることを確認
- [ ] 異なる 2 リポを連続追加時、両方 crawl が走ることを確認
- [ ] 追加直後に repo を削除しても crawl ジョブがエラーにならないことを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * リポジトリ追加後、自動的にスキャンが開始されるようになりました。

* **バグ修正**
  * リポジトリ追加時のエラーハンドリングが改善されました。
  * リポジトリが見つからない場合の処理がより堅牢になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->