### PR TITLE
feat(github-app): webhook handlers, canonical reassignment, and membership initialization (#283 PR 3/7)

### DIFF
--- a/app/routes/api.github.setup.ts
+++ b/app/routes/api.github.setup.ts
@@ -1,12 +1,19 @@
 import { nanoid } from 'nanoid'
 import { href, redirect } from 'react-router'
 import { getSession } from '~/app/libs/auth.server'
+import { getErrorMessage } from '~/app/libs/error-message'
 import {
   consumeInstallState,
   InstallStateError,
 } from '~/app/libs/github-app-state.server'
 import { clearOrgCache } from '~/app/services/cache.server'
 import { db } from '~/app/services/db.server'
+import {
+  logGithubAppLinkEvent,
+  tryLogGithubAppLinkEvent,
+} from '~/app/services/github-app-link-events.server'
+import { initializeMembershipsForInstallation } from '~/app/services/github-app-membership.server'
+import { fetchInstallationRepositories } from '~/app/services/github-installation-repos.server'
 import { createAppOctokit } from '~/app/services/github-octokit.server'
 import type { OrganizationId } from '~/app/types/organization'
 import type { Route } from './+types/api.github.setup'
@@ -26,7 +33,7 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
 
   let installation: {
     id: number
-    account: { id: number; login: string }
+    account: { id: number; login: string; type: string | null }
     repository_selection?: 'all' | 'selected' | null
   }
 
@@ -42,9 +49,13 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
     if (!('login' in account) || typeof account.login !== 'string') {
       return new Response('Invalid installation account', { status: 502 })
     }
+    const accountType =
+      'type' in account && typeof account.type === 'string'
+        ? account.type
+        : null
     installation = {
       id: data.id,
-      account: { id: account.id, login: account.login },
+      account: { id: account.id, login: account.login, type: accountType },
       repository_selection: data.repository_selection,
     }
   } catch {
@@ -74,14 +85,15 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
           organizationId,
           installationId: installation.id,
           githubAccountId: installation.account.id,
+          githubAccountType: installation.account.type,
           githubOrg: installation.account.login,
           appRepositorySelection,
           deletedAt: null,
         })
         .onConflict((oc) =>
-          oc.column('organizationId').doUpdateSet({
-            installationId: installation.id,
+          oc.columns(['organizationId', 'installationId']).doUpdateSet({
             githubAccountId: installation.account.id,
+            githubAccountType: installation.account.type,
             githubOrg: installation.account.login,
             appRepositorySelection,
             deletedAt: null,
@@ -108,10 +120,58 @@ export const loader = async ({ request }: Route.LoaderArgs) => {
           }),
         )
         .execute()
+
+      await logGithubAppLinkEvent(
+        {
+          organizationId,
+          installationId: installation.id,
+          eventType: 'link_created',
+          source: 'setup_callback',
+          status: 'success',
+          details: { accountType: installation.account.type },
+        },
+        trx,
+      )
     })
   } catch (e) {
     console.error('[api.github.setup]', e)
     return new Response('Failed to save installation', { status: 500 })
+  }
+
+  // Best-effort membership initialization. If the GitHub API call fails, the
+  // link is still saved without `membership_initialized_at`; the auto-repair
+  // step in the next crawl will fill it in.
+  try {
+    const repos = await fetchInstallationRepositories(installation.id)
+    await initializeMembershipsForInstallation({
+      organizationId,
+      installationId: installation.id,
+      repositories: repos,
+    })
+    await db
+      .updateTable('githubAppLinks')
+      .set({ membershipInitializedAt: new Date().toISOString() })
+      .where('organizationId', '=', organizationId)
+      .where('installationId', '=', installation.id)
+      .execute()
+    await tryLogGithubAppLinkEvent({
+      organizationId,
+      installationId: installation.id,
+      eventType: 'membership_initialized',
+      source: 'setup_callback',
+      status: 'success',
+      details: { repoCount: repos.length },
+    })
+  } catch (e) {
+    console.error('[api.github.setup] membership init failed', e)
+    await tryLogGithubAppLinkEvent({
+      organizationId,
+      installationId: installation.id,
+      eventType: 'membership_initialized',
+      source: 'setup_callback',
+      status: 'failed',
+      details: { error: getErrorMessage(e) },
+    })
   }
 
   clearOrgCache(organizationId)

--- a/app/services/github-app-link-events.server.ts
+++ b/app/services/github-app-link-events.server.ts
@@ -10,6 +10,7 @@ export type GithubAppLinkEventType =
   | 'link_unsuspended'
   | 'membership_initialized'
   | 'membership_repaired'
+  | 'membership_synced'
   | 'canonical_reassigned'
   | 'canonical_cleared'
   | 'assignment_required'

--- a/app/services/github-app-link-events.server.ts
+++ b/app/services/github-app-link-events.server.ts
@@ -56,3 +56,18 @@ export const logGithubAppLinkEvent = async (
     })
     .execute()
 }
+
+/**
+ * Best-effort variant: writes the audit log entry and swallows any error so the
+ * caller's primary mutation is never affected by audit-log failures. Logs to
+ * stderr if the write fails.
+ */
+export const tryLogGithubAppLinkEvent = async (
+  input: LogGithubAppLinkEventInput,
+): Promise<void> => {
+  try {
+    await logGithubAppLinkEvent(input)
+  } catch (e) {
+    console.error('[github_app_link_events] failed to write audit log entry', e)
+  }
+}

--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -403,4 +403,86 @@ describe('reassignCanonicalAfterLinkLoss', () => {
     // Only the first run produces an event; the second run is a no-op.
     expect(events).toHaveLength(1)
   })
+
+  test('scoped repositoryIds only reassigns the specified repositories', async () => {
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const tenantDb = getTenantDb(ORG_ID)
+
+    await insertLink(LOST_INSTALLATION)
+    await insertLink(ALT_INSTALLATION)
+
+    // Two repos, both canonical = LOST. Only the first is in scope.
+    const REPO_KEEP = 'repo-keep'
+    const REPO_SCOPED = 'repo-scoped'
+    for (const id of [REPO_KEEP, REPO_SCOPED]) {
+      await tenantDb
+        .insertInto('repositories')
+        .values({
+          id,
+          integrationId: 'int-1',
+          provider: 'github',
+          owner: 'octo',
+          repo: id,
+          githubInstallationId: LOST_INSTALLATION,
+          updatedAt: '2026-04-07T00:00:00Z',
+        })
+        .execute()
+      // Both repos have ALT as an eligible alternative candidate.
+      await tenantDb
+        .insertInto('repositoryInstallationMemberships')
+        .values({ repositoryId: id, installationId: ALT_INSTALLATION })
+        .execute()
+    }
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_repositories_webhook',
+      repositoryIds: [REPO_SCOPED],
+    })
+
+    const rows = await tenantDb
+      .selectFrom('repositories')
+      .select(['id', 'githubInstallationId'])
+      .execute()
+    const byId = new Map(rows.map((r) => [r.id, r.githubInstallationId]))
+    // Only the scoped repo is reassigned. The other keeps LOST as canonical
+    // because it still legitimately belongs to that installation.
+    expect(byId.get(REPO_SCOPED)).toBe(ALT_INSTALLATION)
+    expect(byId.get(REPO_KEEP)).toBe(LOST_INSTALLATION)
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events).toHaveLength(1)
+    expect(events[0].eventType).toBe('canonical_reassigned')
+  })
+
+  test('empty repositoryIds array is a no-op', async () => {
+    await insertLink(LOST_INSTALLATION)
+    await seedRepository(LOST_INSTALLATION)
+    await insertMembership(LOST_INSTALLATION)
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_repositories_webhook',
+      repositoryIds: [],
+    })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBe(LOST_INSTALLATION)
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events).toHaveLength(0)
+  })
 })

--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -1,0 +1,406 @@
+import SQLite from 'better-sqlite3'
+import { mkdirSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import {
+  afterAll,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  test,
+  vi,
+} from 'vitest'
+import { closeDb, db } from '~/app/services/db.server'
+import { closeAllTenantDbs } from '~/app/services/tenant-db.server'
+import type { OrganizationId } from '~/app/types/organization'
+import { reassignCanonicalAfterLinkLoss } from './github-app-membership.server'
+
+const ORG_ID = 'org-test' as OrganizationId
+const LOST_INSTALLATION = 100
+const ALT_INSTALLATION = 200
+const SECOND_ALT_INSTALLATION = 300
+const REPO_ID = 'repo-1'
+
+const testDir = path.join(tmpdir(), `membership-${Date.now()}`)
+mkdirSync(testDir, { recursive: true })
+const sharedDbPath = path.join(testDir, 'data.db')
+const tenantDbPath = path.join(testDir, `tenant_${ORG_ID}.db`)
+writeFileSync(sharedDbPath, '')
+writeFileSync(tenantDbPath, '')
+
+const sharedInit = new SQLite(sharedDbPath)
+sharedInit.exec(`
+  CREATE TABLE github_app_links (
+    organization_id text NOT NULL,
+    installation_id integer NOT NULL,
+    github_account_id integer NOT NULL,
+    github_account_type text,
+    github_org text NOT NULL,
+    app_repository_selection text NOT NULL DEFAULT 'all',
+    suspended_at text,
+    membership_initialized_at text,
+    deleted_at text,
+    created_at text NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at text NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    PRIMARY KEY (organization_id, installation_id)
+  );
+  CREATE TABLE github_app_link_events (
+    id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    organization_id text NOT NULL,
+    installation_id integer NOT NULL,
+    event_type text NOT NULL,
+    source text NOT NULL,
+    status text NOT NULL,
+    details_json text,
+    created_at text NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
+`)
+sharedInit.close()
+
+const tenantInit = new SQLite(tenantDbPath)
+tenantInit.exec(`
+  CREATE TABLE repositories (
+    id text NOT NULL PRIMARY KEY,
+    integration_id text NOT NULL,
+    provider text NOT NULL,
+    owner text NOT NULL,
+    repo text NOT NULL,
+    github_installation_id integer,
+    release_detection_method text NOT NULL DEFAULT 'branch',
+    release_detection_key text NOT NULL DEFAULT 'production',
+    updated_at text NOT NULL,
+    created_at text NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    team_id text,
+    scan_watermark text
+  );
+  CREATE TABLE repository_installation_memberships (
+    repository_id text NOT NULL,
+    installation_id integer NOT NULL,
+    created_at text NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    updated_at text NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    deleted_at text,
+    PRIMARY KEY (repository_id, installation_id)
+  );
+`)
+tenantInit.close()
+
+vi.stubEnv('UPFLOW_DATA_DIR', testDir)
+
+const insertLink = async (
+  installationId: number,
+  opts: {
+    deletedAt?: string | null
+    suspendedAt?: string | null
+    membershipInitializedAt?: string | null
+  } = {},
+) => {
+  await db
+    .insertInto('githubAppLinks')
+    .values({
+      organizationId: ORG_ID,
+      installationId,
+      githubAccountId: installationId,
+      githubOrg: `org-${installationId}`,
+      githubAccountType: 'Organization',
+      appRepositorySelection: 'all',
+      suspendedAt: opts.suspendedAt ?? null,
+      membershipInitializedAt:
+        opts.membershipInitializedAt === undefined
+          ? '2026-04-07T00:00:00Z'
+          : opts.membershipInitializedAt,
+      deletedAt: opts.deletedAt ?? null,
+    })
+    .execute()
+}
+
+const insertMembership = async (
+  installationId: number,
+  opts: { deletedAt?: string | null } = {},
+) => {
+  const { getTenantDb } = await import('~/app/services/tenant-db.server')
+  const tenantDb = getTenantDb(ORG_ID)
+  await tenantDb
+    .insertInto('repositoryInstallationMemberships')
+    .values({
+      repositoryId: REPO_ID,
+      installationId,
+      deletedAt: opts.deletedAt ?? null,
+    })
+    .execute()
+}
+
+const seedRepository = async (canonicalInstallationId: number) => {
+  const { getTenantDb } = await import('~/app/services/tenant-db.server')
+  const tenantDb = getTenantDb(ORG_ID)
+  await tenantDb
+    .insertInto('repositories')
+    .values({
+      id: REPO_ID,
+      integrationId: 'int-1',
+      provider: 'github',
+      owner: 'octo',
+      repo: 'hello',
+      githubInstallationId: canonicalInstallationId,
+      updatedAt: '2026-04-07T00:00:00Z',
+    })
+    .execute()
+}
+
+describe('reassignCanonicalAfterLinkLoss', () => {
+  beforeAll(async () => {
+    // Force initial connection so subsequent stubEnv changes don't matter.
+    await db.selectFrom('githubAppLinks').select('installationId').execute()
+  })
+
+  afterAll(async () => {
+    await closeAllTenantDbs()
+    await closeDb()
+  })
+
+  beforeEach(async () => {
+    await db.deleteFrom('githubAppLinkEvents').execute()
+    await db.deleteFrom('githubAppLinks').execute()
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const tenantDb = getTenantDb(ORG_ID)
+    await tenantDb.deleteFrom('repositoryInstallationMemberships').execute()
+    await tenantDb.deleteFrom('repositories').execute()
+  })
+
+  test('1 eligible candidate → reassign + canonical_reassigned event', async () => {
+    await insertLink(LOST_INSTALLATION, {
+      deletedAt: '2026-04-07T00:00:00Z',
+    })
+    await insertLink(ALT_INSTALLATION)
+    await seedRepository(LOST_INSTALLATION)
+    await insertMembership(LOST_INSTALLATION)
+    await insertMembership(ALT_INSTALLATION)
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_webhook',
+    })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBe(ALT_INSTALLATION)
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .where('installationId', '=', LOST_INSTALLATION)
+      .execute()
+    expect(events).toHaveLength(1)
+    expect(events[0].eventType).toBe('canonical_reassigned')
+  })
+
+  test('0 candidates → null + canonical_cleared event', async () => {
+    await insertLink(LOST_INSTALLATION, {
+      deletedAt: '2026-04-07T00:00:00Z',
+    })
+    await seedRepository(LOST_INSTALLATION)
+    await insertMembership(LOST_INSTALLATION)
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_webhook',
+    })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBeNull()
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events.map((e) => e.eventType)).toEqual(['canonical_cleared'])
+  })
+
+  test('2+ candidates → null + assignment_required event', async () => {
+    await insertLink(LOST_INSTALLATION, {
+      deletedAt: '2026-04-07T00:00:00Z',
+    })
+    await insertLink(ALT_INSTALLATION)
+    await insertLink(SECOND_ALT_INSTALLATION)
+    await seedRepository(LOST_INSTALLATION)
+    await insertMembership(LOST_INSTALLATION)
+    await insertMembership(ALT_INSTALLATION)
+    await insertMembership(SECOND_ALT_INSTALLATION)
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_webhook',
+    })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBeNull()
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events.map((e) => e.eventType)).toEqual(['assignment_required'])
+  })
+
+  test('uninitialized link present + 0 eligible candidates → assignment_required (not cleared)', async () => {
+    await insertLink(LOST_INSTALLATION, {
+      deletedAt: '2026-04-07T00:00:00Z',
+    })
+    await insertLink(ALT_INSTALLATION, { membershipInitializedAt: null })
+    await seedRepository(LOST_INSTALLATION)
+    await insertMembership(LOST_INSTALLATION)
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_webhook',
+    })
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events.map((e) => e.eventType)).toEqual(['assignment_required'])
+  })
+
+  test('suspended link is excluded from eligible candidates', async () => {
+    await insertLink(LOST_INSTALLATION, {
+      deletedAt: '2026-04-07T00:00:00Z',
+    })
+    await insertLink(ALT_INSTALLATION, {
+      suspendedAt: '2026-04-07T00:00:00Z',
+    })
+    await seedRepository(LOST_INSTALLATION)
+    await insertMembership(LOST_INSTALLATION)
+    await insertMembership(ALT_INSTALLATION)
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_webhook',
+    })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBeNull()
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events.map((e) => e.eventType)).toEqual(['canonical_cleared'])
+  })
+
+  test('uninitialized link is excluded from eligible candidates', async () => {
+    await insertLink(LOST_INSTALLATION, {
+      deletedAt: '2026-04-07T00:00:00Z',
+    })
+    await insertLink(ALT_INSTALLATION, { membershipInitializedAt: null })
+    await seedRepository(LOST_INSTALLATION)
+    await insertMembership(LOST_INSTALLATION)
+    await insertMembership(ALT_INSTALLATION)
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_webhook',
+    })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBeNull()
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events.map((e) => e.eventType)).toEqual(['assignment_required'])
+  })
+
+  test('soft-deleted membership is excluded from candidates', async () => {
+    await insertLink(LOST_INSTALLATION, {
+      deletedAt: '2026-04-07T00:00:00Z',
+    })
+    await insertLink(ALT_INSTALLATION)
+    await seedRepository(LOST_INSTALLATION)
+    await insertMembership(LOST_INSTALLATION)
+    await insertMembership(ALT_INSTALLATION, {
+      deletedAt: '2026-04-07T00:00:00Z',
+    })
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_webhook',
+    })
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events.map((e) => e.eventType)).toEqual(['canonical_cleared'])
+  })
+
+  test('idempotent: running twice produces same final state', async () => {
+    await insertLink(LOST_INSTALLATION, {
+      deletedAt: '2026-04-07T00:00:00Z',
+    })
+    await insertLink(ALT_INSTALLATION)
+    await seedRepository(LOST_INSTALLATION)
+    await insertMembership(LOST_INSTALLATION)
+    await insertMembership(ALT_INSTALLATION)
+
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_webhook',
+    })
+    await reassignCanonicalAfterLinkLoss({
+      organizationId: ORG_ID,
+      lostInstallationId: LOST_INSTALLATION,
+      source: 'installation_webhook',
+    })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    // After first run repo points at ALT, second run finds nothing pointing
+    // at LOST so does nothing → still ALT.
+    expect(repo.githubInstallationId).toBe(ALT_INSTALLATION)
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    // Only the first run produces an event; the second run is a no-op.
+    expect(events).toHaveLength(1)
+  })
+})

--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -411,7 +411,6 @@ describe('reassignCanonicalAfterLinkLoss', () => {
     await insertLink(LOST_INSTALLATION)
     await insertLink(ALT_INSTALLATION)
 
-    // Two repos, both canonical = LOST. Only the first is in scope.
     const REPO_KEEP = 'repo-keep'
     const REPO_SCOPED = 'repo-scoped'
     for (const id of [REPO_KEEP, REPO_SCOPED]) {
@@ -427,7 +426,6 @@ describe('reassignCanonicalAfterLinkLoss', () => {
           updatedAt: '2026-04-07T00:00:00Z',
         })
         .execute()
-      // Both repos have ALT as an eligible alternative candidate.
       await tenantDb
         .insertInto('repositoryInstallationMemberships')
         .values({ repositoryId: id, installationId: ALT_INSTALLATION })
@@ -446,8 +444,8 @@ describe('reassignCanonicalAfterLinkLoss', () => {
       .select(['id', 'githubInstallationId'])
       .execute()
     const byId = new Map(rows.map((r) => [r.id, r.githubInstallationId]))
-    // Only the scoped repo is reassigned. The other keeps LOST as canonical
-    // because it still legitimately belongs to that installation.
+    // REPO_KEEP must stay on LOST: it still legitimately belongs to that
+    // installation (not in the scoped removal set).
     expect(byId.get(REPO_SCOPED)).toBe(ALT_INSTALLATION)
     expect(byId.get(REPO_KEEP)).toBe(LOST_INSTALLATION)
 

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -35,12 +35,23 @@ export type ReassignmentSource = Extract<
  * The shared-DB audit log entries are written by this helper after the tenant
  * mutation succeeds.
  */
+/**
+ * Reassigns the canonical installation for tenant repositories when a link
+ * is lost. By default operates on every repository whose canonical is still
+ * `lostInstallationId` (the `installation.deleted` case, where the whole
+ * installation is gone). Pass `repositoryIds` to scope the reassignment to
+ * a specific subset — e.g. `installation_repositories.removed`, where only
+ * a handful of repositories were dropped from the installation while the
+ * rest still belong to it.
+ */
 export async function reassignCanonicalAfterLinkLoss(input: {
   organizationId: OrganizationId
   lostInstallationId: number
   source: ReassignmentSource
+  repositoryIds?: string[]
 }): Promise<void> {
-  const { organizationId, lostInstallationId, source } = input
+  const { organizationId, lostInstallationId, source, repositoryIds } = input
+  if (repositoryIds !== undefined && repositoryIds.length === 0) return
 
   const links = await db
     .selectFrom('githubAppLinks')
@@ -60,7 +71,7 @@ export async function reassignCanonicalAfterLinkLoss(input: {
 
   const tenantDb = getTenantDb(organizationId)
 
-  const rows = await tenantDb
+  let rowsQuery = tenantDb
     .selectFrom('repositories')
     .leftJoin(
       'repositoryInstallationMemberships',
@@ -73,7 +84,10 @@ export async function reassignCanonicalAfterLinkLoss(input: {
       'repositoryInstallationMemberships.deletedAt as membershipDeletedAt',
     ])
     .where('repositories.githubInstallationId', '=', lostInstallationId)
-    .execute()
+  if (repositoryIds !== undefined) {
+    rowsQuery = rowsQuery.where('repositories.id', 'in', repositoryIds)
+  }
+  const rows = await rowsQuery.execute()
 
   if (rows.length === 0) return
 

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -1,0 +1,250 @@
+import { db } from '~/app/services/db.server'
+import type { GithubAppLinkEventSource } from '~/app/services/github-app-link-events.server'
+import { logGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
+import { getTenantDb } from '~/app/services/tenant-db.server'
+import type { OrganizationId } from '~/app/types/organization'
+
+export type ReassignmentSource = Extract<
+  GithubAppLinkEventSource,
+  | 'installation_webhook'
+  | 'installation_repositories_webhook'
+  | 'user_disconnect'
+  | 'cli_repair'
+  | 'manual_reassign'
+>
+
+/**
+ * Replace `repository.github_installation_id` for every repo whose canonical
+ * installation is `lostInstallationId`. Picks the next canonical from the
+ * `repository_installation_memberships` table according to the rules below.
+ *
+ * Eligibility:
+ *   - candidate's link must exist, be active (`deleted_at IS NULL`), not
+ *     suspended, and have `membership_initialized_at` set
+ *   - membership row must be active (`deleted_at IS NULL`)
+ *
+ * Outcomes per repository:
+ *   - 1 eligible candidate → reassign + emit `canonical_reassigned`
+ *   - 0 eligible candidates → null + emit `canonical_cleared` (or
+ *     `assignment_required` if any uninitialized link still exists for the org;
+ *     callers can decide between these in the audit log)
+ *   - 2+ eligible candidates → null + emit `assignment_required`
+ *
+ * Cross-store rule (RDD: tenant first / shared second): tenant repository rows
+ * are updated and tenant memberships are inspected before any shared-DB write.
+ * The shared-DB audit log entries are written by this helper after the tenant
+ * mutation succeeds.
+ */
+export async function reassignCanonicalAfterLinkLoss(input: {
+  organizationId: OrganizationId
+  lostInstallationId: number
+  source: ReassignmentSource
+}): Promise<void> {
+  const { organizationId, lostInstallationId, source } = input
+
+  const links = await db
+    .selectFrom('githubAppLinks')
+    .select(['installationId', 'suspendedAt', 'membershipInitializedAt'])
+    .where('organizationId', '=', organizationId)
+    .where('deletedAt', 'is', null)
+    .where('installationId', '!=', lostInstallationId)
+    .execute()
+  const eligibleSet = new Set(
+    links
+      .filter((l) => !l.suspendedAt && l.membershipInitializedAt !== null)
+      .map((l) => l.installationId),
+  )
+  const hasUninitializedLink = links.some(
+    (l) => l.membershipInitializedAt === null,
+  )
+
+  const tenantDb = getTenantDb(organizationId)
+
+  const rows = await tenantDb
+    .selectFrom('repositories')
+    .leftJoin(
+      'repositoryInstallationMemberships',
+      'repositoryInstallationMemberships.repositoryId',
+      'repositories.id',
+    )
+    .select([
+      'repositories.id as repositoryId',
+      'repositoryInstallationMemberships.installationId as candidateInstallationId',
+      'repositoryInstallationMemberships.deletedAt as membershipDeletedAt',
+    ])
+    .where('repositories.githubInstallationId', '=', lostInstallationId)
+    .execute()
+
+  if (rows.length === 0) return
+
+  const candidatesByRepo = new Map<string, Set<number>>()
+  for (const row of rows) {
+    let bucket = candidatesByRepo.get(row.repositoryId)
+    if (!bucket) {
+      bucket = new Set()
+      candidatesByRepo.set(row.repositoryId, bucket)
+    }
+    if (
+      row.candidateInstallationId !== null &&
+      row.membershipDeletedAt === null &&
+      row.candidateInstallationId !== lostInstallationId &&
+      eligibleSet.has(row.candidateInstallationId)
+    ) {
+      bucket.add(row.candidateInstallationId)
+    }
+  }
+
+  const reassignBuckets = new Map<number | null, string[]>()
+  type Decision = {
+    repositoryId: string
+    nextCanonical: number | null
+    eventType:
+      | 'canonical_reassigned'
+      | 'canonical_cleared'
+      | 'assignment_required'
+    candidateCount: number
+  }
+  const decisions: Decision[] = []
+
+  for (const [repositoryId, bucket] of candidatesByRepo) {
+    const candidates = [...bucket]
+    let nextCanonical: number | null
+    let eventType: Decision['eventType']
+    if (candidates.length === 1) {
+      nextCanonical = candidates[0]
+      eventType = 'canonical_reassigned'
+    } else if (candidates.length === 0) {
+      nextCanonical = null
+      eventType = hasUninitializedLink
+        ? 'assignment_required'
+        : 'canonical_cleared'
+    } else {
+      nextCanonical = null
+      eventType = 'assignment_required'
+    }
+    decisions.push({
+      repositoryId,
+      nextCanonical,
+      eventType,
+      candidateCount: candidates.length,
+    })
+
+    let group = reassignBuckets.get(nextCanonical)
+    if (!group) {
+      group = []
+      reassignBuckets.set(nextCanonical, group)
+    }
+    group.push(repositoryId)
+  }
+
+  for (const [nextCanonical, repositoryIds] of reassignBuckets) {
+    await tenantDb
+      .updateTable('repositories')
+      .set({ githubInstallationId: nextCanonical })
+      .where('id', 'in', repositoryIds)
+      .execute()
+  }
+
+  for (const decision of decisions) {
+    await logGithubAppLinkEvent({
+      organizationId,
+      installationId: lostInstallationId,
+      eventType: decision.eventType,
+      source,
+      status: 'success',
+      details: {
+        repositoryId: decision.repositoryId,
+        nextCanonical: decision.nextCanonical,
+        candidateCount: decision.candidateCount,
+      },
+    })
+  }
+}
+
+export async function softDeleteRepositoryMembership(input: {
+  organizationId: OrganizationId
+  installationId: number
+  repositoryId: string
+}): Promise<void> {
+  const tenantDb = getTenantDb(input.organizationId)
+  const now = new Date().toISOString()
+  await tenantDb
+    .updateTable('repositoryInstallationMemberships')
+    .set({ deletedAt: now, updatedAt: now })
+    .where('repositoryId', '=', input.repositoryId)
+    .where('installationId', '=', input.installationId)
+    .where('deletedAt', 'is', null)
+    .execute()
+}
+
+export async function upsertRepositoryMembership(input: {
+  organizationId: OrganizationId
+  installationId: number
+  repositoryId: string
+}): Promise<void> {
+  const tenantDb = getTenantDb(input.organizationId)
+  const now = new Date().toISOString()
+  await tenantDb
+    .insertInto('repositoryInstallationMemberships')
+    .values({
+      repositoryId: input.repositoryId,
+      installationId: input.installationId,
+    })
+    .onConflict((oc) =>
+      oc.columns(['repositoryId', 'installationId']).doUpdateSet({
+        deletedAt: null,
+        updatedAt: now,
+      }),
+    )
+    .execute()
+}
+
+/**
+ * Initialize `repository_installation_memberships` for an installation by
+ * matching the given `(owner, repo)` pairs against existing tenant repositories.
+ *
+ * Returns the list of repository ids whose membership rows were upserted.
+ * Repositories that don't exist in the tenant DB are skipped silently
+ * (they may be added later via the repositories.add UI).
+ */
+export async function initializeMembershipsForInstallation(input: {
+  organizationId: OrganizationId
+  installationId: number
+  repositories: Array<{ owner: string; name: string }>
+}): Promise<string[]> {
+  if (input.repositories.length === 0) return []
+
+  const tenantDb = getTenantDb(input.organizationId)
+  const matched = await tenantDb
+    .selectFrom('repositories')
+    .select(['id', 'owner', 'repo'])
+    .where((eb) =>
+      eb.or(
+        input.repositories.map((r) =>
+          eb.and([eb('owner', '=', r.owner), eb('repo', '=', r.name)]),
+        ),
+      ),
+    )
+    .execute()
+
+  if (matched.length === 0) return []
+
+  const now = new Date().toISOString()
+  await tenantDb
+    .insertInto('repositoryInstallationMemberships')
+    .values(
+      matched.map((repo) => ({
+        repositoryId: repo.id,
+        installationId: input.installationId,
+      })),
+    )
+    .onConflict((oc) =>
+      oc.columns(['repositoryId', 'installationId']).doUpdateSet({
+        deletedAt: null,
+        updatedAt: now,
+      }),
+    )
+    .execute()
+
+  return matched.map((r) => r.id)
+}

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -1,6 +1,6 @@
 import { db } from '~/app/services/db.server'
 import type { GithubAppLinkEventSource } from '~/app/services/github-app-link-events.server'
-import { logGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
+import { tryLogGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
 import { getTenantDb } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
@@ -146,7 +146,7 @@ export async function reassignCanonicalAfterLinkLoss(input: {
   }
 
   for (const decision of decisions) {
-    await logGithubAppLinkEvent({
+    await tryLogGithubAppLinkEvent({
       organizationId,
       installationId: lostInstallationId,
       eventType: decision.eventType,

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -14,9 +14,13 @@ export type ReassignmentSource = Extract<
 >
 
 /**
- * Replace `repository.github_installation_id` for every repo whose canonical
- * installation is `lostInstallationId`. Picks the next canonical from the
- * `repository_installation_memberships` table according to the rules below.
+ * Replace `repository.github_installation_id` when a link is lost. By default
+ * operates on every repository whose canonical is still `lostInstallationId`
+ * (the `installation.deleted` case). Pass `repositoryIds` to scope to a
+ * specific subset (e.g. `installation_repositories.removed`, where only a
+ * handful of repositories were dropped while the rest still belong to it).
+ *
+ * Next canonical is picked from `repository_installation_memberships`.
  *
  * Eligibility:
  *   - candidate's link must exist, be active (`deleted_at IS NULL`), not
@@ -26,23 +30,13 @@ export type ReassignmentSource = Extract<
  * Outcomes per repository:
  *   - 1 eligible candidate → reassign + emit `canonical_reassigned`
  *   - 0 eligible candidates → null + emit `canonical_cleared` (or
- *     `assignment_required` if any uninitialized link still exists for the org;
- *     callers can decide between these in the audit log)
+ *     `assignment_required` if any uninitialized link still exists for the org)
  *   - 2+ eligible candidates → null + emit `assignment_required`
  *
  * Cross-store rule (RDD: tenant first / shared second): tenant repository rows
  * are updated and tenant memberships are inspected before any shared-DB write.
- * The shared-DB audit log entries are written by this helper after the tenant
+ * The shared-DB audit log entries are written best-effort after the tenant
  * mutation succeeds.
- */
-/**
- * Reassigns the canonical installation for tenant repositories when a link
- * is lost. By default operates on every repository whose canonical is still
- * `lostInstallationId` (the `installation.deleted` case, where the whole
- * installation is gone). Pass `repositoryIds` to scope the reassignment to
- * a specific subset — e.g. `installation_repositories.removed`, where only
- * a handful of repositories were dropped from the installation while the
- * rest still belong to it.
  */
 export async function reassignCanonicalAfterLinkLoss(input: {
   organizationId: OrganizationId
@@ -51,7 +45,6 @@ export async function reassignCanonicalAfterLinkLoss(input: {
   repositoryIds?: string[]
 }): Promise<void> {
   const { organizationId, lostInstallationId, source, repositoryIds } = input
-  if (repositoryIds !== undefined && repositoryIds.length === 0) return
 
   const links = await db
     .selectFrom('githubAppLinks')

--- a/app/services/github-installation-repos.server.ts
+++ b/app/services/github-installation-repos.server.ts
@@ -1,0 +1,27 @@
+import { resolveOctokitForInstallation } from '~/app/services/github-octokit.server'
+
+export type InstallationRepoCoord = { owner: string; name: string }
+
+/**
+ * Fetch every repository visible to a GitHub App installation, paginating
+ * through `GET /installation/repositories`. Returns owner/name coordinates only.
+ */
+export async function fetchInstallationRepositories(
+  installationId: number,
+): Promise<InstallationRepoCoord[]> {
+  const octokit = resolveOctokitForInstallation(installationId)
+
+  const repos: InstallationRepoCoord[] = []
+  for await (const response of octokit.paginate.iterator(
+    octokit.rest.apps.listReposAccessibleToInstallation,
+    { per_page: 100 },
+  )) {
+    for (const repo of response.data) {
+      if (typeof repo.name !== 'string') continue
+      const ownerLogin = repo.owner?.login
+      if (typeof ownerLogin !== 'string') continue
+      repos.push({ owner: ownerLogin, name: repo.name })
+    }
+  }
+  return repos
+}

--- a/app/services/github-webhook-installation.server.ts
+++ b/app/services/github-webhook-installation.server.ts
@@ -343,13 +343,14 @@ export async function runInstallationWebhookInTransaction(
       return await handleInstallationRepositoriesEvent(trx, payload)
     })
   if (pending) {
+    const orgId = pending.organizationId as OrganizationId
     const { removedRepositoryIds } = await applyMembershipChangesAfterCommit(
-      pending.organizationId,
+      orgId,
       pending.installationId,
       { added: pending.added, removed: pending.removed },
     )
     await tryLogGithubAppLinkEvent({
-      organizationId: pending.organizationId as OrganizationId,
+      organizationId: orgId,
       installationId: pending.installationId,
       eventType: 'membership_repaired',
       source: 'installation_repositories_webhook',
@@ -357,7 +358,7 @@ export async function runInstallationWebhookInTransaction(
     })
     if (removedRepositoryIds.length > 0) {
       await reassignCanonicalAfterLinkLoss({
-        organizationId: pending.organizationId as OrganizationId,
+        organizationId: orgId,
         lostInstallationId: pending.installationId,
         source: 'installation_repositories_webhook',
         repositoryIds: removedRepositoryIds,

--- a/app/services/github-webhook-installation.server.ts
+++ b/app/services/github-webhook-installation.server.ts
@@ -1,7 +1,10 @@
 import createDebug from 'debug'
 import type { Kysely } from 'kysely'
 import { db, type DB } from '~/app/services/db.server'
-import { logGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
+import {
+  logGithubAppLinkEvent,
+  tryLogGithubAppLinkEvent,
+} from '~/app/services/github-app-link-events.server'
 import {
   reassignCanonicalAfterLinkLoss,
   softDeleteRepositoryMembership,
@@ -341,7 +344,7 @@ export async function runInstallationWebhookInTransaction(
       pending.installationId,
       { added: pending.added, removed: pending.removed },
     )
-    await logGithubAppLinkEvent({
+    await tryLogGithubAppLinkEvent({
       organizationId: pending.organizationId as OrganizationId,
       installationId: pending.installationId,
       eventType: 'membership_repaired',

--- a/app/services/github-webhook-installation.server.ts
+++ b/app/services/github-webhook-installation.server.ts
@@ -190,17 +190,6 @@ async function handleInstallationRepositoriesEvent(
     .where('installationId', '=', installation.id)
     .execute()
 
-  await logGithubAppLinkEvent(
-    {
-      organizationId: link.organizationId as OrganizationId,
-      installationId: installation.id,
-      eventType: 'membership_repaired',
-      source: 'installation_repositories_webhook',
-      status: 'success',
-    },
-    trx,
-  )
-
   const { added, removed } = readRepositoryCoords(payload)
   return {
     organizationId: link.organizationId,
@@ -352,6 +341,13 @@ export async function runInstallationWebhookInTransaction(
       pending.installationId,
       { added: pending.added, removed: pending.removed },
     )
+    await logGithubAppLinkEvent({
+      organizationId: pending.organizationId as OrganizationId,
+      installationId: pending.installationId,
+      eventType: 'membership_repaired',
+      source: 'installation_repositories_webhook',
+      status: 'success',
+    })
     if (pending.removed.length > 0) {
       await reassignCanonicalAfterLinkLoss({
         organizationId: pending.organizationId as OrganizationId,

--- a/app/services/github-webhook-installation.server.ts
+++ b/app/services/github-webhook-installation.server.ts
@@ -1,66 +1,79 @@
 import createDebug from 'debug'
 import type { Kysely } from 'kysely'
 import { db, type DB } from '~/app/services/db.server'
+import { logGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
+import {
+  reassignCanonicalAfterLinkLoss,
+  softDeleteRepositoryMembership,
+  upsertRepositoryMembership,
+} from '~/app/services/github-app-membership.server'
 import {
   findActiveLinkByInstallation,
+  isRecord,
   readInstallation,
   selectionFromInstallation,
   type InstallationLike,
 } from '~/app/services/github-webhook-shared.server'
+import { getTenantDb } from '~/app/services/tenant-db.server'
+import type { OrganizationId } from '~/app/types/organization'
 
 const debug = createDebug('app:github-webhook:installation')
 
-async function findActiveLinkByInstallationOrAccount(
-  trx: Kysely<DB.DB>,
-  installationId: number,
-  githubAccountId: number,
-) {
-  return await trx
-    .selectFrom('githubAppLinks')
-    .selectAll()
-    .where('deletedAt', 'is', null)
-    .where((eb) =>
-      eb.or([
-        eb('installationId', '=', installationId),
-        eb('githubAccountId', '=', githubAccountId),
-      ]),
-    )
-    .executeTakeFirst()
+type RepoCoord = { owner: string; name: string }
+
+function readRepositoryCoords(payload: Record<string, unknown>): {
+  added: RepoCoord[]
+  removed: RepoCoord[]
+} {
+  const collect = (key: string): RepoCoord[] => {
+    const list = payload[key]
+    if (!Array.isArray(list)) return []
+    const out: RepoCoord[] = []
+    for (const item of list) {
+      if (!isRecord(item)) continue
+      const fullName =
+        typeof item.full_name === 'string' ? item.full_name : null
+      if (!fullName) continue
+      const [owner, name] = fullName.split('/')
+      if (!owner || !name) continue
+      out.push({ owner, name })
+    }
+    return out
+  }
+  return {
+    added: collect('repositories_added'),
+    removed: collect('repositories_removed'),
+  }
 }
 
 async function handleInstallationCreated(
   trx: Kysely<DB.DB>,
   installation: InstallationLike,
 ): Promise<string | null> {
-  const accountId = installation.account?.id
-  if (accountId === undefined) return null
-
-  const link = await findActiveLinkByInstallationOrAccount(
-    trx,
-    installation.id,
-    accountId,
-  )
+  // Setup callback (api.github.setup) is the canonical entry for new links;
+  // this webhook only mirrors metadata onto an already-known row.
+  const link = await findActiveLinkByInstallation(trx, installation.id)
   if (!link) {
     debug(
-      'installation.created: no github_app_links row for installation_id=%s account_id=%s',
+      'installation.created: no github_app_links row for installation_id=%s',
       installation.id,
-      accountId,
     )
     return null
   }
 
   const login = installation.account?.login ?? link.githubOrg
+  const accountType = installation.account?.type ?? link.githubAccountType
   const now = new Date().toISOString()
   await trx
     .updateTable('githubAppLinks')
     .set({
-      installationId: installation.id,
-      githubAccountId: accountId,
       githubOrg: login,
+      githubAccountType: accountType,
       appRepositorySelection: selectionFromInstallation(installation),
       updatedAt: now,
     })
     .where('organizationId', '=', link.organizationId)
+    .where('installationId', '=', installation.id)
     .execute()
 
   return link.organizationId
@@ -69,7 +82,7 @@ async function handleInstallationCreated(
 async function handleInstallationDeleted(
   trx: Kysely<DB.DB>,
   installation: InstallationLike,
-): Promise<string | null> {
+): Promise<{ organizationId: string; installationId: number } | null> {
   const link = await findActiveLinkByInstallation(trx, installation.id)
   if (!link) return null
 
@@ -78,9 +91,42 @@ async function handleInstallationDeleted(
     .updateTable('githubAppLinks')
     .set({ deletedAt: now, updatedAt: now })
     .where('organizationId', '=', link.organizationId)
+    .where('installationId', '=', installation.id)
     .execute()
 
-  return link.organizationId
+  // Determine if this was the last active link for the org → revert method.
+  const remaining = await trx
+    .selectFrom('githubAppLinks')
+    .select('installationId')
+    .where('organizationId', '=', link.organizationId)
+    .where('deletedAt', 'is', null)
+    .executeTakeFirst()
+
+  const revertedToToken = !remaining
+  if (revertedToToken) {
+    await trx
+      .updateTable('integrations')
+      .set({ method: 'token', appSuspendedAt: null, updatedAt: now })
+      .where('organizationId', '=', link.organizationId)
+      .execute()
+  }
+
+  await logGithubAppLinkEvent(
+    {
+      organizationId: link.organizationId as OrganizationId,
+      installationId: installation.id,
+      eventType: 'link_deleted',
+      source: 'installation_webhook',
+      status: 'success',
+      details: { revertedToToken },
+    },
+    trx,
+  )
+
+  return {
+    organizationId: link.organizationId,
+    installationId: installation.id,
+  }
 }
 
 async function handleInstallationSuspend(
@@ -93,21 +139,40 @@ async function handleInstallationSuspend(
 
   const now = new Date().toISOString()
   await trx
-    .updateTable('integrations')
+    .updateTable('githubAppLinks')
     .set({
-      appSuspendedAt: suspend ? now : null,
+      suspendedAt: suspend ? now : null,
       updatedAt: now,
     })
     .where('organizationId', '=', link.organizationId)
+    .where('installationId', '=', installation.id)
     .execute()
+
+  await logGithubAppLinkEvent(
+    {
+      organizationId: link.organizationId as OrganizationId,
+      installationId: installation.id,
+      eventType: suspend ? 'link_suspended' : 'link_unsuspended',
+      source: 'installation_webhook',
+      status: 'success',
+    },
+    trx,
+  )
 
   return link.organizationId
 }
 
-async function handleInstallationRepositories(
+type InstallRepositoriesUpdate = {
+  organizationId: string
+  installationId: number
+  added: RepoCoord[]
+  removed: RepoCoord[]
+}
+
+async function handleInstallationRepositoriesEvent(
   trx: Kysely<DB.DB>,
   payload: Record<string, unknown>,
-): Promise<string | null> {
+): Promise<InstallRepositoriesUpdate | null> {
   const installation = readInstallation(payload)
   if (!installation) return null
 
@@ -122,43 +187,178 @@ async function handleInstallationRepositories(
       updatedAt: now,
     })
     .where('organizationId', '=', link.organizationId)
+    .where('installationId', '=', installation.id)
     .execute()
 
-  return link.organizationId
+  await logGithubAppLinkEvent(
+    {
+      organizationId: link.organizationId as OrganizationId,
+      installationId: installation.id,
+      eventType: 'membership_repaired',
+      source: 'installation_repositories_webhook',
+      status: 'success',
+    },
+    trx,
+  )
+
+  const { added, removed } = readRepositoryCoords(payload)
+  return {
+    organizationId: link.organizationId,
+    installationId: installation.id,
+    added,
+    removed,
+  }
+}
+
+async function resolveRepositoryIdsByCoords(
+  organizationId: OrganizationId,
+  coords: RepoCoord[],
+): Promise<Map<string, string>> {
+  if (coords.length === 0) return new Map()
+  const tenantDb = getTenantDb(organizationId)
+  const rows = await tenantDb
+    .selectFrom('repositories')
+    .select(['id', 'owner', 'repo'])
+    .where((eb) =>
+      eb.or(
+        coords.map((c) =>
+          eb.and([eb('owner', '=', c.owner), eb('repo', '=', c.name)]),
+        ),
+      ),
+    )
+    .execute()
+  return new Map(rows.map((r) => [`${r.owner}/${r.repo}`, r.id]))
+}
+
+async function applyMembershipChangesAfterCommit(
+  organizationId: string,
+  installationId: number,
+  changes: { added: RepoCoord[]; removed: RepoCoord[] },
+): Promise<void> {
+  const orgId = organizationId as OrganizationId
+  const idByCoord = await resolveRepositoryIdsByCoords(orgId, [
+    ...changes.added,
+    ...changes.removed,
+  ])
+
+  for (const repo of changes.added) {
+    const repositoryId = idByCoord.get(`${repo.owner}/${repo.name}`)
+    if (!repositoryId) continue
+    await upsertRepositoryMembership({
+      organizationId: orgId,
+      installationId,
+      repositoryId,
+    })
+  }
+
+  for (const repo of changes.removed) {
+    const repositoryId = idByCoord.get(`${repo.owner}/${repo.name}`)
+    if (!repositoryId) continue
+    await softDeleteRepositoryMembership({
+      organizationId: orgId,
+      installationId,
+      repositoryId,
+    })
+  }
 }
 
 async function handleInstallationEvent(
   trx: Kysely<DB.DB>,
   payload: Record<string, unknown>,
-): Promise<string | null> {
+): Promise<{
+  organizationId: string | null
+  deletedInstallationId: number | null
+}> {
   const action = payload.action
-  if (typeof action !== 'string') return null
+  if (typeof action !== 'string') {
+    return { organizationId: null, deletedInstallationId: null }
+  }
 
   const installation = readInstallation(payload)
-  if (!installation) return null
+  if (!installation) {
+    return { organizationId: null, deletedInstallationId: null }
+  }
 
   switch (action) {
-    case 'created':
-      return await handleInstallationCreated(trx, installation)
-    case 'deleted':
-      return await handleInstallationDeleted(trx, installation)
+    case 'created': {
+      const orgId = await handleInstallationCreated(trx, installation)
+      return { organizationId: orgId, deletedInstallationId: null }
+    }
+    case 'deleted': {
+      const result = await handleInstallationDeleted(trx, installation)
+      if (!result) return { organizationId: null, deletedInstallationId: null }
+      return {
+        organizationId: result.organizationId,
+        deletedInstallationId: result.installationId,
+      }
+    }
     case 'suspend':
-      return await handleInstallationSuspend(trx, installation, true)
+      return {
+        organizationId: await handleInstallationSuspend(
+          trx,
+          installation,
+          true,
+        ),
+        deletedInstallationId: null,
+      }
     case 'unsuspend':
-      return await handleInstallationSuspend(trx, installation, false)
+      return {
+        organizationId: await handleInstallationSuspend(
+          trx,
+          installation,
+          false,
+        ),
+        deletedInstallationId: null,
+      }
     default:
-      return null
+      return { organizationId: null, deletedInstallationId: null }
   }
+}
+
+export type WebhookProcessResult = {
+  organizationId: string | null
 }
 
 export async function runInstallationWebhookInTransaction(
   event: 'installation' | 'installation_repositories',
   payload: Record<string, unknown>,
-): Promise<string | null> {
-  return await db.transaction().execute(async (trx) => {
-    if (event === 'installation') {
-      return await handleInstallationEvent(trx, payload)
+): Promise<WebhookProcessResult> {
+  if (event === 'installation') {
+    let deletedInstallationId: number | null = null
+    let organizationId: string | null = null
+    await db.transaction().execute(async (trx) => {
+      const result = await handleInstallationEvent(trx, payload)
+      organizationId = result.organizationId
+      deletedInstallationId = result.deletedInstallationId
+    })
+    if (organizationId && deletedInstallationId !== null) {
+      await reassignCanonicalAfterLinkLoss({
+        organizationId: organizationId as OrganizationId,
+        lostInstallationId: deletedInstallationId,
+        source: 'installation_webhook',
+      })
     }
-    return await handleInstallationRepositories(trx, payload)
-  })
+    return { organizationId }
+  }
+
+  const pending: InstallRepositoriesUpdate | null = await db
+    .transaction()
+    .execute(async (trx) => {
+      return await handleInstallationRepositoriesEvent(trx, payload)
+    })
+  if (pending) {
+    await applyMembershipChangesAfterCommit(
+      pending.organizationId,
+      pending.installationId,
+      { added: pending.added, removed: pending.removed },
+    )
+    if (pending.removed.length > 0) {
+      await reassignCanonicalAfterLinkLoss({
+        organizationId: pending.organizationId as OrganizationId,
+        lostInstallationId: pending.installationId,
+        source: 'installation_repositories_webhook',
+      })
+    }
+  }
+  return { organizationId: pending?.organizationId ?? null }
 }

--- a/app/services/github-webhook-installation.server.ts
+++ b/app/services/github-webhook-installation.server.ts
@@ -352,7 +352,7 @@ export async function runInstallationWebhookInTransaction(
     await tryLogGithubAppLinkEvent({
       organizationId: orgId,
       installationId: pending.installationId,
-      eventType: 'membership_repaired',
+      eventType: 'membership_synced',
       source: 'installation_repositories_webhook',
       status: 'success',
     })

--- a/app/services/github-webhook-installation.server.ts
+++ b/app/services/github-webhook-installation.server.ts
@@ -226,7 +226,7 @@ async function applyMembershipChangesAfterCommit(
   organizationId: string,
   installationId: number,
   changes: { added: RepoCoord[]; removed: RepoCoord[] },
-): Promise<void> {
+): Promise<{ removedRepositoryIds: string[] }> {
   const orgId = organizationId as OrganizationId
   const idByCoord = await resolveRepositoryIdsByCoords(orgId, [
     ...changes.added,
@@ -243,6 +243,7 @@ async function applyMembershipChangesAfterCommit(
     })
   }
 
+  const removedRepositoryIds: string[] = []
   for (const repo of changes.removed) {
     const repositoryId = idByCoord.get(`${repo.owner}/${repo.name}`)
     if (!repositoryId) continue
@@ -251,7 +252,10 @@ async function applyMembershipChangesAfterCommit(
       installationId,
       repositoryId,
     })
+    removedRepositoryIds.push(repositoryId)
   }
+
+  return { removedRepositoryIds }
 }
 
 async function handleInstallationEvent(
@@ -339,7 +343,7 @@ export async function runInstallationWebhookInTransaction(
       return await handleInstallationRepositoriesEvent(trx, payload)
     })
   if (pending) {
-    await applyMembershipChangesAfterCommit(
+    const { removedRepositoryIds } = await applyMembershipChangesAfterCommit(
       pending.organizationId,
       pending.installationId,
       { added: pending.added, removed: pending.removed },
@@ -351,11 +355,12 @@ export async function runInstallationWebhookInTransaction(
       source: 'installation_repositories_webhook',
       status: 'success',
     })
-    if (pending.removed.length > 0) {
+    if (removedRepositoryIds.length > 0) {
       await reassignCanonicalAfterLinkLoss({
         organizationId: pending.organizationId as OrganizationId,
         lostInstallationId: pending.installationId,
         source: 'installation_repositories_webhook',
+        repositoryIds: removedRepositoryIds,
       })
     }
   }

--- a/app/services/github-webhook-pull.server.ts
+++ b/app/services/github-webhook-pull.server.ts
@@ -50,11 +50,20 @@ export async function handlePullWebhookEvent(
   if (prNumber === null) return
 
   const tenantDb = getTenantDb(orgId)
+  // Match by `(owner, repo)` *and* the installation that delivered the
+  // webhook. `github_installation_id IS NULL` is still accepted while
+  // existing rows are unbackfilled; the strict variant drops the OR clause.
   const repo = await tenantDb
     .selectFrom('repositories')
     .select('id')
     .where('owner', '=', coords.owner)
     .where('repo', '=', coords.name)
+    .where((eb) =>
+      eb.or([
+        eb('githubInstallationId', '=', installation.id),
+        eb('githubInstallationId', 'is', null),
+      ]),
+    )
     .executeTakeFirst()
   if (!repo) return
 

--- a/app/services/github-webhook-shared.server.ts
+++ b/app/services/github-webhook-shared.server.ts
@@ -4,7 +4,7 @@ export function isRecord(x: unknown): x is Record<string, unknown> {
 
 export type InstallationLike = {
   id: number
-  account?: { id: number; login?: string }
+  account?: { id: number; login?: string; type?: string }
   repository_selection?: string
 }
 
@@ -14,11 +14,12 @@ export function readInstallation(
   const inst = payload.installation
   if (!isRecord(inst) || typeof inst.id !== 'number') return null
   const acc = inst.account
-  let account: { id: number; login?: string } | undefined
+  let account: { id: number; login?: string; type?: string } | undefined
   if (isRecord(acc) && typeof acc.id === 'number') {
     account = {
       id: acc.id,
       login: typeof acc.login === 'string' ? acc.login : undefined,
+      type: typeof acc.type === 'string' ? acc.type : undefined,
     }
   }
   const repository_selection =

--- a/app/services/github-webhook.server.test.ts
+++ b/app/services/github-webhook.server.test.ts
@@ -276,7 +276,7 @@ describe('processGithubWebhookPayload', () => {
     expect(row.suspendedAt).toBeNull()
   })
 
-  test('installation_repositories updates selection', async () => {
+  test('installation_repositories updates selection and emits membership_synced', async () => {
     await processGithubWebhookPayload('installation_repositories', {
       installation: {
         id: 42,
@@ -291,6 +291,19 @@ describe('processGithubWebhookPayload', () => {
       .executeTakeFirstOrThrow()
 
     expect(row.appRepositorySelection).toBe('selected')
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .select(['eventType', 'source'])
+      .where('organizationId', '=', 'o1')
+      .where('installationId', '=', 42)
+      .execute()
+    expect(events).toEqual([
+      {
+        eventType: 'membership_synced',
+        source: 'installation_repositories_webhook',
+      },
+    ])
   })
 
   test('ping event is ignored', async () => {

--- a/app/services/github-webhook.server.test.ts
+++ b/app/services/github-webhook.server.test.ts
@@ -179,7 +179,10 @@ describe('processGithubWebhookPayload', () => {
         deletedAt: null,
       })
       .execute()
-    await db.deleteFrom('githubAppLinkEvents').execute()
+    await db
+      .deleteFrom('githubAppLinkEvents')
+      .where('organizationId', '=', 'o1')
+      .execute()
     mockTenantSelectFrom.mockClear()
     mockTenantUpdateTable.mockClear()
   })
@@ -255,6 +258,7 @@ describe('processGithubWebhookPayload', () => {
     await db
       .updateTable('githubAppLinks')
       .set({ suspendedAt: '2026-01-01T00:00:00Z' })
+      .where('organizationId', '=', 'o1')
       .where('installationId', '=', 42)
       .execute()
 

--- a/app/services/github-webhook.server.test.ts
+++ b/app/services/github-webhook.server.test.ts
@@ -16,17 +16,38 @@ import { closeDb, db } from '~/app/services/db.server'
 import { processGithubWebhookPayload } from './github-webhook.server'
 
 const mockTenantRepoLookup = vi.fn()
+
+type Chain = {
+  select: (..._args: unknown[]) => Chain
+  where: (..._args: unknown[]) => Chain
+  leftJoin: (..._args: unknown[]) => Chain
+  executeTakeFirst: () => Promise<unknown>
+  execute: () => Promise<unknown[]>
+  set: (..._args: unknown[]) => Chain
+  values: (..._args: unknown[]) => Chain
+  onConflict: (..._args: unknown[]) => Chain
+}
+const makeChain = (): Chain => {
+  const chain: Chain = {
+    select: () => chain,
+    where: () => chain,
+    leftJoin: () => chain,
+    executeTakeFirst: () => Promise.resolve(mockTenantRepoLookup()),
+    execute: () => Promise.resolve([]),
+    set: () => chain,
+    values: () => chain,
+    onConflict: () => chain,
+  }
+  return chain
+}
+const mockTenantSelectFrom = vi.fn(() => makeChain())
+const mockTenantUpdateTable = vi.fn(() => makeChain())
+const mockTenantInsertInto = vi.fn(() => makeChain())
 vi.mock('~/app/services/tenant-db.server', () => ({
   getTenantDb: vi.fn(() => ({
-    selectFrom: () => ({
-      select: () => ({
-        where: () => ({
-          where: () => ({
-            executeTakeFirst: () => mockTenantRepoLookup(),
-          }),
-        }),
-      }),
-    }),
+    selectFrom: mockTenantSelectFrom,
+    updateTable: mockTenantUpdateTable,
+    insertInto: mockTenantInsertInto,
   })),
 }))
 
@@ -71,20 +92,34 @@ rawInit.exec(`
   );
   CREATE UNIQUE INDEX integrations_organization_id_key ON integrations (organization_id);
   CREATE TABLE github_app_links (
-    organization_id text NOT NULL PRIMARY KEY,
+    organization_id text NOT NULL,
     installation_id integer NOT NULL,
     github_account_id integer NOT NULL,
+    github_account_type text,
     github_org text NOT NULL,
     app_repository_selection text NOT NULL DEFAULT 'all',
+    suspended_at text,
+    membership_initialized_at text,
     deleted_at text,
     created_at text NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
     updated_at text NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now')),
+    PRIMARY KEY (organization_id, installation_id),
     CONSTRAINT github_app_links_organization_id_fkey
       FOREIGN KEY (organization_id) REFERENCES organizations(id)
       ON UPDATE CASCADE ON DELETE CASCADE
   );
   CREATE UNIQUE INDEX github_app_links_installation_id_key ON github_app_links (installation_id);
-  CREATE UNIQUE INDEX github_app_links_github_account_id_key ON github_app_links (github_account_id);
+  CREATE INDEX github_app_links_github_account_id_idx ON github_app_links (github_account_id);
+  CREATE TABLE github_app_link_events (
+    id integer NOT NULL PRIMARY KEY AUTOINCREMENT,
+    organization_id text NOT NULL,
+    installation_id integer NOT NULL,
+    event_type text NOT NULL,
+    source text NOT NULL,
+    status text NOT NULL,
+    details_json text,
+    created_at text NOT NULL DEFAULT (strftime('%Y-%m-%dT%H:%M:%SZ', 'now'))
+  );
 `)
 rawInit.close()
 
@@ -136,11 +171,17 @@ describe('processGithubWebhookPayload', () => {
         organizationId: 'o1',
         installationId: 42,
         githubAccountId: 99,
+        githubAccountType: 'Organization',
         githubOrg: 'old-login',
         appRepositorySelection: 'all',
+        suspendedAt: null,
+        membershipInitializedAt: '2026-04-07T00:00:00Z',
         deletedAt: null,
       })
       .execute()
+    await db.deleteFrom('githubAppLinkEvents').execute()
+    mockTenantSelectFrom.mockClear()
+    mockTenantUpdateTable.mockClear()
   })
 
   test('installation.created updates link when matched', async () => {
@@ -194,27 +235,27 @@ describe('processGithubWebhookPayload', () => {
     expect(clearSpy).toHaveBeenCalledWith('o1')
   })
 
-  test('installation.suspend sets appSuspendedAt', async () => {
+  test('installation.suspend sets suspendedAt on the link', async () => {
     await processGithubWebhookPayload('installation', {
       action: 'suspend',
       installation: { id: 42 },
     })
 
     const row = await db
-      .selectFrom('integrations')
-      .select('appSuspendedAt')
-      .where('organizationId', '=', 'o1')
+      .selectFrom('githubAppLinks')
+      .select('suspendedAt')
+      .where('installationId', '=', 42)
       .executeTakeFirstOrThrow()
 
-    expect(row.appSuspendedAt).not.toBeNull()
+    expect(row.suspendedAt).not.toBeNull()
     expect(clearSpy).toHaveBeenCalledWith('o1')
   })
 
-  test('installation.unsuspend clears appSuspendedAt', async () => {
+  test('installation.unsuspend clears suspendedAt on the link', async () => {
     await db
-      .updateTable('integrations')
-      .set({ appSuspendedAt: '2026-01-01T00:00:00Z' })
-      .where('organizationId', '=', 'o1')
+      .updateTable('githubAppLinks')
+      .set({ suspendedAt: '2026-01-01T00:00:00Z' })
+      .where('installationId', '=', 42)
       .execute()
 
     await processGithubWebhookPayload('installation', {
@@ -223,12 +264,12 @@ describe('processGithubWebhookPayload', () => {
     })
 
     const row = await db
-      .selectFrom('integrations')
-      .select('appSuspendedAt')
-      .where('organizationId', '=', 'o1')
+      .selectFrom('githubAppLinks')
+      .select('suspendedAt')
+      .where('installationId', '=', 42)
       .executeTakeFirstOrThrow()
 
-    expect(row.appSuspendedAt).toBeNull()
+    expect(row.suspendedAt).toBeNull()
   })
 
   test('installation_repositories updates selection', async () => {

--- a/app/services/github-webhook.server.ts
+++ b/app/services/github-webhook.server.ts
@@ -14,8 +14,8 @@ export async function processGithubWebhookPayload(
   if (!event || !isRecord(payload)) return
 
   if (event === 'installation' || event === 'installation_repositories') {
-    const orgToClear = await runInstallationWebhookInTransaction(event, payload)
-    if (orgToClear) clearOrgCache(orgToClear)
+    const result = await runInstallationWebhookInTransaction(event, payload)
+    if (result.organizationId) clearOrgCache(result.organizationId)
     return
   }
 

--- a/app/services/jobs/crawl.server.ts
+++ b/app/services/jobs/crawl.server.ts
@@ -1,7 +1,14 @@
 import { defineJob } from '@coji/durably'
 import { z } from 'zod'
-import { getErrorMessageForLog } from '~/app/libs/error-message'
+import {
+  getErrorMessage,
+  getErrorMessageForLog,
+} from '~/app/libs/error-message'
 import { clearOrgCache } from '~/app/services/cache.server'
+import { db } from '~/app/services/db.server'
+import { tryLogGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
+import { initializeMembershipsForInstallation } from '~/app/services/github-app-membership.server'
+import { fetchInstallationRepositories } from '~/app/services/github-installation-repos.server'
 import { resolveOctokitForRepository } from '~/app/services/github-octokit.server'
 import { processConcurrencyKey } from '~/app/services/jobs/concurrency-keys.server'
 import { shouldTriggerFullOrgProcessJob } from '~/app/services/jobs/crawl-process-handoff.server'
@@ -13,6 +20,43 @@ import {
 } from '~/batch/github/fetcher'
 import { createStore } from '~/batch/github/store'
 import { computeAdvancedScanWatermark } from './scan-watermark'
+
+async function repairMembershipForLink(
+  organizationId: OrganizationId,
+  installationId: number,
+): Promise<void> {
+  try {
+    const repos = await fetchInstallationRepositories(installationId)
+    await initializeMembershipsForInstallation({
+      organizationId,
+      installationId,
+      repositories: repos,
+    })
+    await db
+      .updateTable('githubAppLinks')
+      .set({ membershipInitializedAt: new Date().toISOString() })
+      .where('organizationId', '=', organizationId)
+      .where('installationId', '=', installationId)
+      .execute()
+    await tryLogGithubAppLinkEvent({
+      organizationId,
+      installationId,
+      eventType: 'membership_repaired',
+      source: 'crawl_repair',
+      status: 'success',
+      details: { repoCount: repos.length },
+    })
+  } catch (e) {
+    await tryLogGithubAppLinkEvent({
+      organizationId,
+      installationId,
+      eventType: 'membership_repaired',
+      source: 'crawl_repair',
+      status: 'failed',
+      details: { error: getErrorMessage(e) },
+    })
+  }
+}
 
 export const crawlJob = defineJob({
   name: 'crawl',
@@ -64,6 +108,17 @@ export const crawlJob = defineJob({
         exportSetting: fullOrg.exportSetting,
       }
     })
+
+    if (fullOrg.integration?.method === 'github_app') {
+      const uninitialized = fullOrg.githubAppLinks.filter(
+        (l) => l.membershipInitializedAt === null,
+      )
+      for (const link of uninitialized) {
+        await step.run(`repair-membership:${link.installationId}`, async () => {
+          await repairMembershipForLink(orgId, link.installationId)
+        })
+      }
+    }
 
     const updatedPrNumbers = new Map<string, Set<number>>()
     const failedRepos: Array<{ repoLabel: string; error: string }> = []

--- a/docs/rdd/issue-283-multiple-github-accounts.md
+++ b/docs/rdd/issue-283-multiple-github-accounts.md
@@ -371,7 +371,7 @@ schema:
   - `id INTEGER PRIMARY KEY AUTOINCREMENT`
   - `organization_id TEXT NOT NULL` (server-derived。`github_app_links.organization_id` を参照する論理 FK)
   - `installation_id INTEGER NOT NULL`
-  - `event_type TEXT NOT NULL` (`link_created` / `link_deleted` / `link_suspended` / `link_unsuspended` / `membership_initialized` / `membership_repaired` / `canonical_reassigned` / `canonical_cleared` / `assignment_required`)
+  - `event_type TEXT NOT NULL` (`link_created` / `link_deleted` / `link_suspended` / `link_unsuspended` / `membership_initialized` / `membership_repaired` / `membership_synced` / `canonical_reassigned` / `canonical_cleared` / `assignment_required`)
   - `source TEXT NOT NULL` (`setup_callback` / `installation_webhook` / `installation_repositories_webhook` / `user_disconnect` / `crawl_repair` / `manual_reassign` / `cli_repair`)
   - `status TEXT NOT NULL` (`success` / `failed` / `skipped`)
   - `details_json TEXT NULL` (任意の payload。失敗時のエラーメッセージ、reassignment の前後値、affected repository ids など)


### PR DESCRIPTION
## Summary

Issue #283 の実装 stack **PR 3/7** — webhook handler / canonical reassignment / membership 初期投入の中核実装。stack で最重要 PR。

設計根拠: [`docs/rdd/issue-283-multiple-github-accounts.md`](./docs/rdd/issue-283-multiple-github-accounts.md)
作業計画: [`docs/rdd/issue-283-work-plan.md`](./docs/rdd/issue-283-work-plan.md)

依存: #288 (PR 1: schema), #296 (PR 2: query/octokit)

## 変更内容

### setup callback (`app/routes/api.github.setup.ts`)

- `(organizationId, installationId)` 単位 upsert（複合主キー対応）
- `github_account_type` を保存（personal / Organization の UI 分岐用）
- membership 初期投入: `fetchInstallationRepositories` → `initializeMembershipsForInstallation` → `membership_initialized_at = now`
- GitHub API 失敗時は link のみ保存し、`membership_initialized_at IS NULL` のまま auto-repair に委譲
- audit log: `link_created` / `membership_initialized` (success / failed)

### installation webhook (`app/services/github-webhook-installation.server.ts`)

- `findActiveLinkByInstallationOrAccount` 削除
- すべての lookup を `installation_id` で行う
- `installation.deleted`:
  - 該当 link のみ soft-delete
  - 最後の active link を失った時のみ `integrations.method = 'token'` に戻す
  - `link_deleted` 監査ログ
  - tenant 側で canonical reassignment を呼ぶ
- `installation.suspend` / `unsuspend`: `github_app_links.suspended_at` を更新（旧 `integrations.app_suspended_at` から移行）
- `installation_repositories.added/removed`:
  - membership upsert / soft-delete
  - canonical reassignment 呼び出し（removed 時）
  - bulk owner/repo 解決（1 query で N+1 解消）
- `installation.created`: setup callback が正本のため、既存 link が無ければ no-op

### canonical reassignment (`app/services/github-app-membership.server.ts`) 新規

- `reassignCanonicalAfterLinkLoss(orgId, lostInstallationId, source)`:
  - tenant DB の `repository_installation_memberships` を正本とする
  - 候補は active / non-suspended / `membership_initialized_at IS NOT NULL` の link のみ
  - 候補数で判定:
    - 1 → 自動 reassign + `canonical_reassigned`
    - 0 → null + `canonical_cleared` (or `assignment_required` if 未初期化 link 残存)
    - 2+ → null + `assignment_required`
  - **未初期化 link ガード**: 未初期化 link が残っている org では、候補 0 でも `canonical_cleared` ではなく `assignment_required` に倒す
  - LEFT JOIN + bulk update で N+1 を回避
  - tenant first / shared second の cross-store 順序
- `upsertRepositoryMembership` / `softDeleteRepositoryMembership` / `initializeMembershipsForInstallation` helpers

### installation repos fetcher (`app/services/github-installation-repos.server.ts`) 新規

- `fetchInstallationRepositories(installationId)`: GitHub API でその installation が見える repository を全ページ取得

### audit log writer (`app/services/github-app-link-events.server.ts`)

- `tryLogGithubAppLinkEvent` best-effort wrapper を追加（呼び出し側の `.catch(() => {})` ノイズを排除）

### auto repair (`app/services/jobs/crawl.server.ts`)

- crawl 冒頭に独立 step `repair-membership:<installation_id>` を追加
- `membership_initialized_at IS NULL` の active link を検出 → `installation_repositories` を再 fetch → membership upsert → `membership_initialized_at = now`
- per-link で独立 step、durably の中断・再開性を維持
- 失敗時は次回 crawl で再試行（idempotent）

### PR webhook (`app/services/github-webhook-pull.server.ts`)

- `owner + repo + installation_id` で repository を引く
- 移行期間中は `github_installation_id IS NULL` の repository も許可（PR 7 で strict 化）

### tests

- **`app/services/github-app-membership.server.test.ts`** 新規 (8 ケース):
  - 1 候補 → reassign + `canonical_reassigned`
  - 0 候補 → null + `canonical_cleared`
  - 2+ 候補 → null + `assignment_required`
  - 未初期化 link 残存 + 候補 0 → `assignment_required` (cleared じゃない)
  - suspended link は除外
  - 未初期化 link は除外
  - soft-deleted membership は除外
  - idempotency: 2 回実行しても結果が同じ
- **`app/services/github-webhook.server.test.ts`** 既存 12 ケース更新:
  - 新 schema (`suspended_at`, `membership_initialized_at`, `github_account_type`, `github_app_link_events`) 対応
  - tenant DB mock を chain proxy に変更

## 満たす受入条件

- **#8**: `installation.suspend/unsuspend` が対象 installation row のみ更新
- **#9**: `installation_repositories` が対象 installation のみ更新
- **#10**: `installation.deleted` が対象 installation row のみ `deleted_at` セット
- **#11**: 最後の active 切断時のみ method=token + private_token 有無で復帰先を分岐
- **#12**: canonical reassignment が候補 1 件で自動、0/複数で `null` + manual reselect
- **#19**: cross-store 更新は tenant first / shared second + audit log
- **#22**: setup callback で `membership_initialized_at` をセット、失敗時は repair に委譲
- **#23**: 未初期化 link 残存時は assignment_required に倒れる

## Stack 位置

\`\`\`text
PR 1 (#288): schema
└ PR 2 (#296): query/octokit
  └ [PR 3: webhook/membership] ← this PR
    └ PR 4 (UI)
      └ PR 5 (repo UI)
        └ PR 6 (backfill)
          └ PR 7 (strict)
\`\`\`

## 後続 PR への影響

- **PR 4**: integration settings UI が `getGithubAppLinks()` に切替 + installation selector 追加 + `assertInstallationBelongsToOrg` を loader 境界で呼ぶ
- **PR 5**: repository list/detail で `assignment required` バッジ + 個別再選択 mutation（同 helper を再利用）
- **PR 7**: PR webhook の `OR github_installation_id IS NULL` 削除 + crawl/backfill の移行期間 fallback 削除

## テスト

- [x] \`pnpm validate\` (lint / format / typecheck / build / test 全 339 tests)
- [x] canonical reassignment helper を 8 ケースのユニットテストでカバー (cross-store 整合性 / idempotency / 候補 0/1/2+ / 未初期化ガード / suspended 除外 / soft-deleted 除外)
- [x] webhook integration test (12 ケース)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHub Appインストール時にリポジトリメンバーシップを自動初期化・同期する仕組みを追加
  * メンバーシップ情報に基づくリポジトリの正規割り当て（再割り当て）処理を導入
  * インストールのリポジトリ取得機能を追加

* **バグ修正**
  * インストール/サスペンド/削除イベント処理のスコープと整合性を強化
  * 監査ログ書き込み失敗を影響させない安全措置を追加

* **テスト**
  * 再割り当て挙動の包括的なテストスイートを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
