### PR TITLE
feat(ui): multi-installation aware settings UI (#283 PR 4/7)

### DIFF
--- a/app/libs/github-account.ts
+++ b/app/libs/github-account.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared formatting / URL helpers for GitHub App installation links.
+ */
+
+export type GithubAccountLike = {
+  installationId: number
+  githubOrg: string
+  githubAccountType: string | null
+}
+
+export const isPersonalAccount = (link: GithubAccountLike): boolean =>
+  link.githubAccountType === 'User'
+
+/**
+ * UI label for an installation account. Personal accounts get an `@` prefix
+ * (matching GitHub's own convention) while organizations show their bare login.
+ */
+export const formatGithubAccountLabel = (link: GithubAccountLike): string =>
+  isPersonalAccount(link) ? `@${link.githubOrg}` : link.githubOrg
+
+/**
+ * GitHub-side settings URL for managing this installation.
+ *
+ * - Personal: `https://github.com/settings/installations/<id>`
+ * - Organization: `https://github.com/organizations/<login>/settings/installations`
+ */
+export const buildInstallationSettingsUrl = (
+  link: GithubAccountLike,
+): string =>
+  isPersonalAccount(link)
+    ? `https://github.com/settings/installations/${link.installationId}`
+    : `https://github.com/organizations/${encodeURIComponent(link.githubOrg)}/settings/installations`

--- a/app/libs/github-account.ts
+++ b/app/libs/github-account.ts
@@ -8,25 +8,49 @@ export type GithubAccountLike = {
   githubAccountType: string | null
 }
 
+export type GithubAccountKind = 'personal' | 'organization' | 'unknown'
+
+/**
+ * `github_account_type` is nullable for legacy rows migrated before the
+ * column existed; the setup callback / webhooks populate it going forward.
+ * Treat unknown values as `'unknown'` so the UI can degrade rather than
+ * guessing wrong (e.g. building an `/organizations/...` URL that 404s for
+ * a personal account).
+ */
+export const getAccountKind = (link: GithubAccountLike): GithubAccountKind => {
+  if (link.githubAccountType === 'User') return 'personal'
+  if (link.githubAccountType === 'Organization') return 'organization'
+  return 'unknown'
+}
+
 export const isPersonalAccount = (link: GithubAccountLike): boolean =>
-  link.githubAccountType === 'User'
+  getAccountKind(link) === 'personal'
 
 /**
  * UI label for an installation account. Personal accounts get an `@` prefix
- * (matching GitHub's own convention) while organizations show their bare login.
+ * (matching GitHub's own convention). Organizations and unknown-kind accounts
+ * render the bare login.
  */
 export const formatGithubAccountLabel = (link: GithubAccountLike): string =>
-  isPersonalAccount(link) ? `@${link.githubOrg}` : link.githubOrg
+  getAccountKind(link) === 'personal' ? `@${link.githubOrg}` : link.githubOrg
 
 /**
- * GitHub-side settings URL for managing this installation.
+ * GitHub-side settings URL for managing this installation. Returns `null`
+ * when the account kind is unknown — the UI should skip the link rather
+ * than guess and emit a 404.
  *
  * - Personal: `https://github.com/settings/installations/<id>`
  * - Organization: `https://github.com/organizations/<login>/settings/installations`
  */
 export const buildInstallationSettingsUrl = (
   link: GithubAccountLike,
-): string =>
-  isPersonalAccount(link)
-    ? `https://github.com/settings/installations/${link.installationId}`
-    : `https://github.com/organizations/${encodeURIComponent(link.githubOrg)}/settings/installations`
+): string | null => {
+  const kind = getAccountKind(link)
+  if (kind === 'personal') {
+    return `https://github.com/settings/installations/${link.installationId}`
+  }
+  if (kind === 'organization') {
+    return `https://github.com/organizations/${encodeURIComponent(link.githubOrg)}/settings/installations`
+  }
+  return null
+}

--- a/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
+++ b/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
@@ -1,3 +1,4 @@
+import type { SubmissionResult } from '@conform-to/react'
 import {
   getFormProps,
   getInputProps,
@@ -9,6 +10,7 @@ import { ExternalLinkIcon } from 'lucide-react'
 import { useEffect } from 'react'
 import { Form, useActionData, useFetcher, useNavigation } from 'react-router'
 import { toast } from 'sonner'
+import type { z } from 'zod'
 import type { ConfirmDialogData } from '~/app/components/confirm-dialog'
 import { ConfirmDialog } from '~/app/components/confirm-dialog'
 import Github from '~/app/components/icons/Github'
@@ -24,27 +26,127 @@ import {
   Stack,
   Textarea,
 } from '~/app/components/ui'
+import {
+  buildInstallationSettingsUrl,
+  isPersonalAccount,
+} from '~/app/libs/github-account'
 import { INTENTS, integrationSettingsSchema as schema } from '../+schema'
 import type { action } from '../../integration/index'
+
+export type GithubAppLinkSummary = {
+  installationId: number
+  githubOrg: string
+  githubAccountType: string | null
+  appRepositorySelection: 'all' | 'selected'
+  suspendedAt: string | null
+  membershipInitializedAt: string | null
+}
 
 export interface IntegrationSettingsProps {
   integration?: {
     provider: string
     method: 'token' | 'github_app'
     hasToken: boolean
-    appSuspendedAt: string | null
   }
-  githubAppLink: {
-    githubOrg: string
-    appRepositorySelection: 'all' | 'selected'
-  } | null
+  githubAppLinks: GithubAppLinkSummary[]
+}
+
+function InstallationCard({ link }: { link: GithubAppLinkSummary }) {
+  const disconnectFetcher = useFetcher<ConfirmDialogData>()
+  const settingsUrl = buildInstallationSettingsUrl(link)
+  const isPersonal = isPersonalAccount(link)
+  const isSuspended = link.suspendedAt !== null
+  const needsRepair = link.membershipInitializedAt === null
+
+  return (
+    <Stack gap="2" className="border-muted rounded-md border p-3">
+      <div className="space-y-1">
+        <p className="text-sm">
+          {isPersonal ? 'Personal account ' : 'Organization '}
+          <span className="font-medium">{link.githubOrg}</span>
+          {link.appRepositorySelection === 'selected' ? (
+            <span className="text-muted-foreground">
+              {' '}
+              (selected repositories only)
+            </span>
+          ) : null}
+        </p>
+        <p className="text-muted-foreground text-xs">
+          Installation #{link.installationId}
+        </p>
+      </div>
+
+      {isSuspended && (
+        <Alert variant="destructive">
+          <AlertTitle>Suspended</AlertTitle>
+          <AlertDescription>
+            GitHub has suspended this installation. Unsuspend it in GitHub to
+            resume syncing.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {needsRepair && (
+        <Alert>
+          <AlertTitle>Initializing membership</AlertTitle>
+          <AlertDescription>
+            Repository visibility is being initialized. The next crawl will
+            complete this automatically.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      <HStack className="flex-wrap">
+        <Button variant="outline" size="sm" asChild>
+          <a href={settingsUrl} target="_blank" rel="noreferrer">
+            <ExternalLinkIcon className="mr-1 h-4 w-4" />
+            GitHub App settings
+          </a>
+        </Button>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          onClick={() => {
+            disconnectFetcher.submit(
+              {
+                intent: INTENTS.confirmDisconnectGithubAppLink,
+                installationId: String(link.installationId),
+              },
+              { method: 'POST' },
+            )
+          }}
+        >
+          Disconnect
+        </Button>
+      </HStack>
+
+      <ConfirmDialog
+        title="Disconnect GitHub App installation"
+        desc={`Disconnect installation #${link.installationId} (${link.githubOrg}). Repositories tied to it will be reassigned to another active installation if available, or marked as needing manual reassignment.`}
+        confirmText="Disconnect"
+        destructive
+        fetcher={disconnectFetcher}
+      >
+        <input
+          type="hidden"
+          name="intent"
+          value={INTENTS.disconnectGithubAppLink}
+        />
+        <input
+          type="hidden"
+          name="installationId"
+          value={String(link.installationId)}
+        />
+      </ConfirmDialog>
+    </Stack>
+  )
 }
 
 function GitHubAppSection({
   integration,
-  githubAppLink,
-}: Pick<IntegrationSettingsProps, 'integration' | 'githubAppLink'>) {
-  const disconnectFetcher = useFetcher<ConfirmDialogData>()
+  githubAppLinks,
+}: Pick<IntegrationSettingsProps, 'integration' | 'githubAppLinks'>) {
   const revertFetcher = useFetcher<ConfirmDialogData>()
   const copyFetcher = useFetcher<typeof action>()
 
@@ -65,27 +167,15 @@ function GitHubAppSection({
       toast.success('Install URL copied to clipboard')
       copyFetcher.reset()
     })
-  }, [copyFetcher.data, copyFetcher.reset, copyFetcher.state])
+  }, [copyFetcher])
 
-  const isAppConnected =
-    integration?.method === 'github_app' &&
-    githubAppLink != null &&
-    !integration.appSuspendedAt
-  const isAppSuspended =
-    integration?.method === 'github_app' &&
-    githubAppLink != null &&
-    !!integration.appSuspendedAt
-  const needsReconnect =
-    integration?.method === 'github_app' && githubAppLink == null
-
-  const githubInstallationsSettingsUrl = githubAppLink
-    ? `https://github.com/organizations/${encodeURIComponent(githubAppLink.githubOrg)}/settings/installations`
-    : null
+  const hasAnyLink = githubAppLinks.length > 0
+  const needsReconnect = integration?.method === 'github_app' && !hasAnyLink
 
   const tokenNote = !integration?.hasToken ? (
     <p className="text-muted-foreground text-xs">
-      ※ No personal access token is stored. After switching, you will need to
-      enter a token in the Integration settings.
+      ※ No personal access token is stored. After disconnecting all GitHub Apps,
+      you will need to enter a token in the Integration settings.
     </p>
   ) : null
 
@@ -94,110 +184,29 @@ function GitHubAppSection({
       <div className="space-y-1">
         <Label>GitHub App</Label>
         <p className="text-muted-foreground text-sm">
-          Connect with the Upflow GitHub App instead of a personal access token.
+          Connect one or more GitHub accounts via the Upflow GitHub App.
         </p>
       </div>
 
-      {isAppConnected && githubAppLink && (
+      {hasAnyLink && (
         <Stack gap="2">
-          <p className="text-sm">
-            Connected to GitHub organization{' '}
-            <span className="font-medium">{githubAppLink.githubOrg}</span>
-            {githubAppLink.appRepositorySelection === 'selected' ? (
-              <span className="text-muted-foreground">
-                {' '}
-                (selected repositories only)
-              </span>
-            ) : null}
-          </p>
+          {githubAppLinks.map((link) => (
+            <InstallationCard key={link.installationId} link={link} />
+          ))}
           <HStack className="flex-wrap">
-            {githubInstallationsSettingsUrl ? (
-              <Button variant="outline" size="sm" asChild>
-                <a
-                  href={githubInstallationsSettingsUrl}
-                  target="_blank"
-                  rel="noreferrer"
-                >
-                  <ExternalLinkIcon className="mr-1 h-4 w-4" />
-                  GitHub App settings
-                </a>
+            <Form method="POST">
+              <input
+                type="hidden"
+                name="intent"
+                value={INTENTS.installGithubApp}
+              />
+              <Button type="submit" size="sm" variant="outline">
+                Add another GitHub account
               </Button>
-            ) : null}
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                disconnectFetcher.submit(
-                  { intent: INTENTS.confirmDisconnectGithubApp },
-                  { method: 'POST' },
-                )
-              }}
-            >
-              Disconnect
-            </Button>
+            </Form>
           </HStack>
           {tokenNote}
         </Stack>
-      )}
-
-      {isAppSuspended && githubAppLink && githubInstallationsSettingsUrl && (
-        <Stack gap="2">
-          <Alert variant="destructive">
-            <AlertTitle>Suspended</AlertTitle>
-            <AlertDescription>
-              GitHub has suspended this installation. Unsuspend it in GitHub to
-              resume syncing.
-            </AlertDescription>
-          </Alert>
-          <p className="text-sm">
-            Organization:{' '}
-            <span className="font-medium">{githubAppLink.githubOrg}</span>
-          </p>
-          <Button variant="outline" size="sm" asChild>
-            <a
-              href={githubInstallationsSettingsUrl}
-              target="_blank"
-              rel="noreferrer"
-            >
-              <ExternalLinkIcon className="mr-1 h-4 w-4" />
-              Open GitHub App settings
-            </a>
-          </Button>
-          <HStack className="flex-wrap">
-            <Button
-              type="button"
-              variant="outline"
-              size="sm"
-              onClick={() => {
-                disconnectFetcher.submit(
-                  { intent: INTENTS.confirmDisconnectGithubApp },
-                  { method: 'POST' },
-                )
-              }}
-            >
-              Disconnect
-            </Button>
-          </HStack>
-          {tokenNote}
-        </Stack>
-      )}
-
-      {/* Shared disconnect dialog for connected + suspended states */}
-      {(isAppConnected || isAppSuspended) && (
-        <ConfirmDialog
-          title="Disconnect GitHub App"
-          desc="The organization will use a personal access token for GitHub API access again. You can reconnect the app at any time."
-          confirmText="Disconnect"
-          destructive
-          fetcher={disconnectFetcher}
-        >
-          <input
-            type="hidden"
-            name="intent"
-            value={INTENTS.disconnectGithubApp}
-          />
-        </ConfirmDialog>
       )}
 
       {needsReconnect && (
@@ -205,8 +214,8 @@ function GitHubAppSection({
           <Alert>
             <AlertTitle>Reconnection required</AlertTitle>
             <AlertDescription>
-              The GitHub App was uninstalled or the link was removed. Reinstall
-              the app or switch back to a personal access token.
+              All GitHub App installations have been removed. Reinstall the app
+              or switch back to a personal access token.
             </AlertDescription>
           </Alert>
           <HStack className="flex-wrap">
@@ -247,7 +256,7 @@ function GitHubAppSection({
         </Stack>
       )}
 
-      {!isAppConnected && !isAppSuspended && !needsReconnect && (
+      {!hasAnyLink && !needsReconnect && (
         <Stack gap="2">
           <HStack className="flex-wrap">
             <Form method="POST">
@@ -283,7 +292,7 @@ function GitHubAppSection({
 
 export const IntegrationSettings = ({
   integration,
-  githubAppLink,
+  githubAppLinks,
 }: IntegrationSettingsProps) => {
   const actionData = useActionData<typeof action>()
   const navigation = useNavigation()
@@ -291,11 +300,9 @@ export const IntegrationSettings = ({
     navigation.state === 'submitting' &&
     navigation.formData?.get('intent') === INTENTS.integrationSettings
 
-  const needsReconnect =
-    integration?.method === 'github_app' && githubAppLink == null
-  const showPatSection = !(
-    integration?.method === 'github_app' && githubAppLink != null
-  )
+  const hasAnyLink = githubAppLinks.length > 0
+  const needsReconnect = integration?.method === 'github_app' && !hasAnyLink
+  const showPatSection = !(integration?.method === 'github_app' && hasAnyLink)
 
   const integrationLastResult =
     actionData &&
@@ -305,8 +312,10 @@ export const IntegrationSettings = ({
       ? actionData.lastResult
       : undefined
 
-  const [form, { provider, method, privateToken }] = useForm({
-    lastResult: integrationLastResult,
+  const [form, { provider, method, privateToken }] = useForm<
+    z.input<typeof schema>
+  >({
+    lastResult: integrationLastResult as SubmissionResult<string[]> | undefined,
     defaultValue: integration
       ? {
           provider: integration.provider,
@@ -388,7 +397,7 @@ export const IntegrationSettings = ({
 
       <GitHubAppSection
         integration={integration}
-        githubAppLink={githubAppLink}
+        githubAppLinks={githubAppLinks}
       />
     </Stack>
   )

--- a/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
+++ b/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
@@ -167,7 +167,7 @@ function GitHubAppSection({
       toast.success('Install URL copied to clipboard')
       copyFetcher.reset()
     })
-  }, [copyFetcher])
+  }, [copyFetcher.state, copyFetcher.data, copyFetcher.reset])
 
   const hasAnyLink = githubAppLinks.length > 0
   const needsReconnect = integration?.method === 'github_app' && !hasAnyLink

--- a/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
+++ b/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
@@ -150,6 +150,7 @@ function GitHubAppSection({
   const revertFetcher = useFetcher<ConfirmDialogData>()
   const copyFetcher = useFetcher<typeof action>()
 
+  // biome-ignore lint/correctness/useExhaustiveDependencies: useFetcher() returns a fresh object each render; depending only on the primitive `state` keeps the effect tied to the submit lifecycle.
   useEffect(() => {
     if (copyFetcher.state !== 'idle') return
     const d = copyFetcher.data
@@ -167,7 +168,7 @@ function GitHubAppSection({
       toast.success('Install URL copied to clipboard')
       copyFetcher.reset()
     })
-  }, [copyFetcher.state, copyFetcher.data, copyFetcher.reset])
+  }, [copyFetcher.state])
 
   const hasAnyLink = githubAppLinks.length > 0
   const needsReconnect = integration?.method === 'github_app' && !hasAnyLink

--- a/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
+++ b/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
@@ -28,7 +28,7 @@ import {
 } from '~/app/components/ui'
 import {
   buildInstallationSettingsUrl,
-  isPersonalAccount,
+  getAccountKind,
 } from '~/app/libs/github-account'
 import { INTENTS, integrationSettingsSchema as schema } from '../+schema'
 import type { action } from '../../integration/index'
@@ -54,7 +54,13 @@ export interface IntegrationSettingsProps {
 function InstallationCard({ link }: { link: GithubAppLinkSummary }) {
   const disconnectFetcher = useFetcher<ConfirmDialogData>()
   const settingsUrl = buildInstallationSettingsUrl(link)
-  const isPersonal = isPersonalAccount(link)
+  const accountKind = getAccountKind(link)
+  const kindPrefix =
+    accountKind === 'personal'
+      ? 'Personal account '
+      : accountKind === 'organization'
+        ? 'Organization '
+        : ''
   const isSuspended = link.suspendedAt !== null
   const needsRepair = link.membershipInitializedAt === null
 
@@ -62,7 +68,7 @@ function InstallationCard({ link }: { link: GithubAppLinkSummary }) {
     <Stack gap="2" className="border-muted rounded-md border p-3">
       <div className="space-y-1">
         <p className="text-sm">
-          {isPersonal ? 'Personal account ' : 'Organization '}
+          {kindPrefix}
           <span className="font-medium">{link.githubOrg}</span>
           {link.appRepositorySelection === 'selected' ? (
             <span className="text-muted-foreground">
@@ -97,12 +103,14 @@ function InstallationCard({ link }: { link: GithubAppLinkSummary }) {
       )}
 
       <HStack className="flex-wrap">
-        <Button variant="outline" size="sm" asChild>
-          <a href={settingsUrl} target="_blank" rel="noreferrer">
-            <ExternalLinkIcon className="mr-1 h-4 w-4" />
-            GitHub App settings
-          </a>
-        </Button>
+        {settingsUrl && (
+          <Button variant="outline" size="sm" asChild>
+            <a href={settingsUrl} target="_blank" rel="noreferrer">
+              <ExternalLinkIcon className="mr-1 h-4 w-4" />
+              GitHub App settings
+            </a>
+          </Button>
+        )}
         <Button
           type="button"
           variant="outline"

--- a/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
+++ b/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
@@ -150,7 +150,6 @@ function GitHubAppSection({
   const revertFetcher = useFetcher<ConfirmDialogData>()
   const copyFetcher = useFetcher<typeof action>()
 
-  // biome-ignore lint/correctness/useExhaustiveDependencies: useFetcher() returns a fresh object each render; depending only on the primitive `state` keeps the effect tied to the submit lifecycle.
   useEffect(() => {
     if (copyFetcher.state !== 'idle') return
     const d = copyFetcher.data
@@ -168,7 +167,7 @@ function GitHubAppSection({
       toast.success('Install URL copied to clipboard')
       copyFetcher.reset()
     })
-  }, [copyFetcher.state])
+  }, [copyFetcher.state, copyFetcher.data, copyFetcher.reset])
 
   const hasAnyLink = githubAppLinks.length > 0
   const needsReconnect = integration?.method === 'github_app' && !hasAnyLink

--- a/app/routes/$orgSlug/settings/_index/+schema.ts
+++ b/app/routes/$orgSlug/settings/_index/+schema.ts
@@ -45,8 +45,31 @@ export enum INTENTS {
   copyInstallUrl = 'copy-install-url',
   disconnectGithubApp = 'disconnect-github-app',
   confirmDisconnectGithubApp = 'confirm-disconnect-github-app',
+  disconnectGithubAppLink = 'disconnect-github-app-link',
+  confirmDisconnectGithubAppLink = 'confirm-disconnect-github-app-link',
   revertToToken = 'revert-to-token',
   confirmRevertToToken = 'confirm-revert-to-token',
 }
 
 export const intentsSchema = z.enum(INTENTS)
+
+/**
+ * Discriminated union of every intent the integration page action accepts.
+ * Use with parseWithZod + ts-pattern.
+ */
+export const integrationActionSchema = z.discriminatedUnion('intent', [
+  z.object({ intent: z.literal(INTENTS.confirmDisconnectGithubApp) }),
+  z.object({ intent: z.literal(INTENTS.disconnectGithubApp) }),
+  z.object({ intent: z.literal(INTENTS.confirmDisconnectGithubAppLink) }),
+  z.object({
+    intent: z.literal(INTENTS.disconnectGithubAppLink),
+    installationId: z.coerce.number().int().positive(),
+  }),
+  z.object({ intent: z.literal(INTENTS.confirmRevertToToken) }),
+  z.object({ intent: z.literal(INTENTS.revertToToken) }),
+  z.object({ intent: z.literal(INTENTS.installGithubApp) }),
+  z.object({ intent: z.literal(INTENTS.copyInstallUrl) }),
+  z
+    .object({ intent: z.literal(INTENTS.integrationSettings) })
+    .merge(integrationSettingsSchema),
+])

--- a/app/routes/$orgSlug/settings/github-users._index/+functions/search-github-users.server.ts
+++ b/app/routes/$orgSlug/settings/github-users._index/+functions/search-github-users.server.ts
@@ -13,30 +13,19 @@ import type { OrganizationId } from '~/app/types/organization'
  *
  * `search.users` is a global GitHub endpoint — the choice of authentication
  * doesn't change the result set, only rate limits. For `github_app` orgs we
- * pick the first active installation transparently so installations don't
- * need to be exposed in the UI.
+ * iterate active installations in order and fall through to the next one
+ * on transient failures (rate limit, revoked installation, etc.), so a
+ * single troubled installation doesn't break the search UX for the whole
+ * organization.
  */
 export const searchGithubUsers = async (
   organizationId: OrganizationId,
   query: string,
 ): Promise<{ login: string; avatarUrl: string }[]> => {
-  try {
-    const integration = await getIntegration(organizationId)
-    if (!integration) return []
+  const integration = await getIntegration(organizationId)
+  if (!integration) return []
 
-    let octokit: ReturnType<typeof resolveOctokitForInstallation>
-    if (integration.method === 'github_app') {
-      const [firstActive] = await getActiveInstallationOptions(organizationId)
-      if (!firstActive) return []
-      octokit = resolveOctokitForInstallation(firstActive.installationId)
-    } else {
-      if (!integration.privateToken) return []
-      octokit = createOctokit({
-        method: 'token',
-        privateToken: integration.privateToken,
-      })
-    }
-
+  const runSearch = async (octokit: ReturnType<typeof createOctokit>) => {
     const { data } = await octokit.rest.search.users({
       q: `${query} in:login`,
       per_page: 8,
@@ -45,6 +34,33 @@ export const searchGithubUsers = async (
       login: u.login,
       avatarUrl: u.avatar_url,
     }))
+  }
+
+  if (integration.method === 'github_app') {
+    const installations = await getActiveInstallationOptions(organizationId)
+    for (const installation of installations) {
+      try {
+        const octokit = resolveOctokitForInstallation(
+          installation.installationId,
+        )
+        return await runSearch(octokit)
+      } catch (e) {
+        console.warn(
+          `[searchGithubUsers] installation ${installation.installationId} failed, trying next`,
+          e,
+        )
+      }
+    }
+    return []
+  }
+
+  if (!integration.privateToken) return []
+  try {
+    const octokit = createOctokit({
+      method: 'token',
+      privateToken: integration.privateToken,
+    })
+    return await runSearch(octokit)
   } catch {
     return []
   }

--- a/app/routes/$orgSlug/settings/github-users._index/+functions/search-github-users.server.ts
+++ b/app/routes/$orgSlug/settings/github-users._index/+functions/search-github-users.server.ts
@@ -1,20 +1,42 @@
 import {
-  getGithubAppLink,
+  getActiveInstallationOptions,
   getIntegration,
 } from '~/app/services/github-integration-queries.server'
-import { resolveOctokitFromOrg } from '~/app/services/github-octokit.server'
+import {
+  createOctokit,
+  resolveOctokitForInstallation,
+} from '~/app/services/github-octokit.server'
 import type { OrganizationId } from '~/app/types/organization'
 
+/**
+ * Search GitHub users via the search API.
+ *
+ * `search.users` is a global GitHub endpoint — the choice of authentication
+ * doesn't change the result set, only rate limits. For `github_app` orgs we
+ * pick the first active installation transparently so installations don't
+ * need to be exposed in the UI.
+ */
 export const searchGithubUsers = async (
   organizationId: OrganizationId,
   query: string,
 ): Promise<{ login: string; avatarUrl: string }[]> => {
   try {
-    const [integration, githubAppLink] = await Promise.all([
-      getIntegration(organizationId),
-      getGithubAppLink(organizationId),
-    ])
-    const octokit = resolveOctokitFromOrg({ integration, githubAppLink })
+    const integration = await getIntegration(organizationId)
+    if (!integration) return []
+
+    let octokit: ReturnType<typeof resolveOctokitForInstallation>
+    if (integration.method === 'github_app') {
+      const [firstActive] = await getActiveInstallationOptions(organizationId)
+      if (!firstActive) return []
+      octokit = resolveOctokitForInstallation(firstActive.installationId)
+    } else {
+      if (!integration.privateToken) return []
+      octokit = createOctokit({
+        method: 'token',
+        privateToken: integration.privateToken,
+      })
+    }
+
     const { data } = await octokit.rest.search.users({
       q: `${query} in:login`,
       per_page: 8,

--- a/app/routes/$orgSlug/settings/integration/index.tsx
+++ b/app/routes/$orgSlug/settings/integration/index.tsx
@@ -1,20 +1,26 @@
-import type { SubmissionResult } from '@conform-to/react'
 import { parseWithZod } from '@conform-to/zod/v4'
 import { data, href, redirect } from 'react-router'
 import { dataWithError, dataWithSuccess } from 'remix-toast'
+import { match } from 'ts-pattern'
+import { requireOrgOwner } from '~/app/libs/auth.server'
 import { getErrorMessage } from '~/app/libs/error-message'
 import { generateInstallState } from '~/app/libs/github-app-state.server'
 import { orgContext } from '~/app/middleware/context'
-import { disconnectGithubApp } from '~/app/services/github-app-mutations.server'
 import {
-  getGithubAppLink,
+  disconnectGithubApp,
+  disconnectGithubAppLink,
+} from '~/app/services/github-app-mutations.server'
+import {
+  assertInstallationBelongsToOrg,
+  getGithubAppLinks,
   getIntegration,
 } from '~/app/services/github-integration-queries.server'
 import { getGithubAppSlug } from '~/app/services/github-octokit.server'
+import type { OrganizationId } from '~/app/types/organization'
 import ContentSection from '../+components/content-section'
 import { IntegrationSettings } from '../_index/+forms/integration-settings'
 import { upsertIntegration } from '../_index/+functions/mutations.server'
-import { INTENTS, integrationSettingsSchema as schema } from '../_index/+schema'
+import { INTENTS, integrationActionSchema } from '../_index/+schema'
 import type { Route } from './+types/index'
 
 export const handle = {
@@ -26,9 +32,9 @@ export const handle = {
 
 export const loader = async ({ context }: Route.LoaderArgs) => {
   const { organization } = context.get(orgContext)
-  const [integration, githubAppLink, githubAppSlug] = await Promise.all([
+  const [integration, githubAppLinks, githubAppSlug] = await Promise.all([
     getIntegration(organization.id),
-    getGithubAppLink(organization.id),
+    getGithubAppLinks(organization.id),
     getGithubAppSlug(),
   ])
   const safeIntegration = integration
@@ -36,192 +42,211 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
         provider: integration.provider,
         method: integration.method,
         hasToken: !!integration.privateToken,
-        appSuspendedAt: integration.appSuspendedAt,
       }
     : null
-  const safeGithubAppLink = githubAppLink
-    ? {
-        githubOrg: githubAppLink.githubOrg,
-        appRepositorySelection: githubAppLink.appRepositorySelection,
-      }
-    : null
+  const safeGithubAppLinks = githubAppLinks.map((l) => ({
+    installationId: l.installationId,
+    githubOrg: l.githubOrg,
+    githubAccountType: l.githubAccountType,
+    appRepositorySelection: l.appRepositorySelection,
+    suspendedAt: l.suspendedAt,
+    membershipInitializedAt: l.membershipInitializedAt,
+  }))
   return {
     integration: safeIntegration,
-    githubAppLink: safeGithubAppLink,
+    githubAppLinks: safeGithubAppLinks,
     githubAppSlug,
   }
 }
 
+async function buildInstallUrl(
+  organizationId: OrganizationId,
+): Promise<string | null> {
+  const slug = await getGithubAppSlug()
+  if (!slug) return null
+  const nonce = await generateInstallState(organizationId)
+  return `https://github.com/apps/${slug}/installations/new?state=${encodeURIComponent(nonce)}`
+}
+
 export const action = async ({ request, context }: Route.ActionArgs) => {
-  const { organization } = context.get(orgContext)
+  const { organization, membership } = context.get(orgContext)
+  requireOrgOwner(membership, organization.slug)
   const formData = await request.formData()
-  const intent = formData.get('intent')
-
-  if (intent === INTENTS.confirmDisconnectGithubApp) {
-    return data({ shouldConfirm: true as const })
-  }
-
-  if (intent === INTENTS.disconnectGithubApp) {
-    try {
-      await disconnectGithubApp(organization.id)
-    } catch (e) {
-      console.error('Failed to disconnect GitHub App:', e)
-      const message = getErrorMessage(e)
-      return data(
-        {
-          intent: INTENTS.disconnectGithubApp,
-          lastResult: {
-            error: { '': [message] },
-          } as SubmissionResult,
-          shouldConfirm: true,
-        },
-        { status: 400 },
-      )
-    }
-
-    return dataWithSuccess(
-      {
-        intent: INTENTS.disconnectGithubApp,
-        lastResult: undefined,
-      },
-      { message: 'GitHub App disconnected' },
-    )
-  }
-
-  if (intent === INTENTS.confirmRevertToToken) {
-    return data({ shouldConfirm: true as const })
-  }
-
-  if (intent === INTENTS.revertToToken) {
-    try {
-      await disconnectGithubApp(organization.id)
-    } catch (e) {
-      console.error('Failed to revert to token:', e)
-      const message = getErrorMessage(e)
-      return data(
-        {
-          intent: INTENTS.revertToToken,
-          lastResult: {
-            error: { '': [message] },
-          } as SubmissionResult,
-          shouldConfirm: true,
-        },
-        { status: 400 },
-      )
-    }
-
-    return dataWithSuccess(
-      {
-        intent: INTENTS.revertToToken,
-        lastResult: undefined,
-      },
-      { message: 'Switched to personal access token' },
-    )
-  }
-
-  if (
-    intent === INTENTS.installGithubApp ||
-    intent === INTENTS.copyInstallUrl
-  ) {
-    const slug = await getGithubAppSlug()
-    if (!slug) {
-      return dataWithError(
-        { intent: intent as string },
-        {
-          message:
-            'GitHub App is not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY missing)',
-        },
-      )
-    }
-    const baseUrl = `https://github.com/apps/${slug}/installations/new`
-    const nonce = await generateInstallState(organization.id)
-    const installUrl = `${baseUrl}?state=${encodeURIComponent(nonce)}`
-
-    if (intent === INTENTS.installGithubApp) {
-      throw redirect(installUrl)
-    }
-    return data({
-      intent: INTENTS.copyInstallUrl,
-      installUrl,
-    })
-  }
-
-  const submission = await parseWithZod(formData, { schema })
+  const submission = parseWithZod(formData, { schema: integrationActionSchema })
   if (submission.status !== 'success') {
-    return {
-      intent: 'integration-settings' as const,
-      lastResult: submission.reply(),
-    }
-  }
-
-  const activeGithubAppLink = await getGithubAppLink(organization.id)
-  const existingIntegration = await getIntegration(organization.id)
-  if (activeGithubAppLink && existingIntegration?.method === 'github_app') {
-    const message =
-      'GitHub App is connected. Use the App section to manage the connection.'
-    return dataWithError(
+    return data(
       {
-        intent: 'integration-settings' as const,
-        lastResult: submission.reply({ formErrors: [message] }),
+        intent: INTENTS.integrationSettings,
+        lastResult: submission.reply(),
       },
-      { message },
+      { status: 400 },
     )
   }
 
-  try {
-    const { privateToken, ...rest } = submission.value
+  const confirmGuard = (intent: INTENTS) =>
+    data({
+      intent,
+      lastResult: undefined,
+      shouldConfirm: true as const,
+    })
 
-    if (submission.value.method === 'github_app') {
-      const resolvedToken = privateToken
-        ? privateToken
-        : (existingIntegration?.privateToken ?? null)
-      await upsertIntegration(organization.id, {
-        ...rest,
-        privateToken: resolvedToken,
-      })
-    } else if (!privateToken) {
-      if (!existingIntegration?.privateToken) {
-        const message = 'Private token is required for new integrations.'
+  const errorWithDialog = (intent: INTENTS, message: string) =>
+    data(
+      {
+        intent,
+        lastResult: submission.reply({ formErrors: [message] }),
+        shouldConfirm: true as const,
+      },
+      { status: 400 },
+    )
+
+  return match(submission.value)
+    .with({ intent: INTENTS.confirmDisconnectGithubApp }, () =>
+      confirmGuard(INTENTS.confirmDisconnectGithubApp),
+    )
+    .with({ intent: INTENTS.confirmDisconnectGithubAppLink }, () =>
+      confirmGuard(INTENTS.confirmDisconnectGithubAppLink),
+    )
+    .with({ intent: INTENTS.confirmRevertToToken }, () =>
+      confirmGuard(INTENTS.confirmRevertToToken),
+    )
+    .with({ intent: INTENTS.disconnectGithubAppLink }, async (v) => {
+      try {
+        await assertInstallationBelongsToOrg(organization.id, v.installationId)
+        await disconnectGithubAppLink(organization.id, v.installationId)
+      } catch (e) {
+        console.error('Failed to disconnect GitHub App link:', e)
+        return errorWithDialog(
+          INTENTS.disconnectGithubAppLink,
+          getErrorMessage(e),
+        )
+      }
+      return dataWithSuccess(
+        { intent: INTENTS.disconnectGithubAppLink, lastResult: undefined },
+        { message: 'GitHub App installation disconnected' },
+      )
+    })
+    .with({ intent: INTENTS.disconnectGithubApp }, async () => {
+      try {
+        await disconnectGithubApp(organization.id)
+      } catch (e) {
+        console.error('Failed to disconnect GitHub App:', e)
+        return errorWithDialog(INTENTS.disconnectGithubApp, getErrorMessage(e))
+      }
+      return dataWithSuccess(
+        { intent: INTENTS.disconnectGithubApp, lastResult: undefined },
+        { message: 'GitHub App disconnected' },
+      )
+    })
+    .with({ intent: INTENTS.revertToToken }, async () => {
+      try {
+        await disconnectGithubApp(organization.id)
+      } catch (e) {
+        console.error('Failed to revert to token:', e)
+        return errorWithDialog(INTENTS.revertToToken, getErrorMessage(e))
+      }
+      return dataWithSuccess(
+        { intent: INTENTS.revertToToken, lastResult: undefined },
+        { message: 'Switched to personal access token' },
+      )
+    })
+    .with({ intent: INTENTS.installGithubApp }, async () => {
+      const installUrl = await buildInstallUrl(organization.id)
+      if (!installUrl) {
+        return dataWithError(
+          { intent: INTENTS.installGithubApp },
+          {
+            message:
+              'GitHub App is not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY missing)',
+          },
+        )
+      }
+      throw redirect(installUrl)
+    })
+    .with({ intent: INTENTS.copyInstallUrl }, async () => {
+      const installUrl = await buildInstallUrl(organization.id)
+      if (!installUrl) {
+        return dataWithError(
+          { intent: INTENTS.copyInstallUrl },
+          {
+            message:
+              'GitHub App is not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY missing)',
+          },
+        )
+      }
+      return data({ intent: INTENTS.copyInstallUrl, installUrl })
+    })
+    .with({ intent: INTENTS.integrationSettings }, async (v) => {
+      const [activeGithubAppLinks, existingIntegration] = await Promise.all([
+        getGithubAppLinks(organization.id),
+        getIntegration(organization.id),
+      ])
+      if (
+        activeGithubAppLinks.length > 0 &&
+        existingIntegration?.method === 'github_app'
+      ) {
+        const message =
+          'GitHub App is connected. Use the App section to manage the connection.'
         return dataWithError(
           {
-            intent: 'integration-settings' as const,
+            intent: INTENTS.integrationSettings,
             lastResult: submission.reply({ formErrors: [message] }),
           },
           { message },
         )
       }
-      await upsertIntegration(organization.id, {
-        ...rest,
-        privateToken: existingIntegration.privateToken,
-      })
-    } else {
-      await upsertIntegration(organization.id, { ...rest, privateToken })
-    }
-  } catch (e) {
-    console.error('Failed to update integration:', e)
-    const message = getErrorMessage(e)
-    return dataWithError(
-      {
-        intent: 'integration-settings' as const,
-        lastResult: submission.reply({ formErrors: [message] }),
-      },
-      { message },
-    )
-  }
 
-  return dataWithSuccess(
-    {
-      intent: 'integration-settings' as const,
-      lastResult: submission.reply(),
-    },
-    {
-      message: 'Update integration settings successfully',
-    },
-  )
+      try {
+        const { privateToken, intent: _ignored, ...rest } = v
+        if (v.method === 'github_app') {
+          await upsertIntegration(organization.id, {
+            ...rest,
+            privateToken:
+              privateToken || (existingIntegration?.privateToken ?? null),
+          })
+        } else if (!privateToken) {
+          if (!existingIntegration?.privateToken) {
+            const message = 'Private token is required for new integrations.'
+            return dataWithError(
+              {
+                intent: INTENTS.integrationSettings,
+                lastResult: submission.reply({ formErrors: [message] }),
+              },
+              { message },
+            )
+          }
+          await upsertIntegration(organization.id, {
+            ...rest,
+            privateToken: existingIntegration.privateToken,
+          })
+        } else {
+          await upsertIntegration(organization.id, { ...rest, privateToken })
+        }
+      } catch (e) {
+        console.error('Failed to update integration:', e)
+        const message = getErrorMessage(e)
+        return dataWithError(
+          {
+            intent: INTENTS.integrationSettings,
+            lastResult: submission.reply({ formErrors: [message] }),
+          },
+          { message },
+        )
+      }
+
+      return dataWithSuccess(
+        {
+          intent: INTENTS.integrationSettings,
+          lastResult: submission.reply(),
+        },
+        { message: 'Update integration settings successfully' },
+      )
+    })
+    .exhaustive()
 }
 
 export default function IntegrationSettingsPage({
-  loaderData: { integration, githubAppLink },
+  loaderData: { integration, githubAppLinks },
 }: Route.ComponentProps) {
   return (
     <ContentSection
@@ -230,7 +255,7 @@ export default function IntegrationSettingsPage({
     >
       <IntegrationSettings
         integration={integration ?? undefined}
-        githubAppLink={githubAppLink}
+        githubAppLinks={githubAppLinks}
       />
     </ContentSection>
   )

--- a/app/routes/$orgSlug/settings/integration/index.tsx
+++ b/app/routes/$orgSlug/settings/integration/index.tsx
@@ -59,6 +59,17 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
   }
 }
 
+const githubAppNotConfigured = (
+  intent: INTENTS.installGithubApp | INTENTS.copyInstallUrl,
+) =>
+  dataWithError(
+    { intent },
+    {
+      message:
+        'GitHub App is not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY missing)',
+    },
+  )
+
 async function buildInstallUrl(
   organizationId: OrganizationId,
 ): Promise<string | null> {
@@ -152,28 +163,12 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
     })
     .with({ intent: INTENTS.installGithubApp }, async () => {
       const installUrl = await buildInstallUrl(organization.id)
-      if (!installUrl) {
-        return dataWithError(
-          { intent: INTENTS.installGithubApp },
-          {
-            message:
-              'GitHub App is not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY missing)',
-          },
-        )
-      }
+      if (!installUrl) return githubAppNotConfigured(INTENTS.installGithubApp)
       throw redirect(installUrl)
     })
     .with({ intent: INTENTS.copyInstallUrl }, async () => {
       const installUrl = await buildInstallUrl(organization.id)
-      if (!installUrl) {
-        return dataWithError(
-          { intent: INTENTS.copyInstallUrl },
-          {
-            message:
-              'GitHub App is not configured (GITHUB_APP_ID / GITHUB_APP_PRIVATE_KEY missing)',
-          },
-        )
-      }
+      if (!installUrl) return githubAppNotConfigured(INTENTS.copyInstallUrl)
       return data({ intent: INTENTS.copyInstallUrl, installUrl })
     })
     .with({ intent: INTENTS.integrationSettings }, async (v) => {

--- a/app/routes/$orgSlug/settings/integration/index.tsx
+++ b/app/routes/$orgSlug/settings/integration/index.tsx
@@ -6,6 +6,7 @@ import { requireOrgOwner } from '~/app/libs/auth.server'
 import { getErrorMessage } from '~/app/libs/error-message'
 import { generateInstallState } from '~/app/libs/github-app-state.server'
 import { orgContext } from '~/app/middleware/context'
+import { reassignCanonicalAfterLinkLoss } from '~/app/services/github-app-membership.server'
 import {
   disconnectGithubApp,
   disconnectGithubAppLink,
@@ -132,6 +133,14 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
           getErrorMessage(e),
         )
       }
+      // Mirror the webhook path: soft-deleting the link leaves repositories
+      // whose `githubInstallationId` points at it dangling. Reassign them to
+      // another eligible installation (or clear to null) before returning.
+      await reassignCanonicalAfterLinkLoss({
+        organizationId: organization.id,
+        lostInstallationId: v.installationId,
+        source: 'user_disconnect',
+      })
       return dataWithSuccess(
         { intent: INTENTS.disconnectGithubAppLink, lastResult: undefined },
         { message: 'GitHub App installation disconnected' },

--- a/app/routes/$orgSlug/settings/repositories.add/+components/repository-item.tsx
+++ b/app/routes/$orgSlug/settings/repositories.add/+components/repository-item.tsx
@@ -9,10 +9,12 @@ export const RepositoryItem = ({
   repo,
   isAdded,
   isLast,
+  installationId,
 }: {
   repo: Repository
   isAdded: boolean
   isLast: boolean
+  installationId: number | null
 }) => {
   const fetcher = useFetcher({
     key: `repo-${repo.owner}/${repo.name}`,
@@ -38,6 +40,13 @@ export const RepositoryItem = ({
       <fetcher.Form method="POST">
         <input type="hidden" name="owner" value={repo.owner} />
         <input type="hidden" name="name" value={repo.name} />
+        {installationId !== null && (
+          <input
+            type="hidden"
+            name="installationId"
+            value={String(installationId)}
+          />
+        )}
         <Button
           type="submit"
           size="sm"

--- a/app/routes/$orgSlug/settings/repositories.add/+functions/get-installation-repos.test.ts
+++ b/app/routes/$orgSlug/settings/repositories.add/+functions/get-installation-repos.test.ts
@@ -4,6 +4,7 @@ import {
   extractOwners,
   fetchAllInstallationRepos,
   filterInstallationRepos,
+  type TaggedInstallationRepo,
 } from './get-installation-repos'
 
 describe('get-installation-repos', () => {
@@ -22,45 +23,54 @@ describe('get-installation-repos', () => {
   })
 
   test('extractOwners returns sorted unique logins', () => {
-    const repos = [
-      { owner: { login: 'zebra' } },
-      { owner: { login: 'alpha' } },
-      { owner: { login: 'alpha' } },
-    ] as Awaited<ReturnType<typeof fetchAllInstallationRepos>>
+    const tagged = [
+      { installationId: 1, repo: { owner: { login: 'zebra' } } },
+      { installationId: 1, repo: { owner: { login: 'alpha' } } },
+      { installationId: 2, repo: { owner: { login: 'alpha' } } },
+    ] as unknown as TaggedInstallationRepo[]
 
-    expect(extractOwners(repos)).toEqual(['alpha', 'zebra'])
+    expect(extractOwners(tagged)).toEqual(['alpha', 'zebra'])
   })
 
   test('filterInstallationRepos filters by owner and keyword and maps fields', () => {
-    const repos = [
+    const tagged = [
       {
-        id: 1,
-        node_id: 'R_kgDOA',
-        name: 'foo-bar',
-        full_name: 'acme/foo-bar',
-        private: true,
-        owner: { login: 'acme' },
-        pushed_at: '2024-01-02T00:00:00Z',
+        installationId: 100,
+        repo: {
+          id: 1,
+          node_id: 'R_kgDOA',
+          name: 'foo-bar',
+          full_name: 'acme/foo-bar',
+          private: true,
+          owner: { login: 'acme' },
+          pushed_at: '2024-01-02T00:00:00Z',
+        },
       },
       {
-        id: 2,
-        node_id: 'R_kgDOB',
-        name: 'other',
-        full_name: 'acme/other',
-        private: false,
-        owner: { login: 'acme' },
-        pushed_at: null,
+        installationId: 100,
+        repo: {
+          id: 2,
+          node_id: 'R_kgDOB',
+          name: 'other',
+          full_name: 'acme/other',
+          private: false,
+          owner: { login: 'acme' },
+          pushed_at: null,
+        },
       },
       {
-        id: 3,
-        name: 'nope',
-        owner: { login: 'other-org' },
-        private: true,
-        pushed_at: null,
+        installationId: 200,
+        repo: {
+          id: 3,
+          name: 'nope',
+          owner: { login: 'other-org' },
+          private: true,
+          pushed_at: null,
+        },
       },
-    ] as Awaited<ReturnType<typeof fetchAllInstallationRepos>>
+    ] as unknown as TaggedInstallationRepo[]
 
-    const result = filterInstallationRepos(repos, 'acme', 'bar')
+    const result = filterInstallationRepos(tagged, 'acme', 'bar')
     expect(result).toHaveLength(1)
     expect(result[0]).toEqual({
       id: 'R_kgDOA',
@@ -68,30 +78,33 @@ describe('get-installation-repos', () => {
       owner: 'acme',
       visibility: 'private',
       pushedAt: '2024-01-02T00:00:00Z',
+      installationId: 100,
     })
   })
 
   test('filterInstallationRepos falls back to String(id) when node_id is missing', () => {
-    const repos = [
+    const tagged = [
       {
-        id: 42,
-        name: 'no-node-id',
-        full_name: 'acme/no-node-id',
-        private: false,
-        owner: { login: 'acme' },
-        pushed_at: null,
+        installationId: 7,
+        repo: {
+          id: 42,
+          name: 'no-node-id',
+          full_name: 'acme/no-node-id',
+          private: false,
+          owner: { login: 'acme' },
+          pushed_at: null,
+        },
       },
-    ] as Awaited<ReturnType<typeof fetchAllInstallationRepos>>
+    ] as unknown as TaggedInstallationRepo[]
 
-    const result = filterInstallationRepos(repos, 'acme')
+    const result = filterInstallationRepos(tagged, 'acme')
     expect(result).toHaveLength(1)
     expect(result[0].id).toBe('42')
+    expect(result[0].installationId).toBe(7)
   })
 
   test('filterInstallationRepos returns [] when owner is missing', () => {
-    const repos = [] as unknown as Awaited<
-      ReturnType<typeof fetchAllInstallationRepos>
-    >
-    expect(filterInstallationRepos(repos, undefined, 'x')).toEqual([])
+    const tagged = [] as TaggedInstallationRepo[]
+    expect(filterInstallationRepos(tagged, undefined, 'x')).toEqual([])
   })
 })

--- a/app/routes/$orgSlug/settings/repositories.add/+functions/get-installation-repos.ts
+++ b/app/routes/$orgSlug/settings/repositories.add/+functions/get-installation-repos.ts
@@ -11,29 +11,35 @@ export async function fetchAllInstallationRepos(octokit: Octokit) {
 
 type InstallationRepo = Awaited<ReturnType<typeof fetchAllInstallationRepos>>[0]
 
+export type TaggedInstallationRepo = {
+  installationId: number
+  repo: InstallationRepo
+}
+
 /** Extract unique owners from pre-fetched installation repos. */
-export function extractOwners(repos: InstallationRepo[]): string[] {
-  return [...new Set(repos.map((r) => r.owner.login))].sort((a, b) =>
+export function extractOwners(tagged: TaggedInstallationRepo[]): string[] {
+  return [...new Set(tagged.map((t) => t.repo.owner.login))].sort((a, b) =>
     a.localeCompare(b, undefined, { sensitivity: 'base' }),
   )
 }
 
 /** Filter + map pre-fetched installation repos by owner and keyword. */
 export function filterInstallationRepos(
-  repos: InstallationRepo[],
+  tagged: TaggedInstallationRepo[],
   owner?: string,
   keyword?: string,
 ): Repository[] {
   if (!owner) return []
   const kw = keyword?.trim().toLowerCase() ?? ''
-  return repos
-    .filter((r) => r.owner.login === owner)
-    .filter((r) => !kw || r.name.toLowerCase().includes(kw))
-    .map((r) => ({
-      id: r.node_id ?? String(r.id),
-      name: r.name,
-      owner: r.owner.login,
-      visibility: r.visibility ?? (r.private ? 'private' : 'public'),
-      pushedAt: r.pushed_at ?? null,
+  return tagged
+    .filter((t) => t.repo.owner.login === owner)
+    .filter((t) => !kw || t.repo.name.toLowerCase().includes(kw))
+    .map(({ installationId, repo }) => ({
+      id: repo.node_id ?? String(repo.id),
+      name: repo.name,
+      owner: repo.owner.login,
+      visibility: repo.visibility ?? (repo.private ? 'private' : 'public'),
+      pushedAt: repo.pushed_at ?? null,
+      installationId,
     }))
 }

--- a/app/routes/$orgSlug/settings/repositories.add/+functions/get-repositories-by-owner-and-keyword.ts
+++ b/app/routes/$orgSlug/settings/repositories.add/+functions/get-repositories-by-owner-and-keyword.ts
@@ -4,6 +4,11 @@ export interface Repository {
   visibility: string
   owner: string
   pushedAt: string | null
+  /**
+   * Installation that surfaced this repository (for github_app mode). `null`
+   * for token-mode results.
+   */
+  installationId: number | null
 }
 
 interface PageInfo {
@@ -75,6 +80,7 @@ export const getRepositoriesByOwnerAndKeyword = async ({
       visibility: item.visibility ?? 'private',
       owner: item.owner.login,
       pushedAt: item.pushed_at,
+      installationId: null,
     }),
   )
 

--- a/app/routes/$orgSlug/settings/repositories.add/+functions/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.add/+functions/mutations.server.ts
@@ -1,12 +1,24 @@
 import { nanoid } from 'nanoid'
 import { db, sql } from '~/app/services/db.server'
+import { upsertRepositoryMembership } from '~/app/services/github-app-membership.server'
 import { getTenantDb } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
+export type AddRepositoryResult = {
+  id: string
+  /**
+   * `true` when the repository was inserted but the `repository_installation_memberships`
+   * row could not be written. The repo is functional but canonical reassignment
+   * after a future installation removal might be inaccurate until the next
+   * crawl-time membership repair fixes it.
+   */
+  membershipUpsertFailed: boolean
+}
+
 export const addRepository = async (
   organizationId: OrganizationId,
-  data: { owner: string; repo: string },
-) => {
+  data: { owner: string; repo: string; githubInstallationId: number | null },
+): Promise<AddRepositoryResult> => {
   const tenantDb = getTenantDb(organizationId)
 
   const organizationSetting = await tenantDb
@@ -19,7 +31,7 @@ export const addRepository = async (
     .where('organizationId', '=', organizationId)
     .executeTakeFirstOrThrow()
 
-  return await tenantDb
+  const inserted = await tenantDb
     .insertInto('repositories')
     .values({
       id: nanoid(),
@@ -27,6 +39,7 @@ export const addRepository = async (
       provider: integration.provider,
       owner: data.owner,
       repo: data.repo,
+      githubInstallationId: data.githubInstallationId,
       releaseDetectionKey: organizationSetting.releaseDetectionKey,
       releaseDetectionMethod: organizationSetting.releaseDetectionMethod,
       updatedAt: sql`CURRENT_TIMESTAMP`,
@@ -35,6 +48,7 @@ export const addRepository = async (
       cb.columns(['integrationId', 'owner', 'repo']).doUpdateSet((eb) => ({
         owner: eb.ref('excluded.owner'),
         repo: eb.ref('excluded.repo'),
+        githubInstallationId: eb.ref('excluded.githubInstallationId'),
         releaseDetectionKey: eb.ref('excluded.releaseDetectionKey'),
         releaseDetectionMethod: eb.ref('excluded.releaseDetectionMethod'),
         updatedAt: eb.ref('excluded.updatedAt'),
@@ -42,4 +56,26 @@ export const addRepository = async (
     )
     .returning('id')
     .executeTakeFirstOrThrow()
+
+  let membershipUpsertFailed = false
+  if (data.githubInstallationId !== null) {
+    try {
+      await upsertRepositoryMembership({
+        organizationId,
+        installationId: data.githubInstallationId,
+        repositoryId: inserted.id,
+      })
+    } catch (e) {
+      // Repository row is already committed; surface this so callers don't
+      // hide the inconsistency. Crawl-time auto-repair will fix the
+      // membership table on the next pass.
+      console.error(
+        '[addRepository] failed to upsert repository_installation_membership',
+        e,
+      )
+      membershipUpsertFailed = true
+    }
+  }
+
+  return { id: inserted.id, membershipUpsertFailed }
 }

--- a/app/routes/$orgSlug/settings/repositories.add/+functions/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/repositories.add/+functions/mutations.server.ts
@@ -48,7 +48,10 @@ export const addRepository = async (
       cb.columns(['integrationId', 'owner', 'repo']).doUpdateSet((eb) => ({
         owner: eb.ref('excluded.owner'),
         repo: eb.ref('excluded.repo'),
-        githubInstallationId: eb.ref('excluded.githubInstallationId'),
+        // Preserve the existing githubInstallationId when the incoming value
+        // is null (e.g. stale POST from token mode). A null overwrite would
+        // break the link between the repository row and its membership.
+        githubInstallationId: sql`COALESCE(${eb.ref('excluded.githubInstallationId')}, ${sql.ref('repositories.githubInstallationId')})`,
         releaseDetectionKey: eb.ref('excluded.releaseDetectionKey'),
         releaseDetectionMethod: eb.ref('excluded.releaseDetectionMethod'),
         updatedAt: eb.ref('excluded.updatedAt'),

--- a/app/routes/$orgSlug/settings/repositories.add/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories.add/index.tsx
@@ -26,6 +26,7 @@ import {
   Stack,
 } from '~/app/components/ui'
 import { requireOrgOwner } from '~/app/libs/auth.server'
+import { getErrorMessage } from '~/app/libs/error-message'
 import { captureExceptionToSentry } from '~/app/libs/sentry-node.server'
 import { orgContext } from '~/app/middleware/context'
 import { clearOrgCache, getOrgCachedData } from '~/app/services/cache.server'
@@ -283,7 +284,7 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
       return dataWithError(
         {},
         {
-          message: e instanceof Error ? e.message : 'Invalid installation id',
+          message: getErrorMessage(e),
         },
       )
     }

--- a/app/routes/$orgSlug/settings/repositories.add/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories.add/index.tsx
@@ -30,8 +30,11 @@ import { captureExceptionToSentry } from '~/app/libs/sentry-node.server'
 import { orgContext } from '~/app/middleware/context'
 import { clearOrgCache, getOrgCachedData } from '~/app/services/cache.server'
 import { durably } from '~/app/services/durably.server'
-import { getGithubAppLink } from '~/app/services/github-integration-queries.server'
-import { resolveOctokitFromOrg } from '~/app/services/github-octokit.server'
+import {
+  assertInstallationBelongsToOrg,
+  getActiveInstallationOptions,
+} from '~/app/services/github-integration-queries.server'
+import { resolveOctokitForInstallation } from '~/app/services/github-octokit.server'
 import { crawlRepoConcurrencyKey } from '~/app/services/jobs/concurrency-keys.server'
 import type { OrganizationId } from '~/app/types/organization'
 import ContentSection from '../+components/content-section'
@@ -40,6 +43,7 @@ import {
   extractOwners,
   fetchAllInstallationRepos,
   filterInstallationRepos,
+  type TaggedInstallationRepo,
 } from './+functions/get-installation-repos'
 import type { Repository } from './+functions/get-repositories-by-owner-and-keyword'
 import { getRepositoriesByOwnerAndKeyword } from './+functions/get-repositories-by-owner-and-keyword'
@@ -53,6 +57,7 @@ export const handle = { breadcrumb: () => ({ label: 'Add Repositories' }) }
 const AddRepoSchema = z.object({
   owner: z.string(),
   name: z.string(),
+  installationId: z.coerce.number().int().positive().optional(),
 })
 
 type IntegrationWithRepositories = NonNullable<
@@ -67,7 +72,12 @@ type AddRepositoriesLoaderData = {
   owners: string[]
   repos: Repository[]
   isGithubAppRepos: boolean
-  appRepositorySelection?: 'all' | 'selected'
+  /** Number of active installations whose appRepositorySelection is `'selected'`. */
+  selectedInstallationCount: number
+  /** Total number of active installations queried. */
+  totalInstallationCount: number
+  /** Installations whose repository fetch failed (so the UI can warn). */
+  failedInstallationIds: number[]
 }
 
 async function loadReposForToken(
@@ -118,6 +128,9 @@ async function loadReposForToken(
     owners,
     repos,
     isGithubAppRepos: false,
+    selectedInstallationCount: 0,
+    totalInstallationCount: 0,
+    failedInstallationIds: [],
   }
 }
 
@@ -127,22 +140,56 @@ async function loadReposForApp(
   owner: string | undefined,
   query: string,
 ): Promise<AddRepositoriesLoaderData> {
-  const githubAppLink = await getGithubAppLink(organizationId)
-  if (!githubAppLink) {
+  const installationOptions = await getActiveInstallationOptions(organizationId)
+  if (installationOptions.length === 0) {
     throw new Error('GitHub App is not connected')
   }
-  const octokit = resolveOctokitFromOrg({ integration, githubAppLink })
+
+  // Fetch every installation's visible repositories in parallel.
+  // Use allSettled so a transient failure on one installation (e.g. revoked
+  // token mid-request) doesn't blank out the entire Add UI.
+  const settled = await Promise.allSettled(
+    installationOptions.map(async (link) => {
+      const octokit = resolveOctokitForInstallation(link.installationId)
+      const repos = await getOrgCachedData(
+        organizationId,
+        `app-installation-all-repos:${link.installationId}`,
+        () => fetchAllInstallationRepos(octokit),
+        300000,
+      )
+      return repos.map(
+        (repo): TaggedInstallationRepo => ({
+          installationId: link.installationId,
+          repo,
+        }),
+      )
+    }),
+  )
+  const failedInstallationIds: number[] = []
+  // Dedupe by `owner/repo`. The createdAt-asc order from
+  // getActiveInstallationOptions makes the *oldest* active installation win,
+  // which keeps the canonical attribution stable across page reloads. The
+  // membership table is the source of truth for "which installations can
+  // see this repo" so this UI choice does not affect crawl correctness.
+  const seen = new Set<string>()
+  const allTagged: TaggedInstallationRepo[] = []
+  settled.forEach((result, index) => {
+    if (result.status === 'rejected') {
+      failedInstallationIds.push(installationOptions[index].installationId)
+      return
+    }
+    for (const tagged of result.value) {
+      const key = `${tagged.repo.owner.login}/${tagged.repo.name}`
+      if (seen.has(key)) continue
+      seen.add(key)
+      allTagged.push(tagged)
+    }
+  })
+
   const registeredOwners = [
     ...new Set(integration.repositories.map((r) => r.owner)),
   ]
-  // Fetch all installation repos once (cached), derive owners + filtered repos
-  const allRepos = await getOrgCachedData(
-    organizationId,
-    'app-installation-all-repos',
-    () => fetchAllInstallationRepos(octokit),
-    300000,
-  )
-  const apiOwners = extractOwners(allRepos)
+  const apiOwners = extractOwners(allTagged)
   const owners = [...new Set([...apiOwners, ...registeredOwners])].sort(
     (a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }),
   )
@@ -150,7 +197,10 @@ async function loadReposForApp(
     throw new Error('invalid owner')
   }
 
-  const repos = filterInstallationRepos(allRepos, owner, query)
+  const repos = filterInstallationRepos(allTagged, owner, query)
+  const selectedInstallationCount = installationOptions.filter(
+    (l) => l.appRepositorySelection === 'selected',
+  ).length
 
   return {
     registeredRepos: integration.repositories,
@@ -159,8 +209,10 @@ async function loadReposForApp(
     owner,
     owners,
     repos,
-    appRepositorySelection: githubAppLink.appRepositorySelection,
     isGithubAppRepos: true,
+    selectedInstallationCount,
+    totalInstallationCount: installationOptions.length,
+    failedInstallationIds,
   }
 }
 
@@ -214,9 +266,34 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
     return dataWithError({}, { message: 'Invalid form submission' })
   }
 
+  let installationId: number | null = null
+  if (integration.method === 'github_app') {
+    if (submission.value.installationId === undefined) {
+      return dataWithError(
+        {},
+        { message: 'Installation id is required for GitHub App mode' },
+      )
+    }
+    try {
+      await assertInstallationBelongsToOrg(
+        organization.id,
+        submission.value.installationId,
+      )
+    } catch (e) {
+      return dataWithError(
+        {},
+        {
+          message: e instanceof Error ? e.message : 'Invalid installation id',
+        },
+      )
+    }
+    installationId = submission.value.installationId
+  }
+
   const inserted = await addRepository(organization.id, {
     owner: submission.value.owner,
     repo: submission.value.name,
+    githubInstallationId: installationId,
   }).catch((e) => {
     console.error('Failed to add repository:', e)
     return null
@@ -225,6 +302,19 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
     return dataWithError(
       {},
       { message: 'Failed to add repository. Please try again.' },
+    )
+  }
+  if (inserted.membershipUpsertFailed) {
+    captureExceptionToSentry(
+      new Error('addRepository: membership upsert failed'),
+      {
+        tags: { component: 'repositories.add', operation: 'membership.upsert' },
+        extra: {
+          organizationId: organization.id,
+          repositoryId: inserted.id,
+          installationId,
+        },
+      },
     )
   }
 
@@ -269,11 +359,19 @@ export default function AddRepositoryPage({
     owner,
     owners,
     repos,
-    appRepositorySelection,
     isGithubAppRepos,
+    selectedInstallationCount,
+    totalInstallationCount,
+    failedInstallationIds,
   },
 }: Route.ComponentProps) {
   const [searchParams, setSearchParams] = useSearchParams()
+
+  const allInstallationsAreSelected =
+    totalInstallationCount > 0 &&
+    selectedInstallationCount === totalInstallationCount
+  const someInstallationsAreSelected =
+    selectedInstallationCount > 0 && !allInstallationsAreSelected
 
   return (
     <ContentSection
@@ -282,12 +380,31 @@ export default function AddRepositoryPage({
       fullWidth
     >
       <Stack>
-        {appRepositorySelection === 'selected' ? (
+        {failedInstallationIds.length > 0 ? (
+          <Alert variant="destructive">
+            <AlertDescription>
+              Failed to load repositories from {failedInstallationIds.length}{' '}
+              installation(s). The list below may be incomplete. Try refreshing
+              or check the GitHub App settings.
+            </AlertDescription>
+          </Alert>
+        ) : null}
+
+        {allInstallationsAreSelected ? (
           <Alert>
             <AlertDescription>
               Only repositories selected in the GitHub App settings are shown.
               You can change which repositories are included in the GitHub App
               settings on GitHub.
+            </AlertDescription>
+          </Alert>
+        ) : someInstallationsAreSelected ? (
+          <Alert>
+            <AlertDescription>
+              Some of your GitHub App installations only expose selected
+              repositories. Repositories from those installations may be missing
+              from this list — adjust the selection in the GitHub App settings
+              if needed.
             </AlertDescription>
           </Alert>
         ) : null}
@@ -388,6 +505,7 @@ export default function AddRepositoryPage({
                   (r) => r.owner === repo.owner && r.repo === repo.name,
                 )}
                 isLast={index === repos.length - 1}
+                installationId={repo.installationId}
               />
             ))
           )}

--- a/app/routes/$orgSlug/settings/repositories.add/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories.add/index.tsx
@@ -309,6 +309,16 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
       )
     } catch (e) {
       console.error('Failed to verify installation access:', e)
+      captureExceptionToSentry(e, {
+        tags: {
+          component: 'repositories.add',
+          operation: 'visibility.check',
+        },
+        extra: {
+          organizationId: organization.id,
+          installationId: submission.value.installationId,
+        },
+      })
       return dataWithError(
         {},
         {

--- a/app/routes/$orgSlug/settings/repositories.add/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories.add/index.tsx
@@ -194,7 +194,11 @@ async function loadReposForApp(
   const owners = [...new Set([...apiOwners, ...registeredOwners])].sort(
     (a, b) => a.localeCompare(b, undefined, { sensitivity: 'base' }),
   )
-  if (owner && !owners.includes(owner)) {
+  // Only reject an unknown owner when every installation's repo list
+  // resolved successfully. If any installation failed, the owner may
+  // legitimately belong to the missing set — degrade gracefully instead
+  // of crashing the page.
+  if (owner && !owners.includes(owner) && failedInstallationIds.length === 0) {
     throw new Error('invalid owner')
   }
 
@@ -286,6 +290,30 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
         {
           message: getErrorMessage(e),
         },
+      )
+    }
+    // Defend against tampered hidden inputs: confirm the installation can
+    // actually see (owner, name) before inserting. `installationId` alone
+    // isn't enough — a malicious form submit could pair a valid org-owned
+    // installation with a repo from a different installation.
+    const octokit = resolveOctokitForInstallation(
+      submission.value.installationId,
+    )
+    const visibleRepos = await getOrgCachedData(
+      organization.id,
+      `app-installation-all-repos:${submission.value.installationId}`,
+      () => fetchAllInstallationRepos(octokit),
+      300000,
+    )
+    const canAccessRepo = visibleRepos.some(
+      (repo) =>
+        repo.owner.login === submission.value.owner &&
+        repo.name === submission.value.name,
+    )
+    if (!canAccessRepo) {
+      return dataWithError(
+        {},
+        { message: 'Selected installation cannot access this repository' },
       )
     }
     installationId = submission.value.installationId

--- a/app/routes/$orgSlug/settings/repositories.add/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories.add/index.tsx
@@ -56,8 +56,8 @@ import type { Route } from './+types/index'
 export const handle = { breadcrumb: () => ({ label: 'Add Repositories' }) }
 
 const AddRepoSchema = z.object({
-  owner: z.string(),
-  name: z.string(),
+  owner: z.string().trim().min(1),
+  name: z.string().trim().min(1),
   installationId: z.coerce.number().int().positive().optional(),
 })
 
@@ -296,15 +296,27 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
     // actually see (owner, name) before inserting. `installationId` alone
     // isn't enough — a malicious form submit could pair a valid org-owned
     // installation with a repo from a different installation.
-    const octokit = resolveOctokitForInstallation(
-      submission.value.installationId,
-    )
-    const visibleRepos = await getOrgCachedData(
-      organization.id,
-      `app-installation-all-repos:${submission.value.installationId}`,
-      () => fetchAllInstallationRepos(octokit),
-      300000,
-    )
+    let visibleRepos: Awaited<ReturnType<typeof fetchAllInstallationRepos>>
+    try {
+      const octokit = resolveOctokitForInstallation(
+        submission.value.installationId,
+      )
+      visibleRepos = await getOrgCachedData(
+        organization.id,
+        `app-installation-all-repos:${submission.value.installationId}`,
+        () => fetchAllInstallationRepos(octokit),
+        300000,
+      )
+    } catch (e) {
+      console.error('Failed to verify installation access:', e)
+      return dataWithError(
+        {},
+        {
+          message:
+            'Could not verify the selected installation. Please try again.',
+        },
+      )
+    }
     const canAccessRepo = visibleRepos.some(
       (repo) =>
         repo.owner.login === submission.value.owner &&

--- a/app/services/github-integration-queries.server.ts
+++ b/app/services/github-integration-queries.server.ts
@@ -58,6 +58,32 @@ export const getGithubAppLinkByInstallationId = async (
   )
 }
 
+export type ActiveInstallationOption = {
+  installationId: number
+  githubOrg: string
+  githubAccountType: string | null
+  appRepositorySelection: 'all' | 'selected'
+}
+
+/**
+ * Active (non-deleted, non-suspended) installations for an org in the shape
+ * UI loaders need for installation selectors. Suspended links are excluded
+ * because they can't be used for API calls.
+ */
+export const getActiveInstallationOptions = async (
+  organizationId: OrganizationId,
+): Promise<ActiveInstallationOption[]> => {
+  const links = await getGithubAppLinks(organizationId)
+  return links
+    .filter((l) => l.suspendedAt === null)
+    .map((l) => ({
+      installationId: l.installationId,
+      githubOrg: l.githubOrg,
+      githubAccountType: l.githubAccountType,
+      appRepositorySelection: l.appRepositorySelection,
+    }))
+}
+
 /**
  * Boundary guard for client-provided `installationId`. Throws if the
  * installation does not belong to the given org or is deleted/suspended.

--- a/app/services/github-integration-queries.server.ts
+++ b/app/services/github-integration-queries.server.ts
@@ -1,3 +1,4 @@
+import { AppError } from '~/app/libs/app-error'
 import { db } from '~/app/services/db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
@@ -104,14 +105,14 @@ export const assertInstallationBelongsToOrg = async (
     .executeTakeFirst()
 
   if (!link) {
-    throw new Error(
+    throw new AppError(
       `Installation ${installationId} does not belong to this organization`,
     )
   }
   if (link.deletedAt !== null) {
-    throw new Error(`Installation ${installationId} is disconnected`)
+    throw new AppError(`Installation ${installationId} is disconnected`)
   }
   if (link.suspendedAt !== null) {
-    throw new Error(`Installation ${installationId} is suspended`)
+    throw new AppError(`Installation ${installationId} is suspended`)
   }
 }

--- a/app/services/github-integration-queries.server.ts
+++ b/app/services/github-integration-queries.server.ts
@@ -70,6 +70,10 @@ export type ActiveInstallationOption = {
  * Active (non-deleted, non-suspended) installations for an org in the shape
  * UI loaders need for installation selectors. Suspended links are excluded
  * because they can't be used for API calls.
+ *
+ * Order is deterministic: `createdAt ASC` (inherited from {@link getGithubAppLinks}).
+ * Callers that deduplicate repos across installations rely on this to
+ * keep the "oldest installation wins" attribution stable across reloads.
  */
 export const getActiveInstallationOptions = async (
   organizationId: OrganizationId,

--- a/docs/rdd/issue-283-work-plan.md
+++ b/docs/rdd/issue-283-work-plan.md
@@ -149,70 +149,92 @@ RDD: [`issue-283-multiple-github-accounts.md`](./issue-283-multiple-github-accou
 
 **ブランチ**: `feat/issue-283-ui` (base: 直前の PR ブランチ、`gt create` で作成)
 
+**UX 哲学** (PR 4 実装中に確立、Vercel/Netlify 風):
+
+ユーザーには「installation」概念を意識させない。リポジトリ一覧やユーザー検索では複数 installation を裏で merge して 1 リストとして見せ、各リポジトリは内部的に「どの installation 経由で見えていたか」を保持する。Installation そのものの管理は integration settings 画面でだけ行う。
+
 **スコープ**:
 
 - `app/routes/$orgSlug/settings/integration/index.tsx` + `_index/+forms/integration-settings.tsx`:
-  - `githubAppLinks[]` 表示
+  - `githubAppLinks[]` 表示（**ここだけは installation 単位カードで明示**）
   - installation 単位 connected / suspended / deleted バッジ
   - `Add another GitHub account` ボタン
   - personal account / org の URL 分岐 (`github_account_type`)
-  - installation 単位 disconnect
-- `app/routes/$orgSlug/settings/repositories.add/index.tsx` + `+functions/queries.server.ts` + `+functions/mutations.server.ts`:
-  - installation selector（loader / action / cache key に `installationId` 反映）
-  - `github_app` モードで installation 必須
-  - server-side で `assertInstallationBelongsToOrg()` による検証
-  - `addRepository()` mutation に `githubInstallationId` 引数追加
+  - installation 単位 disconnect (per-installation fetcher + ConfirmDialog)
+  - action は CLAUDE.md 規約に従い `parseWithZod` + `match.exhaustive` の discriminated union パターンへ refactor
+- `app/routes/$orgSlug/settings/repositories.add/`:
+  - **installation selector を出さない**。全 active installation の repo を `Promise.allSettled` で並列 fetch → owner/repo で dedupe → 1 リスト表示
+  - 各 repository は `TaggedInstallationRepo` (`{ installationId, repo }` wrapper) として元 installation を tag
+  - `Add` ボタン押下時、その repo の `installationId` を hidden input で submit
+  - server action 側で `assertInstallationBelongsToOrg()` を呼び、client 由来 `installationId` を検証
+  - `addRepository()` mutation に `githubInstallationId` 引数追加 + `upsertRepositoryMembership()` 呼び出し
+  - `fetchAllInstallationRepos` の cache key は per-installation
+  - 1 installation の fetch 失敗時は警告 Alert を表示（他は引き続き使える）
+  - `selected` notice は installation の状態（all / mixed / none）で 3 状態表示
 - `app/routes/$orgSlug/settings/github-users._index/`:
-  - installation selector
-  - `searchGithubUsers()` API に `installationId` 引数
-  - server-side 検証
-- `assertInstallationBelongsToOrg()` は PR 2 で既に追加済み。本 PR では loader / action から呼び出すだけ
+  - **installation selector を出さない**。`search.users` は global API なので、`getActiveInstallationOptions()` の最初の active installation を裏で使う
+- 共有 helpers:
+  - `app/libs/github-account.ts`: `formatGithubAccountLabel`, `isPersonalAccount`, `buildInstallationSettingsUrl`
+  - `app/services/github-integration-queries.server.ts`: `getActiveInstallationOptions(orgId)`
 - e2e / route テスト更新
 
 **満たす受入条件**: 1, 4, 5, 13, 14, 15, 17, 21
 **注意**:
 
-- `repositories.add` の cache key を `installationId` 込みに変更すること（既存固定 key の漏れに注意）
-- personal account の URL は `/settings/installations/<id>`、org は `/organizations/<login>/settings/installations`
+- `repositories.add` の cache key を per-installation (`app-installation-all-repos:<id>`) に変更
+- personal account の URL は `/settings/installations/<id>`、organization は `/organizations/<login>/settings/installations`
+- dedupe 順序は createdAt asc（古い installation が勝つ）。membership table が真実なので UI 表示の attribution は crawl 動作には影響しない
 
 **テスト要件**:
 
-- `assertInstallationBelongsToOrg()` で他 org の installation / deleted / suspended を弾くこと
-- `repositories.add` の cache key が installation 切替で正しく無効化されること
-- selector を持たない personal account の文言と URL が正しく分岐すること
+- `assertInstallationBelongsToOrg()` で他 org の installation / deleted / suspended を弾く
+- `TaggedInstallationRepo` wrapper の filter / dedupe ロジック
+- personal account / organization の URL 分岐
 
 ---
 
-### PR 5: PR webhook lookup 強化 + repository list/detail の installation 表示 + assignment required UI
+### PR 5: assignment required の救済 UI + 再割当 mutation + batch CLI
 
 **ブランチ**: `feat/issue-283-repo-ui` (base: 直前の PR ブランチ、`gt create` で作成)
+
+**UX 哲学**: PR 4 の Vercel 哲学に従い、通常時は repository 一覧/詳細に installation 名を出さない。canonical installation を失って `github_installation_id IS NULL` になった repository（broken state）だけを救済導線として可視化する。
 
 **スコープ**:
 
 - `app/routes/$orgSlug/settings/repositories._index/queries.server.ts`:
-  - `github_installation_id` を select に追加
-  - `assignment required` 判定
+  - `github_installation_id` を select に追加（broken 判定用）
 - `app/routes/$orgSlug/settings/repositories._index/index.tsx`:
-  - installation 名 / `assignment required` バッジ表示
-  - 再選択フォーム
-- 注: `repositories.add/+functions/queries.server.ts` は PR 4 が触る。本 PR は触らない
-- `app/routes/$orgSlug/settings/repositories/$repository/queries.server.ts` / `$pull/`:
-  - installation 情報を含めて取得
-- 注: `github_installation_id` を select する箇所が PR 3 (webhook lookup) と PR 5 (一覧 / 詳細) に分散するため、共通 select fragment を `app/services/github-integration-queries.server.ts` 等に切り出すことを検討する。本 PR で実施するか PR 3 にバックポートするかは実装時に判断
-- 個別 repository の installation 再選択 mutation:
-  - PR 3 で実装する canonical reassignment helper を再利用する
-  - target installation が `repository_installation_memberships` に `deleted_at IS NULL` で存在することを必ず検証
-  - 検証に通らない installation を指定した場合はエラーを返す
-  - cross-store 整合性ルール（tenant first / shared second）に従う
-- batch 側に `reassign-repository-installation` CLI 補助コマンド追加（同 helper を共有）
+  - `integrations.method === 'github_app'` かつ `github_installation_id IS NULL` の repository に「Needs reconnection」バッジ（または同等の visual cue）
+  - tooltip / help text で「GitHub App installation が外れた、再割当を試行してください」と説明
+  - 1 クリック「Try auto-reassign」ボタン:
+    - PR 3 の canonical reassignment helper (`reassignCanonicalAfterLinkLoss`) を呼び直す mutation
+    - 成功（候補 1 件で reassign） → トースト + バッジ消失
+    - 失敗（候補 0 件 or 2+ 件） → トーストでヘルプ（reinstall 推奨 or org admin に連絡）
+- mutation:
+  - `reassignBrokenRepository(orgId, repositoryId)` を repositories.add の +functions に追加
+  - 内部で canonical reassignment helper を呼ぶ
+  - cross-store 整合性ルール（tenant first / shared second）+ audit log
+- batch CLI:
+  - `batch/commands/reassign-repository-installation.ts` を追加
+  - 引数: `<organizationId>` または `<organizationId> <repositoryId>`
+  - 全 broken repository に対して canonical reassignment を順次実行
+  - 運用者が一括修復に使う
 
-**満たす受入条件**: 7, 18
+**スコープ外（Vercel 哲学に従い意図的に削除）**:
+
+- 通常 repository 一覧/詳細での installation 名表示
+- 個別 repository の installation 手動 dropdown 選択 UI
+- `repositories/$repository/queries.server.ts` / `$pull/` の変更（installation 情報は出さない）
+
+**満たす受入条件**: 7（broken 復旧経路）, 18（assignment required 表示）
 
 **テスト要件**:
 
-- 再選択 mutation: target installation が membership に存在しないケースでエラーを返す
-- 再選択 mutation: 検証通過時に `repositories.github_installation_id` 更新と `github_app_link_events` 記録が両方行われる
-- list / detail loader が `assignment required` を正しく判定する
+- mutation: broken でない repo に対して呼ぶと no-op で成功
+- mutation: 候補 0 件のときエラーを返し audit log に `assignment_required` が記録される
+- mutation: 候補 1 件のとき `repositories.github_installation_id` 更新 + `canonical_reassigned` 監査ログ
+- list loader が `github_installation_id IS NULL` を正しく検出
+- batch CLI コマンドが組織内の broken repo すべてに helper を呼ぶ
 
 ---
 


### PR DESCRIPTION
## Summary

Issue #283 の実装 stack **PR 4/7** — settings UI を multi-installation 対応に。Vercel ライクに installation の存在をユーザーに意識させない UX。

設計根拠: [\`docs/rdd/issue-283-multiple-github-accounts.md\`](./docs/rdd/issue-283-multiple-github-accounts.md)
作業計画: [\`docs/rdd/issue-283-work-plan.md\`](./docs/rdd/issue-283-work-plan.md)

依存: #288 (PR 1: schema), #296 (PR 2: query/octokit), #290 (PR 3: webhook/membership)

## 変更内容

### integration page (\`app/routes/$orgSlug/settings/integration/index.tsx\`)

- loader が \`githubAppLinks[]\` 配列で各 installation の状態 (suspended / membership_initialized) を返す
- action を **discriminated union + parseWithZod + match.exhaustive** に refactor (CLAUDE.md 規約準拠、200 行 if-chain → ts-pattern)
- 新 INTENTS: \`disconnectGithubAppLink\`, \`confirmDisconnectGithubAppLink\`
- per-installation disconnect (\`assertInstallationBelongsToOrg\` 検証)

### GitHub App セクション UI

- \`InstallationCard\` で active installation を 1 枚ずつカード表示
- カードごとに fetcher + ConfirmDialog (installationId を保持できる)
- \`Add another GitHub account\` ボタン (1 件以上接続済みのとき)
- personal account / organization で GitHub 設定 URL を分岐 (\`buildInstallationSettingsUrl\`)

### repositories.add page (Vercel 風 merge UI)

- **installation selector を出さない**: 全 active installation の repo を並列 fetch → owner/repo で dedupe → 1 リスト表示
- 各 repo は元 installation を tag (\`TaggedInstallationRepo\`)
- ユーザーが Add 押下時、その repo の \`installationId\` が hidden input で submit される
- action 側で \`assertInstallationBelongsToOrg\` を server-side 検証
- \`addRepository\` mutation に \`githubInstallationId\` 引数追加 + \`upsertRepositoryMembership\` 呼び出し
- \`fetchAllInstallationRepos\` cache key を per-installation に変更

### github-users page

- **installation selector を出さない**: \`search.users\` は global API なので、複数 active link があれば最初を裏で使う
- \`searchGithubUsers\` を installationId 引数なしに簡素化
- toolbar / loader / table から installation 関連 UI 削除

### 共有 helpers

- \`app/libs/github-account.ts\`:
  - \`formatGithubAccountLabel\` (personal は \`@login\`, org はそのまま)
  - \`isPersonalAccount\`
  - \`buildInstallationSettingsUrl\` (User → \`/settings/installations/<id>\`, Organization → \`/organizations/<login>/settings/installations\`)
- \`app/services/github-integration-queries.server.ts\`:
  - \`getActiveInstallationOptions\` 共通 helper

## 満たす受入条件

- **#1**: 同一 org で複数 installation を接続できる (UI で確認可能)
- **#4**: repository 追加時に installationId が記録される (UI 上は merge されているが裏で installationId が紐付く)
- **#5**: github-users で複数 installation 環境でも検索可能 (active link を裏で選択)
- **#13/#14/#15**: integration UI の installation 単位表示 / Add another / personal/org URL 分岐
- **#17**: server-side で client 由来 installationId を検証
- **#21**: 1 件目のみは selector なしでデフォルト動作

## Stack 位置

\`\`\`text
PR 1 (#288): schema
└ PR 2 (#296): query/octokit
  └ PR 3 (#290): webhook/membership
    └ [PR 4: UI] ← this PR
      └ PR 5 (repo UI)
        └ PR 6 (backfill)
          └ PR 7 (strict)
\`\`\`

## UX 哲学

最初は installation selector で実装したが、Vercel など先行サービスが「installation を意識させない」UX を取っているのを参考に書き直し。ユーザーは repository を選ぶだけでよく、installation は内部の attribution として透過的に処理される。

## テスト

- [x] \`pnpm validate\` (lint / format / typecheck / build / test 全 339 tests)
- [x] \`get-installation-repos.test.ts\` を \`TaggedInstallationRepo\` 対応に更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * 各GitHub Appインストールを個別カードで表示し、アカウント表示ラベルとインストール設定への直接リンクを追加。

* **改善**
  * インストール単位の接続解除（確認付き）と専用意図を導入。リポジトリ追加は全アクティブインストールを並列取得・重複排除し、各リポジトリにインストールIDを保持。ユーザー検索はアクティブインストールを順次試行するフォールバックを実装。

* **ドキュメント**
  * 統合UXと回復フロー案を更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
