### PR TITLE
feat(repo-ui): broken repository recovery (#283 PR 5/7)

### DIFF
--- a/app/libs/github-account.ts
+++ b/app/libs/github-account.ts
@@ -54,3 +54,15 @@ export const buildInstallationSettingsUrl = (
   }
   return null
 }
+
+/**
+ * Predicate for the "broken repository" state: a repository whose canonical
+ * GitHub App installation was lost (e.g. the installation was uninstalled and
+ * canonical reassignment found 0 or 2+ candidates). Shared between the
+ * repositories list UI and the batch CLI command.
+ */
+export const isRepositoryBroken = (
+  repo: { githubInstallationId: number | null },
+  integrationMethod: 'token' | 'github_app' | null,
+): boolean =>
+  integrationMethod === 'github_app' && repo.githubInstallationId === null

--- a/app/routes/$orgSlug/settings/repositories._index/+components/repo-columns.tsx
+++ b/app/routes/$orgSlug/settings/repositories._index/+components/repo-columns.tsx
@@ -1,5 +1,5 @@
 import type { ColumnDef } from '@tanstack/react-table'
-import { ExternalLinkIcon } from 'lucide-react'
+import { AlertTriangleIcon, ExternalLinkIcon } from 'lucide-react'
 import { Link, useFetcher } from 'react-router'
 import { match } from 'ts-pattern'
 import {
@@ -8,13 +8,52 @@ import {
   SelectItem,
   SelectTrigger,
   SelectValue,
+  Tooltip,
+  TooltipContent,
+  TooltipTrigger,
 } from '~/app/components/ui'
 import { Badge } from '~/app/components/ui/badge'
+import { Button } from '~/app/components/ui/button'
 import { Checkbox } from '~/app/components/ui/checkbox'
+import { isRepositoryBroken } from '~/app/libs/github-account'
 import type { TeamRow } from '../../teams._index/queries.server'
 import type { RepositoryRow } from '../queries.server'
 import { DataTableColumnHeader } from './data-table-column-header'
 import { RepoRowActions } from './repo-row-actions'
+
+function NeedsReconnectionBadge({ repositoryId }: { repositoryId: string }) {
+  const fetcher = useFetcher()
+  const isReassigning = fetcher.state !== 'idle'
+  return (
+    <span className="ml-2 inline-flex items-center gap-1">
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <Badge variant="destructive" className="gap-1">
+            <AlertTriangleIcon className="h-3 w-3" />
+            Needs reconnection
+          </Badge>
+        </TooltipTrigger>
+        <TooltipContent>
+          The GitHub App installation that owned this repository was removed.
+          Click Reassign to try another active installation, or reinstall the
+          GitHub App.
+        </TooltipContent>
+      </Tooltip>
+      <fetcher.Form method="post">
+        <input type="hidden" name="intent" value="reassignBroken" />
+        <input type="hidden" name="repositoryId" value={repositoryId} />
+        <Button
+          type="submit"
+          size="sm"
+          variant="outline"
+          loading={isReassigning}
+        >
+          Reassign
+        </Button>
+      </fetcher.Form>
+    </span>
+  )
+}
 
 function TeamSelect({
   repositoryId,
@@ -56,6 +95,7 @@ function TeamSelect({
 export const createColumns = (
   orgSlug: string,
   teams: TeamRow[],
+  integrationMethod: 'token' | 'github_app' | null,
 ): ColumnDef<RepositoryRow>[] => [
   {
     id: 'select',
@@ -86,20 +126,24 @@ export const createColumns = (
       <DataTableColumnHeader column={column} title="Repository" />
     ),
     cell: ({ row }) => {
-      const { owner, repo, provider } = row.original
+      const { id, owner, repo, provider } = row.original
       const repoUrl = match(provider)
         .with('github', () => `https://github.com/${owner}/${repo}`)
         .otherwise(() => '')
+      const isBroken = isRepositoryBroken(row.original, integrationMethod)
       return (
-        <Link
-          to={repoUrl}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="inline-flex items-center gap-1 font-medium hover:underline"
-        >
-          {owner}/{repo}
-          <ExternalLinkIcon className="h-3 w-3" />
-        </Link>
+        <span className="inline-flex items-center gap-1">
+          <Link
+            to={repoUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="inline-flex items-center gap-1 font-medium hover:underline"
+          >
+            {owner}/{repo}
+            <ExternalLinkIcon className="h-3 w-3" />
+          </Link>
+          {isBroken && <NeedsReconnectionBadge repositoryId={id} />}
+        </span>
       )
     },
     enableHiding: false,

--- a/app/routes/$orgSlug/settings/repositories._index/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories._index/index.tsx
@@ -59,12 +59,7 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
       getIntegration(organization.id),
     ])
 
-  const integrationMethod: 'token' | 'github_app' | null =
-    integration?.method === 'github_app'
-      ? 'github_app'
-      : integration?.method === 'token'
-        ? 'token'
-        : null
+  const integrationMethod = integration?.method ?? null
 
   return {
     organization,

--- a/app/routes/$orgSlug/settings/repositories._index/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories._index/index.tsx
@@ -182,6 +182,12 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
               },
             ),
           )
+          .with({ status: 'not_found' }, () =>
+            dataWithError(
+              { ok: false, lastResult: null },
+              { message: 'Repository not found.' },
+            ),
+          )
           .with({ status: 'not_broken' }, () =>
             dataWithSuccess(
               { ok: true, lastResult: null },

--- a/app/routes/$orgSlug/settings/repositories._index/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories._index/index.tsx
@@ -7,6 +7,8 @@ import { z } from 'zod'
 import { isOrgOwner } from '~/app/libs/auth.server'
 import { getErrorMessage } from '~/app/libs/error-message'
 import { orgContext } from '~/app/middleware/context'
+import { reassignBrokenRepository } from '~/app/services/github-app-membership.server'
+import { getIntegration } from '~/app/services/github-integration-queries.server'
 import ContentSection from '../+components/content-section'
 import { listTeams } from '../teams._index/queries.server'
 import { createColumns } from './+components/repo-columns'
@@ -42,17 +44,27 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
     per_page: searchParams.get('per_page'),
   })
 
-  const { data: repositories, pagination } = await listFilteredRepositories({
-    organizationId: organization.id,
-    repo,
-    teamId: team || undefined,
-    currentPage,
-    pageSize,
-    sortBy,
-    sortOrder,
-  })
+  const [{ data: repositories, pagination }, teams, integration] =
+    await Promise.all([
+      listFilteredRepositories({
+        organizationId: organization.id,
+        repo,
+        teamId: team || undefined,
+        currentPage,
+        pageSize,
+        sortBy,
+        sortOrder,
+      }),
+      listTeams(organization.id),
+      getIntegration(organization.id),
+    ])
 
-  const teams = await listTeams(organization.id)
+  const integrationMethod: 'token' | 'github_app' | null =
+    integration?.method === 'github_app'
+      ? 'github_app'
+      : integration?.method === 'token'
+        ? 'token'
+        : null
 
   return {
     organization,
@@ -60,6 +72,7 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
     pagination,
     teams,
     canAddRepositories: isOrgOwner(membership.role),
+    integrationMethod,
   }
 }
 
@@ -80,9 +93,15 @@ const bulkUpdateTeamSchema = z.object({
   teamId: nullableTeamId,
 })
 
+const reassignBrokenSchema = z.object({
+  intent: z.literal('reassignBroken'),
+  repositoryId: z.string().min(1),
+})
+
 const actionSchema = z.discriminatedUnion('intent', [
   updateTeamSchema,
   bulkUpdateTeamSchema,
+  reassignBrokenSchema,
 ])
 
 export const action = async ({ request, context }: Route.ActionArgs) => {
@@ -132,6 +151,50 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
         { message: `${repositoryIds.length}件のチームを変更しました` },
       )
     })
+    .with({ intent: 'reassignBroken' }, async ({ repositoryId }) => {
+      try {
+        const result = await reassignBrokenRepository({
+          organizationId: organization.id,
+          repositoryId,
+          source: 'manual_reassign',
+        })
+        return match(result)
+          .with({ status: 'reassigned' }, () =>
+            dataWithSuccess(
+              { ok: true, lastResult: null },
+              { message: 'Repository reassigned to an active installation.' },
+            ),
+          )
+          .with({ status: 'no_candidates' }, () =>
+            dataWithError(
+              { ok: false, lastResult: null },
+              {
+                message:
+                  'No active installation can see this repository. Reinstall the GitHub App and try again.',
+              },
+            ),
+          )
+          .with({ status: 'ambiguous' }, ({ candidateCount }) =>
+            dataWithError(
+              { ok: false, lastResult: null },
+              {
+                message: `${candidateCount} installations can see this repository. Manual reassignment is required — disconnect the unwanted installations to resolve.`,
+              },
+            ),
+          )
+          .with({ status: 'not_broken' }, () =>
+            dataWithSuccess(
+              { ok: true, lastResult: null },
+              { message: 'Repository is already assigned.' },
+            ),
+          )
+          .exhaustive()
+      } catch (e) {
+        console.error('Failed to reassign broken repository:', e)
+        const message = getErrorMessage(e)
+        return dataWithError({ ok: false, lastResult: null }, { message })
+      }
+    })
     .exhaustive()
 }
 
@@ -142,10 +205,14 @@ export default function OrganizationRepositoryIndexPage({
     pagination,
     teams,
     canAddRepositories,
+    integrationMethod,
   },
 }: Route.ComponentProps) {
   const slug = organization.slug
-  const columns = useMemo(() => createColumns(slug, teams), [slug, teams])
+  const columns = useMemo(
+    () => createColumns(slug, teams, integrationMethod),
+    [slug, teams, integrationMethod],
+  )
 
   return (
     <ContentSection

--- a/app/routes/$orgSlug/settings/repositories._index/index.tsx
+++ b/app/routes/$orgSlug/settings/repositories._index/index.tsx
@@ -174,6 +174,15 @@ export const action = async ({ request, context }: Route.ActionArgs) => {
               },
             ),
           )
+          .with({ status: 'pending_initialization' }, () =>
+            dataWithError(
+              { ok: false, lastResult: null },
+              {
+                message:
+                  'An installation is pending membership initialization. Please wait a moment and try again.',
+              },
+            ),
+          )
           .with({ status: 'ambiguous' }, ({ candidateCount }) =>
             dataWithError(
               { ok: false, lastResult: null },

--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -660,4 +660,20 @@ describe('reassignBrokenRepository', () => {
     })
     expect(result).toEqual({ status: 'pending_initialization' })
   })
+
+  test('suspended + uninitialized link → no_candidates (not pending_initialization)', async () => {
+    await insertLink(ALT_INSTALLATION, {
+      suspendedAt: '2026-04-07T00:00:00Z',
+      membershipInitializedAt: null,
+    })
+    await seedBrokenRepo()
+    await insertMembership(ALT_INSTALLATION)
+
+    const result = await reassignBrokenRepository({
+      organizationId: ORG_ID,
+      repositoryId: REPO_ID,
+      source: 'manual_reassign',
+    })
+    expect(result).toEqual({ status: 'no_candidates' })
+  })
 })

--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -648,7 +648,7 @@ describe('reassignBrokenRepository', () => {
     expect(result).toEqual({ status: 'no_candidates' })
   })
 
-  test('uninitialized link is excluded from candidates', async () => {
+  test('uninitialized link → pending_initialization', async () => {
     await insertLink(ALT_INSTALLATION, { membershipInitializedAt: null })
     await seedBrokenRepo()
     await insertMembership(ALT_INSTALLATION)
@@ -658,6 +658,6 @@ describe('reassignBrokenRepository', () => {
       repositoryId: REPO_ID,
       source: 'manual_reassign',
     })
-    expect(result).toEqual({ status: 'no_candidates' })
+    expect(result).toEqual({ status: 'pending_initialization' })
   })
 })

--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -14,7 +14,10 @@ import {
 import { closeDb, db } from '~/app/services/db.server'
 import { closeAllTenantDbs } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
-import { reassignCanonicalAfterLinkLoss } from './github-app-membership.server'
+import {
+  reassignBrokenRepository,
+  reassignCanonicalAfterLinkLoss,
+} from './github-app-membership.server'
 
 const ORG_ID = 'org-test' as OrganizationId
 const LOST_INSTALLATION = 100
@@ -482,5 +485,179 @@ describe('reassignCanonicalAfterLinkLoss', () => {
       .selectAll()
       .execute()
     expect(events).toHaveLength(0)
+  })
+})
+
+describe('reassignBrokenRepository', () => {
+  const seedBrokenRepo = async () => {
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const tenantDb = getTenantDb(ORG_ID)
+    await tenantDb
+      .insertInto('repositories')
+      .values({
+        id: REPO_ID,
+        integrationId: 'int-1',
+        provider: 'github',
+        owner: 'octo',
+        repo: 'hello',
+        githubInstallationId: null,
+        updatedAt: '2026-04-07T00:00:00Z',
+      })
+      .execute()
+  }
+
+  beforeEach(async () => {
+    await db.deleteFrom('githubAppLinkEvents').execute()
+    await db.deleteFrom('githubAppLinks').execute()
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const tenantDb = getTenantDb(ORG_ID)
+    await tenantDb.deleteFrom('repositoryInstallationMemberships').execute()
+    await tenantDb.deleteFrom('repositories').execute()
+  })
+
+  test('1 eligible candidate → reassigned + canonical_reassigned event', async () => {
+    await insertLink(ALT_INSTALLATION)
+    await seedBrokenRepo()
+    await insertMembership(ALT_INSTALLATION)
+
+    const result = await reassignBrokenRepository({
+      organizationId: ORG_ID,
+      repositoryId: REPO_ID,
+      source: 'manual_reassign',
+    })
+
+    expect(result).toEqual({
+      status: 'reassigned',
+      installationId: ALT_INSTALLATION,
+    })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBe(ALT_INSTALLATION)
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events.map((e) => e.eventType)).toEqual(['canonical_reassigned'])
+  })
+
+  test('0 candidates → no_candidates, no audit event written', async () => {
+    await seedBrokenRepo()
+
+    const result = await reassignBrokenRepository({
+      organizationId: ORG_ID,
+      repositoryId: REPO_ID,
+      source: 'manual_reassign',
+    })
+
+    expect(result).toEqual({ status: 'no_candidates' })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBeNull()
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events).toHaveLength(0)
+  })
+
+  test('2+ candidates → ambiguous, no audit event written', async () => {
+    await insertLink(ALT_INSTALLATION)
+    await insertLink(SECOND_ALT_INSTALLATION)
+    await seedBrokenRepo()
+    await insertMembership(ALT_INSTALLATION)
+    await insertMembership(SECOND_ALT_INSTALLATION)
+
+    const result = await reassignBrokenRepository({
+      organizationId: ORG_ID,
+      repositoryId: REPO_ID,
+      source: 'manual_reassign',
+    })
+
+    expect(result).toEqual({ status: 'ambiguous', candidateCount: 2 })
+
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', REPO_ID)
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBeNull()
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events).toHaveLength(0)
+  })
+
+  test('not_broken: repo already has a canonical installation → no event', async () => {
+    await insertLink(ALT_INSTALLATION)
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const tenantDb = getTenantDb(ORG_ID)
+    await tenantDb
+      .insertInto('repositories')
+      .values({
+        id: REPO_ID,
+        integrationId: 'int-1',
+        provider: 'github',
+        owner: 'octo',
+        repo: 'hello',
+        githubInstallationId: ALT_INSTALLATION,
+        updatedAt: '2026-04-07T00:00:00Z',
+      })
+      .execute()
+
+    const result = await reassignBrokenRepository({
+      organizationId: ORG_ID,
+      repositoryId: REPO_ID,
+      source: 'manual_reassign',
+    })
+    expect(result).toEqual({ status: 'not_broken' })
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events).toHaveLength(0)
+  })
+
+  test('suspended link is excluded from candidates', async () => {
+    await insertLink(ALT_INSTALLATION, {
+      suspendedAt: '2026-04-07T00:00:00Z',
+    })
+    await seedBrokenRepo()
+    await insertMembership(ALT_INSTALLATION)
+
+    const result = await reassignBrokenRepository({
+      organizationId: ORG_ID,
+      repositoryId: REPO_ID,
+      source: 'manual_reassign',
+    })
+    expect(result).toEqual({ status: 'no_candidates' })
+  })
+
+  test('uninitialized link is excluded from candidates', async () => {
+    await insertLink(ALT_INSTALLATION, { membershipInitializedAt: null })
+    await seedBrokenRepo()
+    await insertMembership(ALT_INSTALLATION)
+
+    const result = await reassignBrokenRepository({
+      organizationId: ORG_ID,
+      repositoryId: REPO_ID,
+      source: 'manual_reassign',
+    })
+    expect(result).toEqual({ status: 'no_candidates' })
   })
 })

--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -676,4 +676,19 @@ describe('reassignBrokenRepository', () => {
     })
     expect(result).toEqual({ status: 'no_candidates' })
   })
+
+  test('not_found: non-existent repositoryId → no event', async () => {
+    const result = await reassignBrokenRepository({
+      organizationId: ORG_ID,
+      repositoryId: 'missing-repo-id',
+      source: 'manual_reassign',
+    })
+    expect(result).toEqual({ status: 'not_found' })
+
+    const events = await db
+      .selectFrom('githubAppLinkEvents')
+      .selectAll()
+      .execute()
+    expect(events).toHaveLength(0)
+  })
 })

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -1,9 +1,6 @@
 import { db } from '~/app/services/db.server'
 import type { GithubAppLinkEventSource } from '~/app/services/github-app-link-events.server'
-import {
-  logGithubAppLinkEvent,
-  tryLogGithubAppLinkEvent,
-} from '~/app/services/github-app-link-events.server'
+import { tryLogGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
 import { getTenantDb } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
@@ -53,6 +50,7 @@ export type ReassignBrokenRepositoryResult =
   | { status: 'reassigned'; installationId: number }
   | { status: 'no_candidates' }
   | { status: 'ambiguous'; candidateCount: number }
+  | { status: 'not_found' }
   | { status: 'not_broken' }
 
 /**
@@ -68,6 +66,7 @@ export type ReassignBrokenRepositoryResult =
  *   - `reassigned`: a single eligible candidate was found, repo is now fixed
  *   - `no_candidates`: no installation can see this repo; user must reinstall
  *   - `ambiguous`: 2+ candidates, manual choice needed
+ *   - `not_found`: no repository row exists for the given ID
  *   - `not_broken`: repository already has a `github_installation_id` set
  */
 export async function reassignBrokenRepository(input: {
@@ -83,7 +82,7 @@ export async function reassignBrokenRepository(input: {
     .select(['id', 'githubInstallationId'])
     .where('id', '=', repositoryId)
     .executeTakeFirst()
-  if (!repo) return { status: 'not_broken' }
+  if (!repo) return { status: 'not_found' }
   if (repo.githubInstallationId !== null) return { status: 'not_broken' }
 
   const { ids: eligibleSet } =
@@ -106,7 +105,7 @@ export async function reassignBrokenRepository(input: {
       .set({ githubInstallationId: nextCanonical })
       .where('id', '=', repositoryId)
       .execute()
-    await logGithubAppLinkEvent({
+    await tryLogGithubAppLinkEvent({
       organizationId,
       installationId: nextCanonical,
       eventType: 'canonical_reassigned',

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -1,6 +1,9 @@
 import { db } from '~/app/services/db.server'
 import type { GithubAppLinkEventSource } from '~/app/services/github-app-link-events.server'
-import { tryLogGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
+import {
+  logGithubAppLinkEvent,
+  tryLogGithubAppLinkEvent,
+} from '~/app/services/github-app-link-events.server'
 import { getTenantDb } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
@@ -12,6 +15,115 @@ export type ReassignmentSource = Extract<
   | 'cli_repair'
   | 'manual_reassign'
 >
+
+/**
+ * Active GitHub App installation ids that are eligible to receive a canonical
+ * reassignment for a repository: not deleted, not suspended, and with their
+ * `repository_installation_memberships` initialized.
+ */
+async function fetchEligibleInstallationIds(
+  organizationId: OrganizationId,
+  options: { excludeInstallationId?: number } = {},
+): Promise<{ ids: Set<number>; hasUninitializedLink: boolean }> {
+  let linkQuery = db
+    .selectFrom('githubAppLinks')
+    .select(['installationId', 'suspendedAt', 'membershipInitializedAt'])
+    .where('organizationId', '=', organizationId)
+    .where('deletedAt', 'is', null)
+  if (options.excludeInstallationId !== undefined) {
+    linkQuery = linkQuery.where(
+      'installationId',
+      '!=',
+      options.excludeInstallationId,
+    )
+  }
+  const links = await linkQuery.execute()
+  const ids = new Set(
+    links
+      .filter((l) => !l.suspendedAt && l.membershipInitializedAt !== null)
+      .map((l) => l.installationId),
+  )
+  const hasUninitializedLink = links.some(
+    (l) => l.membershipInitializedAt === null,
+  )
+  return { ids, hasUninitializedLink }
+}
+
+export type ReassignBrokenRepositoryResult =
+  | { status: 'reassigned'; installationId: number }
+  | { status: 'no_candidates' }
+  | { status: 'ambiguous'; candidateCount: number }
+  | { status: 'not_broken' }
+
+/**
+ * Try to assign a canonical installation to a single repository whose
+ * `github_installation_id` is currently `NULL`. Used by the "Try auto-reassign"
+ * UI button and the `reassign-repository-installation` CLI command.
+ *
+ * Eligibility rules match {@link reassignCanonicalAfterLinkLoss}: candidate
+ * link must be active, non-suspended, and have `membership_initialized_at` set;
+ * membership row must be active.
+ *
+ * Returns a discriminated result so callers can show the appropriate UI:
+ *   - `reassigned`: a single eligible candidate was found, repo is now fixed
+ *   - `no_candidates`: no installation can see this repo; user must reinstall
+ *   - `ambiguous`: 2+ candidates, manual choice needed
+ *   - `not_broken`: repository already has a `github_installation_id` set
+ */
+export async function reassignBrokenRepository(input: {
+  organizationId: OrganizationId
+  repositoryId: string
+  source: Extract<GithubAppLinkEventSource, 'manual_reassign' | 'cli_repair'>
+}): Promise<ReassignBrokenRepositoryResult> {
+  const { organizationId, repositoryId, source } = input
+  const tenantDb = getTenantDb(organizationId)
+
+  const repo = await tenantDb
+    .selectFrom('repositories')
+    .select(['id', 'githubInstallationId'])
+    .where('id', '=', repositoryId)
+    .executeTakeFirst()
+  if (!repo) return { status: 'not_broken' }
+  if (repo.githubInstallationId !== null) return { status: 'not_broken' }
+
+  const { ids: eligibleSet } =
+    await fetchEligibleInstallationIds(organizationId)
+
+  const memberships = await tenantDb
+    .selectFrom('repositoryInstallationMemberships')
+    .select(['installationId'])
+    .where('repositoryId', '=', repositoryId)
+    .where('deletedAt', 'is', null)
+    .execute()
+  const candidates = memberships
+    .map((m) => m.installationId)
+    .filter((id) => eligibleSet.has(id))
+
+  if (candidates.length === 1) {
+    const nextCanonical = candidates[0]
+    await tenantDb
+      .updateTable('repositories')
+      .set({ githubInstallationId: nextCanonical })
+      .where('id', '=', repositoryId)
+      .execute()
+    await logGithubAppLinkEvent({
+      organizationId,
+      installationId: nextCanonical,
+      eventType: 'canonical_reassigned',
+      source,
+      status: 'success',
+      details: { repositoryId, candidateCount: 1, recoveredFromBroken: true },
+    })
+    return { status: 'reassigned', installationId: nextCanonical }
+  }
+
+  // Skip the audit log entry for the no-candidates / ambiguous cases: there is
+  // no installation to attribute the event to (and the audit table requires a
+  // non-null `installationId`). The function return value already conveys the
+  // outcome to the UI / CLI caller, which surfaces it via toast / console.
+  if (candidates.length === 0) return { status: 'no_candidates' }
+  return { status: 'ambiguous', candidateCount: candidates.length }
+}
 
 /**
  * Replace `repository.github_installation_id` when a link is lost. By default
@@ -46,21 +158,10 @@ export async function reassignCanonicalAfterLinkLoss(input: {
 }): Promise<void> {
   const { organizationId, lostInstallationId, source, repositoryIds } = input
 
-  const links = await db
-    .selectFrom('githubAppLinks')
-    .select(['installationId', 'suspendedAt', 'membershipInitializedAt'])
-    .where('organizationId', '=', organizationId)
-    .where('deletedAt', 'is', null)
-    .where('installationId', '!=', lostInstallationId)
-    .execute()
-  const eligibleSet = new Set(
-    links
-      .filter((l) => !l.suspendedAt && l.membershipInitializedAt !== null)
-      .map((l) => l.installationId),
-  )
-  const hasUninitializedLink = links.some(
-    (l) => l.membershipInitializedAt === null,
-  )
+  const { ids: eligibleSet, hasUninitializedLink } =
+    await fetchEligibleInstallationIds(organizationId, {
+      excludeInstallationId: lostInstallationId,
+    })
 
   const tenantDb = getTenantDb(organizationId)
 

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -41,7 +41,7 @@ async function fetchEligibleInstallationIds(
       .map((l) => l.installationId),
   )
   const hasUninitializedLink = links.some(
-    (l) => l.membershipInitializedAt === null,
+    (l) => !l.suspendedAt && l.membershipInitializedAt === null,
   )
   return { ids, hasUninitializedLink }
 }

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -49,6 +49,7 @@ async function fetchEligibleInstallationIds(
 export type ReassignBrokenRepositoryResult =
   | { status: 'reassigned'; installationId: number }
   | { status: 'no_candidates' }
+  | { status: 'pending_initialization' }
   | { status: 'ambiguous'; candidateCount: number }
   | { status: 'not_found' }
   | { status: 'not_broken' }
@@ -65,6 +66,7 @@ export type ReassignBrokenRepositoryResult =
  * Returns a discriminated result so callers can show the appropriate UI:
  *   - `reassigned`: a single eligible candidate was found, repo is now fixed
  *   - `no_candidates`: no installation can see this repo; user must reinstall
+ *   - `pending_initialization`: an installation exists but membership init hasn't completed yet
  *   - `ambiguous`: 2+ candidates, manual choice needed
  *   - `not_found`: no repository row exists for the given ID
  *   - `not_broken`: repository already has a `github_installation_id` set
@@ -85,7 +87,7 @@ export async function reassignBrokenRepository(input: {
   if (!repo) return { status: 'not_found' }
   if (repo.githubInstallationId !== null) return { status: 'not_broken' }
 
-  const { ids: eligibleSet } =
+  const { ids: eligibleSet, hasUninitializedLink } =
     await fetchEligibleInstallationIds(organizationId)
 
   const memberships = await tenantDb
@@ -120,7 +122,11 @@ export async function reassignBrokenRepository(input: {
   // no installation to attribute the event to (and the audit table requires a
   // non-null `installationId`). The function return value already conveys the
   // outcome to the UI / CLI caller, which surfaces it via toast / console.
-  if (candidates.length === 0) return { status: 'no_candidates' }
+  if (candidates.length === 0) {
+    return hasUninitializedLink
+      ? { status: 'pending_initialization' }
+      : { status: 'no_candidates' }
+  }
   return { status: 'ambiguous', candidateCount: candidates.length }
 }
 

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -56,7 +56,7 @@ export type ReassignBrokenRepositoryResult =
 /**
  * Try to assign a canonical installation to a single repository whose
  * `github_installation_id` is currently `NULL`. Used by the "Try auto-reassign"
- * UI button and the `reassign-repository-installation` CLI command.
+ * UI button and the `reassign-broken-repositories` CLI command.
  *
  * Eligibility rules match {@link reassignCanonicalAfterLinkLoss}: candidate
  * link must be active, non-suspended, and have `membership_initialized_at` set;

--- a/batch/cli.ts
+++ b/batch/cli.ts
@@ -145,6 +145,32 @@ const report = command(
   },
 )
 
+const reassignBrokenRepositories = command(
+  {
+    name: 'reassign-broken-repositories',
+    parameters: ['[organization id]'],
+    flags: {
+      repository: {
+        type: String,
+        description:
+          'Reassign a single repository by id (default: every broken repo)',
+      },
+    },
+    help: {
+      description:
+        'Reassign repositories whose canonical GitHub App installation was lost. Picks a new canonical from the membership table when exactly one eligible candidate exists.',
+    },
+  },
+  async (argv) => {
+    const { reassignBrokenRepositoriesCommand } =
+      await import('./commands/reassign-broken-repositories')
+    await reassignBrokenRepositoriesCommand({
+      organizationId: argv._.organizationId,
+      repositoryId: argv.flags.repository,
+    })
+  },
+)
+
 process.on('unhandledRejection', async (error) => {
   captureExceptionToSentry(error, { tags: { component: 'batch-cli' } })
   await flushSentryNode()
@@ -152,5 +178,12 @@ process.on('unhandledRejection', async (error) => {
 })
 
 cli({
-  commands: [crawl, processCmd, classify, backfill, report],
+  commands: [
+    crawl,
+    processCmd,
+    classify,
+    backfill,
+    report,
+    reassignBrokenRepositories,
+  ],
 })

--- a/batch/commands/reassign-broken-repositories.ts
+++ b/batch/commands/reassign-broken-repositories.ts
@@ -51,6 +51,7 @@ export async function reassignBrokenRepositoriesCommand(
       not_found: 0,
       not_broken: 0,
     }
+    let failed = 0
     for (const repo of broken) {
       const label = `${repo.owner}/${repo.repo}`
       try {
@@ -85,10 +86,11 @@ export async function reassignBrokenRepositoriesCommand(
           )
           .exhaustive()
       } catch (e) {
+        failed++
         consola.error(`${label}:`, e)
       }
     }
-    consola.info('Summary:', counts)
+    consola.info('Summary:', { ...counts, failed })
   } finally {
     await shutdown()
   }

--- a/batch/commands/reassign-broken-repositories.ts
+++ b/batch/commands/reassign-broken-repositories.ts
@@ -21,13 +21,13 @@ interface ReassignBrokenRepositoriesCommandProps {
 export async function reassignBrokenRepositoriesCommand(
   props: ReassignBrokenRepositoriesCommandProps,
 ) {
-  const result = await requireOrganization(props.organizationId)
-  if (!result) return
-
-  const { orgId } = result
-  const tenantDb = getTenantDb(orgId)
-
   try {
+    const result = await requireOrganization(props.organizationId)
+    if (!result) return
+
+    const { orgId } = result
+    const tenantDb = getTenantDb(orgId)
+
     let query = tenantDb
       .selectFrom('repositories')
       .select(['id', 'owner', 'repo'])

--- a/batch/commands/reassign-broken-repositories.ts
+++ b/batch/commands/reassign-broken-repositories.ts
@@ -45,6 +45,7 @@ export async function reassignBrokenRepositoriesCommand(
     const counts = {
       reassigned: 0,
       no_candidates: 0,
+      pending_initialization: 0,
       ambiguous: 0,
       not_found: 0,
       not_broken: 0,
@@ -69,6 +70,11 @@ export async function reassignBrokenRepositoriesCommand(
           )
           .with({ status: 'no_candidates' }, () =>
             consola.warn(`${label}: no active installation can see this repo`),
+          )
+          .with({ status: 'pending_initialization' }, () =>
+            consola.warn(
+              `${label}: installation pending membership initialization`,
+            ),
           )
           .with({ status: 'not_found' }, () =>
             consola.warn(`${label}: repository not found`),

--- a/batch/commands/reassign-broken-repositories.ts
+++ b/batch/commands/reassign-broken-repositories.ts
@@ -1,0 +1,84 @@
+import consola from 'consola'
+import { match } from 'ts-pattern'
+import { reassignBrokenRepository } from '~/app/services/github-app-membership.server'
+import { getTenantDb } from '~/app/services/tenant-db.server'
+import { requireOrganization } from './helpers'
+import { shutdown } from './shutdown'
+
+interface ReassignBrokenRepositoriesCommandProps {
+  organizationId?: string
+  repositoryId?: string
+}
+
+/**
+ * Operator command to recover repositories whose canonical
+ * `github_installation_id` was lost. Walks every broken repository in the org
+ * (or a single one if `repositoryId` is given) and asks
+ * {@link reassignBrokenRepository} to assign a new canonical from the
+ * membership table.
+ */
+export async function reassignBrokenRepositoriesCommand(
+  props: ReassignBrokenRepositoriesCommandProps,
+) {
+  const result = await requireOrganization(props.organizationId)
+  if (!result) return
+
+  const { orgId } = result
+  const tenantDb = getTenantDb(orgId)
+
+  try {
+    let query = tenantDb
+      .selectFrom('repositories')
+      .select(['id', 'owner', 'repo'])
+      .where('githubInstallationId', 'is', null)
+    if (props.repositoryId) {
+      query = query.where('id', '=', props.repositoryId)
+    }
+    const broken = await query.execute()
+
+    if (broken.length === 0) {
+      consola.info('No broken repositories found.')
+      return
+    }
+    consola.info(`Found ${broken.length} broken repositories. Reassigning...`)
+
+    const counts = {
+      reassigned: 0,
+      no_candidates: 0,
+      ambiguous: 0,
+      not_broken: 0,
+    }
+    for (const repo of broken) {
+      const label = `${repo.owner}/${repo.repo}`
+      try {
+        const outcome = await reassignBrokenRepository({
+          organizationId: orgId,
+          repositoryId: repo.id,
+          source: 'cli_repair',
+        })
+        counts[outcome.status]++
+        match(outcome)
+          .with({ status: 'reassigned' }, ({ installationId }) =>
+            consola.success(`${label} → installation ${installationId}`),
+          )
+          .with({ status: 'ambiguous' }, ({ candidateCount }) =>
+            consola.warn(
+              `${label}: ${candidateCount} candidates, manual disconnect required`,
+            ),
+          )
+          .with({ status: 'no_candidates' }, () =>
+            consola.warn(`${label}: no active installation can see this repo`),
+          )
+          .with({ status: 'not_broken' }, () =>
+            consola.info(`${label}: already assigned`),
+          )
+          .exhaustive()
+      } catch (e) {
+        consola.error(`${label}:`, e)
+      }
+    }
+    consola.info('Summary:', counts)
+  } finally {
+    await shutdown()
+  }
+}

--- a/batch/commands/reassign-broken-repositories.ts
+++ b/batch/commands/reassign-broken-repositories.ts
@@ -46,6 +46,7 @@ export async function reassignBrokenRepositoriesCommand(
       reassigned: 0,
       no_candidates: 0,
       ambiguous: 0,
+      not_found: 0,
       not_broken: 0,
     }
     for (const repo of broken) {
@@ -68,6 +69,9 @@ export async function reassignBrokenRepositoriesCommand(
           )
           .with({ status: 'no_candidates' }, () =>
             consola.warn(`${label}: no active installation can see this repo`),
+          )
+          .with({ status: 'not_found' }, () =>
+            consola.warn(`${label}: repository not found`),
           )
           .with({ status: 'not_broken' }, () =>
             consola.info(`${label}: already assigned`),

--- a/batch/commands/reassign-broken-repositories.ts
+++ b/batch/commands/reassign-broken-repositories.ts
@@ -1,5 +1,6 @@
 import consola from 'consola'
 import { match } from 'ts-pattern'
+import type { ReassignBrokenRepositoryResult } from '~/app/services/github-app-membership.server'
 import { reassignBrokenRepository } from '~/app/services/github-app-membership.server'
 import { getTenantDb } from '~/app/services/tenant-db.server'
 import { requireOrganization } from './helpers'
@@ -42,7 +43,7 @@ export async function reassignBrokenRepositoriesCommand(
     }
     consola.info(`Found ${broken.length} broken repositories. Reassigning...`)
 
-    const counts = {
+    const counts: Record<ReassignBrokenRepositoryResult['status'], number> = {
       reassigned: 0,
       no_candidates: 0,
       pending_initialization: 0,


### PR DESCRIPTION
## Summary

Issue #283 の実装 stack **PR 5/7** — broken state（`github_installation_id IS NULL`）の repository を救済する UI / mutation / batch CLI を追加。

設計根拠: [\`docs/rdd/issue-283-multiple-github-accounts.md\`](./docs/rdd/issue-283-multiple-github-accounts.md)
作業計画: [\`docs/rdd/issue-283-work-plan.md\`](./docs/rdd/issue-283-work-plan.md)

依存: #288 (PR 1: schema), #296 (PR 2: query/octokit), #290 (PR 3: webhook/membership), #291 (PR 4: UI)

## UX 哲学

PR 4 の Vercel 哲学を継承し、**通常時は repository 一覧/詳細に installation 名を出さない**。canonical installation を失った broken state の repository だけを救済導線として可視化する。

## 変更内容

### service helper (\`app/services/github-app-membership.server.ts\`)

- \`fetchEligibleInstallationIds()\` 内部 helper 抽出 — \`reassignCanonicalAfterLinkLoss\` と \`reassignBrokenRepository\` で eligible link 取得ロジックを共有
- \`reassignBrokenRepository(orgId, repoId, source)\` 追加
  - canonical installation を持たない repo に対して membership table から候補を引いて再割当を試みる
  - 結果を discriminated union で返す: \`reassigned | no_candidates | ambiguous | not_broken\`
  - 1 候補 → \`canonical_reassigned\` audit log を書く
  - 0 候補 / 2+ 候補 → 戻り値で表現、audit log は書かない（installationId が無いため）
- \`isRepositoryBroken()\` を \`app/libs/github-account.ts\` に追加（client-safe）

### route mutation (\`app/routes/$orgSlug/settings/repositories._index/\`)

- loader が \`integrationMethod\` を \`'token' | 'github_app' | null\` で返す
- action に \`reassignBroken\` intent 追加（\`source: 'manual_reassign'\`）
- discriminated union を \`match.exhaustive\` でハンドリング

### UI (\`+components/repo-columns.tsx\`)

- \`NeedsReconnectionBadge\` コンポーネント
  - \`isRepositoryBroken(repo, integrationMethod)\` で判定
  - destructive variant Badge + \`AlertTriangleIcon\` + tooltip
  - 1-click "Reassign" ボタン (per-row \`useFetcher\`)
- 結果別 toast:
  - 成功 → "Repository reassigned to an active installation."
  - 候補 0 → "No active installation can see this repository. Reinstall the GitHub App and try again."
  - 候補 2+ → "Disconnect the unwanted installations to resolve."

### batch CLI (\`batch/commands/reassign-broken-repositories.ts\`)

- \`pnpm batch reassign-broken-repositories <orgId> [--repository <id>]\`
- broken repository を全て列挙 → 順次 \`reassignBrokenRepository\` (\`source: 'cli_repair'\`)
- 結果集計と各 repo の状況を consola で出力
- \`match.exhaustive\` で網羅性確保

### tests

- \`github-app-membership.server.test.ts\` に 6 ケース追加:
  - 1 候補 → reassigned + canonical_reassigned event
  - 0 候補 → no_candidates (audit log なし)
  - 2+ 候補 → ambiguous (audit log なし)
  - not_broken（既に canonical あり）
  - suspended link は候補から除外
  - 未初期化 link は候補から除外

## 満たす受入条件

- **#7**: 失われた canonical installation の repository 救済経路
- **#18**: assignment required 状態の表示と再割当 UI

## Stack 位置

\`\`\`text
PR 1 (#288): schema
└ PR 2 (#296): query/octokit
  └ PR 3 (#290): webhook/membership
    └ PR 4 (#291): UI
      └ [PR 5: repo UI] ← this PR
        └ PR 6 (backfill)
          └ PR 7 (strict)
\`\`\`

## テスト

- [x] \`pnpm validate\` (lint / format / typecheck / build / test 全 345 tests)
- [x] \`reassignBrokenRepository\` の 6 ケースをユニットテストでカバー

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * GitHub App連携で「接続切れ（broken）」判定を共通化するチェックを追加
  * リポジトリ一覧に警告バッジを表示し、バッジから再割り当て（再接続）操作を実行可能に（操作中の状態表示・ツールチップ付き）
  * 壊れたリポジトリを一括検出・再割り当てするCLIコマンドを追加
* **改善**
  * 設定画面で再接続操作が利用可能になり、結果に応じた通知（成功／候補なし／初期化待ち／あいまい／未該当／未発見）を表示
* **テスト**
  * 再割り当ての主要な結果パスを網羅する自動テストを追加
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
