### PR TITLE
feat(github-app): per-repo Octokit resolution and multi-installation queries (#283 PR 2/7)

### DIFF
--- a/app/services/github-app-link-events.server.ts
+++ b/app/services/github-app-link-events.server.ts
@@ -1,0 +1,58 @@
+import type { Kysely, Transaction } from 'kysely'
+import { db } from '~/app/services/db.server'
+import type { DB } from '~/app/services/type'
+import type { OrganizationId } from '~/app/types/organization'
+
+export type GithubAppLinkEventType =
+  | 'link_created'
+  | 'link_deleted'
+  | 'link_suspended'
+  | 'link_unsuspended'
+  | 'membership_initialized'
+  | 'membership_repaired'
+  | 'canonical_reassigned'
+  | 'canonical_cleared'
+  | 'assignment_required'
+
+export type GithubAppLinkEventSource =
+  | 'setup_callback'
+  | 'installation_webhook'
+  | 'installation_repositories_webhook'
+  | 'user_disconnect'
+  | 'crawl_repair'
+  | 'manual_reassign'
+  | 'cli_repair'
+
+export type GithubAppLinkEventStatus = 'success' | 'failed' | 'skipped'
+
+export type LogGithubAppLinkEventInput = {
+  organizationId: OrganizationId
+  installationId: number
+  eventType: GithubAppLinkEventType
+  source: GithubAppLinkEventSource
+  status: GithubAppLinkEventStatus
+  details?: Record<string, unknown>
+}
+
+/**
+ * Append an entry to the `github_app_link_events` audit log.
+ *
+ * Pass a transaction to commit the log together with the underlying mutation;
+ * otherwise it writes against the default connection.
+ */
+export const logGithubAppLinkEvent = async (
+  input: LogGithubAppLinkEventInput,
+  dbOrTrx: Kysely<DB> | Transaction<DB> = db,
+): Promise<void> => {
+  await dbOrTrx
+    .insertInto('githubAppLinkEvents')
+    .values({
+      organizationId: input.organizationId,
+      installationId: input.installationId,
+      eventType: input.eventType,
+      source: input.source,
+      status: input.status,
+      detailsJson: input.details ? JSON.stringify(input.details) : null,
+    })
+    .execute()
+}

--- a/app/services/github-app-mutations.server.ts
+++ b/app/services/github-app-mutations.server.ts
@@ -1,26 +1,117 @@
 import { clearOrgCache } from '~/app/services/cache.server'
 import { db } from '~/app/services/db.server'
+import { logGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
 import type { OrganizationId } from '~/app/types/organization'
 
 /**
- * Soft-delete the org's GitHub App link and revert integration to token method.
- * Clears appSuspendedAt so a prior suspend flag cannot linger after disconnect.
+ * Soft-delete a single GitHub App installation link.
+ *
+ * Reverts `integrations.method` to `'token'` (and clears `app_suspended_at`)
+ * only when the deleted link was the last active one for the org.
+ *
+ * Writes a `link_deleted` audit log event with `source='user_disconnect'`.
+ *
+ * Idempotent: a no-op if the link is already deleted or does not exist.
  */
-export async function disconnectGithubApp(organizationId: OrganizationId) {
+export async function disconnectGithubAppLink(
+  organizationId: OrganizationId,
+  installationId: number,
+) {
   const now = new Date().toISOString()
+
   await db.transaction().execute(async (trx) => {
-    await trx
+    const updateResult = await trx
       .updateTable('githubAppLinks')
       .set({ deletedAt: now, updatedAt: now })
       .where('organizationId', '=', organizationId)
+      .where('installationId', '=', installationId)
+      .where('deletedAt', 'is', null)
+      .executeTakeFirst()
+
+    if (updateResult.numUpdatedRows === 0n) return
+
+    const remaining = await trx
+      .selectFrom('githubAppLinks')
+      .select('installationId')
+      .where('organizationId', '=', organizationId)
+      .where('deletedAt', 'is', null)
+      .executeTakeFirst()
+
+    const revertedToToken = !remaining
+    if (revertedToToken) {
+      await trx
+        .updateTable('integrations')
+        .set({ method: 'token', appSuspendedAt: null, updatedAt: now })
+        .where('organizationId', '=', organizationId)
+        .execute()
+    }
+
+    await logGithubAppLinkEvent(
+      {
+        organizationId,
+        installationId,
+        eventType: 'link_deleted',
+        source: 'user_disconnect',
+        status: 'success',
+        details: { revertedToToken },
+      },
+      trx,
+    )
+  })
+
+  clearOrgCache(organizationId)
+}
+
+/**
+ * Soft-delete every active GitHub App link for the org in a single transaction
+ * and revert integration to token method. Convenience for legacy "disconnect all"
+ * UI flows that treat GitHub App as a single org-wide connection.
+ *
+ * Writes one `link_deleted` audit log entry per affected installation.
+ *
+ * @deprecated Prefer {@link disconnectGithubAppLink} for installation-scoped
+ *   disconnects.
+ */
+export async function disconnectGithubApp(organizationId: OrganizationId) {
+  const now = new Date().toISOString()
+
+  await db.transaction().execute(async (trx) => {
+    const links = await trx
+      .selectFrom('githubAppLinks')
+      .select('installationId')
+      .where('organizationId', '=', organizationId)
       .where('deletedAt', 'is', null)
       .execute()
+
+    if (links.length > 0) {
+      await trx
+        .updateTable('githubAppLinks')
+        .set({ deletedAt: now, updatedAt: now })
+        .where('organizationId', '=', organizationId)
+        .where('deletedAt', 'is', null)
+        .execute()
+    }
 
     await trx
       .updateTable('integrations')
       .set({ method: 'token', appSuspendedAt: null, updatedAt: now })
       .where('organizationId', '=', organizationId)
       .execute()
+
+    for (const link of links) {
+      await logGithubAppLinkEvent(
+        {
+          organizationId,
+          installationId: link.installationId,
+          eventType: 'link_deleted',
+          source: 'user_disconnect',
+          status: 'success',
+          details: { revertedToToken: true },
+        },
+        trx,
+      )
+    }
   })
+
   clearOrgCache(organizationId)
 }

--- a/app/services/github-integration-queries.server.ts
+++ b/app/services/github-integration-queries.server.ts
@@ -1,6 +1,17 @@
 import { db } from '~/app/services/db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
+const githubAppLinkColumns = [
+  'organizationId',
+  'installationId',
+  'githubAccountId',
+  'githubAccountType',
+  'githubOrg',
+  'appRepositorySelection',
+  'suspendedAt',
+  'membershipInitializedAt',
+] as const
+
 export const getIntegration = async (organizationId: OrganizationId) => {
   return await db
     .selectFrom('integrations')
@@ -9,13 +20,72 @@ export const getIntegration = async (organizationId: OrganizationId) => {
     .executeTakeFirst()
 }
 
+/**
+ * All active (not deleted) GitHub App links for an organization, ordered by
+ * `createdAt` for deterministic iteration.
+ */
+export const getGithubAppLinks = async (organizationId: OrganizationId) => {
+  return await db
+    .selectFrom('githubAppLinks')
+    .select(githubAppLinkColumns)
+    .where('organizationId', '=', organizationId)
+    .where('deletedAt', 'is', null)
+    .orderBy('createdAt', 'asc')
+    .execute()
+}
+
+/**
+ * Oldest active GitHub App link for an organization, or null.
+ *
+ * @deprecated Returns an arbitrary link when an org has multiple active
+ *   installations. Use {@link getGithubAppLinks} and operate per-installation.
+ */
 export const getGithubAppLink = async (organizationId: OrganizationId) => {
+  const links = await getGithubAppLinks(organizationId)
+  return links[0] ?? null
+}
+
+export const getGithubAppLinkByInstallationId = async (
+  installationId: number,
+) => {
   return (
     (await db
       .selectFrom('githubAppLinks')
-      .select(['githubOrg', 'appRepositorySelection', 'installationId'])
-      .where('organizationId', '=', organizationId)
+      .select([...githubAppLinkColumns, 'deletedAt'])
+      .where('installationId', '=', installationId)
       .where('deletedAt', 'is', null)
       .executeTakeFirst()) ?? null
   )
+}
+
+/**
+ * Boundary guard for client-provided `installationId`. Throws if the
+ * installation does not belong to the given org or is deleted/suspended.
+ *
+ * The query is constrained by `organizationId` first so the database can never
+ * leak the existence of installations from other organizations — even the
+ * "not found" branch only fires when the row is missing *for this org*.
+ */
+export const assertInstallationBelongsToOrg = async (
+  organizationId: OrganizationId,
+  installationId: number,
+): Promise<void> => {
+  const link = await db
+    .selectFrom('githubAppLinks')
+    .select(['suspendedAt', 'deletedAt'])
+    .where('organizationId', '=', organizationId)
+    .where('installationId', '=', installationId)
+    .executeTakeFirst()
+
+  if (!link) {
+    throw new Error(
+      `Installation ${installationId} does not belong to this organization`,
+    )
+  }
+  if (link.deletedAt !== null) {
+    throw new Error(`Installation ${installationId} is disconnected`)
+  }
+  if (link.suspendedAt !== null) {
+    throw new Error(`Installation ${installationId} is suspended`)
+  }
 }

--- a/app/services/github-octokit.server.test.ts
+++ b/app/services/github-octokit.server.test.ts
@@ -1,10 +1,20 @@
-import { afterEach, describe, expect, test, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, test, vi } from 'vitest'
 import {
   assertOrgGithubAuthResolvable,
   createAppOctokit,
   createOctokit,
+  resolveOctokitForInstallation,
+  resolveOctokitForRepository,
   resolveOctokitFromOrg,
 } from './github-octokit.server'
+
+const stubGithubAppEnv = () => {
+  vi.stubEnv('GITHUB_APP_ID', '12345')
+  vi.stubEnv(
+    'GITHUB_APP_PRIVATE_KEY',
+    Buffer.from('fake-pem').toString('base64'),
+  )
+}
 
 describe('createAppOctokit', () => {
   afterEach(() => {
@@ -116,15 +126,154 @@ describe('resolveOctokitFromOrg', () => {
   })
 
   test('github_app path uses createOctokit when env set', () => {
-    vi.stubEnv('GITHUB_APP_ID', '12345')
-    vi.stubEnv(
-      'GITHUB_APP_PRIVATE_KEY',
-      Buffer.from('fake-pem').toString('base64'),
-    )
+    stubGithubAppEnv()
     const o = resolveOctokitFromOrg({
       integration: { method: 'github_app', privateToken: null },
       githubAppLink: { installationId: 42 },
     })
     expect(o).toBeDefined()
+  })
+})
+
+describe('resolveOctokitForInstallation', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  test('returns Octokit for given installation id', () => {
+    stubGithubAppEnv()
+    expect(resolveOctokitForInstallation(99)).toBeDefined()
+  })
+})
+
+describe('resolveOctokitForRepository', () => {
+  beforeEach(() => {
+    stubGithubAppEnv()
+  })
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  const integrationGithubApp = {
+    method: 'github_app',
+    privateToken: null,
+  } as const
+  const integrationToken = {
+    method: 'token',
+    privateToken: 'ghp_test',
+  } as const
+  const integrationTokenEmpty = {
+    method: 'token',
+    privateToken: null,
+  } as const
+
+  describe('github_app mode with explicit installation id on repository', () => {
+    test('uses repository.githubInstallationId when matching link is active', () => {
+      const o = resolveOctokitForRepository({
+        integration: integrationGithubApp,
+        githubAppLinks: [{ installationId: 42, suspendedAt: null }],
+        repository: { githubInstallationId: 42 },
+      })
+      expect(o).toBeDefined()
+    })
+
+    test('throws when matching link does not exist', () => {
+      expect(() =>
+        resolveOctokitForRepository({
+          integration: integrationGithubApp,
+          githubAppLinks: [{ installationId: 99, suspendedAt: null }],
+          repository: { githubInstallationId: 42 },
+        }),
+      ).toThrow(/installation 42 is not active/)
+    })
+
+    test('throws when matching link is suspended', () => {
+      expect(() =>
+        resolveOctokitForRepository({
+          integration: integrationGithubApp,
+          githubAppLinks: [
+            { installationId: 42, suspendedAt: '2026-04-07T00:00:00Z' },
+          ],
+          repository: { githubInstallationId: 42 },
+        }),
+      ).toThrow(/installation 42 is suspended/)
+    })
+  })
+
+  describe('github_app mode transitional fallback (githubInstallationId IS NULL)', () => {
+    test('active link 1 件: uses that installation', () => {
+      const o = resolveOctokitForRepository({
+        integration: integrationGithubApp,
+        githubAppLinks: [{ installationId: 7, suspendedAt: null }],
+        repository: { githubInstallationId: null },
+      })
+      expect(o).toBeDefined()
+    })
+
+    test('active link 0 件: throws (does NOT fall back to PAT)', () => {
+      expect(() =>
+        resolveOctokitForRepository({
+          integration: integrationGithubApp,
+          githubAppLinks: [],
+          repository: { githubInstallationId: null },
+        }),
+      ).toThrow(/GitHub App is not connected/)
+    })
+
+    test('active link 2 件以上: throws backfill required', () => {
+      expect(() =>
+        resolveOctokitForRepository({
+          integration: integrationGithubApp,
+          githubAppLinks: [
+            { installationId: 1, suspendedAt: null },
+            { installationId: 2, suspendedAt: null },
+          ],
+          repository: { githubInstallationId: null },
+        }),
+      ).toThrow(/Backfill required/)
+    })
+
+    test('suspended links are excluded from active count (1 active + 1 suspended → uses active)', () => {
+      const o = resolveOctokitForRepository({
+        integration: integrationGithubApp,
+        githubAppLinks: [
+          { installationId: 1, suspendedAt: null },
+          { installationId: 2, suspendedAt: '2026-04-07T00:00:00Z' },
+        ],
+        repository: { githubInstallationId: null },
+      })
+      expect(o).toBeDefined()
+    })
+  })
+
+  describe('token mode', () => {
+    test('with privateToken: uses PAT', () => {
+      const o = resolveOctokitForRepository({
+        integration: integrationToken,
+        githubAppLinks: [],
+        repository: { githubInstallationId: null },
+      })
+      expect(o).toBeDefined()
+    })
+
+    test('without privateToken: throws', () => {
+      expect(() =>
+        resolveOctokitForRepository({
+          integration: integrationTokenEmpty,
+          githubAppLinks: [],
+          repository: { githubInstallationId: null },
+        }),
+      ).toThrow(/No auth configured/)
+    })
+  })
+
+  test('throws when no integration', () => {
+    expect(() =>
+      resolveOctokitForRepository({
+        integration: null,
+        githubAppLinks: [],
+        repository: { githubInstallationId: null },
+      }),
+    ).toThrow(/No integration configured/)
   })
 })

--- a/app/services/github-octokit.server.ts
+++ b/app/services/github-octokit.server.ts
@@ -47,11 +47,24 @@ export type IntegrationAuth =
   | { method: 'token'; privateToken: string }
   | { method: 'github_app'; installationId: number }
 
+export type IntegrationMethod = 'token' | 'github_app'
+
+export type IntegrationForOctokit = {
+  method: IntegrationMethod | (string & {})
+  privateToken: string | null
+}
+
+export type GithubAppLinkForOctokit = {
+  installationId: number
+  suspendedAt?: string | null
+}
+
+export type RepositoryForOctokit = {
+  githubInstallationId: number | null
+}
+
 export type OrgGithubAuthInput = {
-  integration:
-    | { method: string; privateToken: string | null }
-    | null
-    | undefined
+  integration: IntegrationForOctokit | null | undefined
   githubAppLink: { installationId: number } | null | undefined
 }
 
@@ -68,7 +81,18 @@ export function createOctokit(auth: IntegrationAuth): Octokit {
 }
 
 /**
- * durably step 内で呼べる。Octokit は作らず、ユーザー向けエラーのみ投げる。
+ * Build an Octokit for a specific installation id.
+ */
+export function resolveOctokitForInstallation(installationId: number): Octokit {
+  return createOctokit({ method: 'github_app', installationId })
+}
+
+/**
+ * Single-link sanity check used by legacy callers that still treat GitHub App
+ * as one installation per org. New callers should validate per repository via
+ * {@link resolveOctokitForRepository}.
+ *
+ * @deprecated
  */
 export function assertOrgGithubAuthResolvable(org: OrgGithubAuthInput): void {
   const { integration, githubAppLink } = org
@@ -84,8 +108,68 @@ export function assertOrgGithubAuthResolvable(org: OrgGithubAuthInput): void {
 }
 
 /**
+ * Resolve Octokit for a single repository.
+ *
+ * Strict path: when `repository.githubInstallationId` is set, use the matching
+ * (non-suspended) GitHub App link.
+ *
+ * Transitional fallback for `github_app` mode without an explicit installation id:
+ *   - exactly 1 active link → use it
+ *   - 0 active links → throw (PAT auto-fallback is forbidden by design)
+ *   - 2+ active links → throw (ambiguous; requires explicit assignment)
+ */
+export function resolveOctokitForRepository(input: {
+  integration: IntegrationForOctokit | null | undefined
+  githubAppLinks: GithubAppLinkForOctokit[]
+  repository: RepositoryForOctokit
+}): Octokit {
+  const { integration, githubAppLinks, repository } = input
+  if (!integration) throw new Error('No integration configured')
+
+  if (integration.method === 'github_app') {
+    if (repository.githubInstallationId !== null) {
+      const matched = githubAppLinks.find(
+        (l) => l.installationId === repository.githubInstallationId,
+      )
+      if (!matched) {
+        throw new Error(
+          `GitHub App installation ${repository.githubInstallationId} is not active for this organization`,
+        )
+      }
+      if (matched.suspendedAt) {
+        throw new Error(
+          `GitHub App installation ${repository.githubInstallationId} is suspended`,
+        )
+      }
+      return resolveOctokitForInstallation(matched.installationId)
+    }
+
+    const activeLinks = githubAppLinks.filter((l) => !l.suspendedAt)
+    if (activeLinks.length === 1) {
+      return resolveOctokitForInstallation(activeLinks[0].installationId)
+    }
+    if (activeLinks.length === 0) {
+      throw new Error('GitHub App is not connected')
+    }
+    throw new Error(
+      `Repository has no canonical installation assigned and ${activeLinks.length} active installations exist. Backfill required.`,
+    )
+  }
+
+  if (integration.privateToken) {
+    return createOctokit({
+      method: 'token',
+      privateToken: integration.privateToken,
+    })
+  }
+  throw new Error('No auth configured')
+}
+
+/**
  * org の integration + githubAppLink から Octokit を生成する。
- * method 分岐・エラー判定を1箇所に集約。
+ *
+ * @deprecated Use {@link resolveOctokitForRepository} (per-repo) or
+ *   {@link resolveOctokitForInstallation} (explicit installation id).
  */
 export function resolveOctokitFromOrg(org: OrgGithubAuthInput): Octokit {
   assertOrgGithubAuthResolvable(org)
@@ -100,10 +184,7 @@ export function resolveOctokitFromOrg(org: OrgGithubAuthInput): Octokit {
       githubAppLink,
       'githubAppLink must be set for github_app method after assertOrgGithubAuthResolvable',
     )
-    return createOctokit({
-      method: 'github_app',
-      installationId: githubAppLink.installationId,
-    })
+    return resolveOctokitForInstallation(githubAppLink.installationId)
   }
 
   invariant(

--- a/app/services/jobs/backfill.server.ts
+++ b/app/services/jobs/backfill.server.ts
@@ -1,9 +1,7 @@
 import { defineJob } from '@coji/durably'
 import { z } from 'zod'
-import {
-  assertOrgGithubAuthResolvable,
-  resolveOctokitFromOrg,
-} from '~/app/services/github-octokit.server'
+import { getErrorMessageForLog } from '~/app/libs/error-message'
+import { resolveOctokitForRepository } from '~/app/services/github-octokit.server'
 import type { OrganizationId } from '~/app/types/organization'
 import { getOrganization } from '~/batch/db/queries'
 import { backfillRepo } from '~/batch/github/backfill-repo'
@@ -25,18 +23,24 @@ export const backfillJob = defineJob({
 
     const organization = await step.run('load-organization', () => {
       step.progress(0, 0, 'Loading organization...')
-      assertOrgGithubAuthResolvable({
-        integration: fullOrg.integration,
-        githubAppLink: fullOrg.githubAppLink,
-      })
+      if (!fullOrg.integration) {
+        throw new Error('No integration configured')
+      }
+      if (
+        fullOrg.integration.method === 'github_app' &&
+        fullOrg.githubAppLinks.filter((l) => !l.suspendedAt).length === 0
+      ) {
+        throw new Error('GitHub App is not connected')
+      }
+      if (
+        fullOrg.integration.method === 'token' &&
+        !fullOrg.integration.privateToken
+      ) {
+        throw new Error('No auth configured')
+      }
       return {
         repositories: fullOrg.repositories,
       }
-    })
-
-    const octokit = resolveOctokitFromOrg({
-      integration: fullOrg.integration,
-      githubAppLink: fullOrg.githubAppLink,
     })
 
     const repoCount = organization.repositories.length
@@ -47,6 +51,17 @@ export const backfillJob = defineJob({
 
       await step.run(`backfill:${repoLabel}`, async () => {
         step.progress(i + 1, repoCount, `Backfilling ${repoLabel}...`)
+        let octokit: ReturnType<typeof resolveOctokitForRepository>
+        try {
+          octokit = resolveOctokitForRepository({
+            integration: fullOrg.integration,
+            githubAppLinks: fullOrg.githubAppLinks,
+            repository,
+          })
+        } catch (e) {
+          step.log.warn(`Skipping ${repoLabel}: ${getErrorMessageForLog(e)}`)
+          return
+        }
         await backfillRepo(orgId, repository, octokit, {
           files: input.files,
         })

--- a/app/services/jobs/crawl.server.ts
+++ b/app/services/jobs/crawl.server.ts
@@ -2,10 +2,7 @@ import { defineJob } from '@coji/durably'
 import { z } from 'zod'
 import { getErrorMessageForLog } from '~/app/libs/error-message'
 import { clearOrgCache } from '~/app/services/cache.server'
-import {
-  assertOrgGithubAuthResolvable,
-  resolveOctokitFromOrg,
-} from '~/app/services/github-octokit.server'
+import { resolveOctokitForRepository } from '~/app/services/github-octokit.server'
 import { processConcurrencyKey } from '~/app/services/jobs/concurrency-keys.server'
 import { shouldTriggerFullOrgProcessJob } from '~/app/services/jobs/crawl-process-handoff.server'
 import type { OrganizationId } from '~/app/types/organization'
@@ -45,21 +42,27 @@ export const crawlJob = defineJob({
       if (!fullOrg.organizationSetting) {
         throw new Error('No organization setting configured')
       }
-      assertOrgGithubAuthResolvable({
-        integration: fullOrg.integration,
-        githubAppLink: fullOrg.githubAppLink,
-      })
+      if (!fullOrg.integration) {
+        throw new Error('No integration configured')
+      }
+      if (
+        fullOrg.integration.method === 'github_app' &&
+        fullOrg.githubAppLinks.filter((l) => !l.suspendedAt).length === 0
+      ) {
+        throw new Error('GitHub App is not connected')
+      }
+      if (
+        fullOrg.integration.method === 'token' &&
+        !fullOrg.integration.privateToken
+      ) {
+        throw new Error('No auth configured')
+      }
       return {
         organizationSetting: fullOrg.organizationSetting,
         botLogins: fullOrg.botLogins,
         repositories: fullOrg.repositories,
         exportSetting: fullOrg.exportSetting,
       }
-    })
-
-    const octokit = resolveOctokitFromOrg({
-      integration: fullOrg.integration,
-      githubAppLink: fullOrg.githubAppLink,
     })
 
     const updatedPrNumbers = new Map<string, Set<number>>()
@@ -85,6 +88,11 @@ export const crawlJob = defineJob({
       const repoLabel = `${repo.owner}/${repo.repo}`
 
       try {
+        const octokit = resolveOctokitForRepository({
+          integration: fullOrg.integration,
+          githubAppLinks: fullOrg.githubAppLinks,
+          repository: repo,
+        })
         const store = createStore({
           organizationId: orgId,
           repositoryId: repo.id,

--- a/batch/db/queries.ts
+++ b/batch/db/queries.ts
@@ -37,18 +37,19 @@ const githubAppLinkColumns = [
   'installationId',
   'githubOrg',
   'githubAccountId',
+  'githubAccountType',
   'appRepositorySelection',
+  'suspendedAt',
+  'membershipInitializedAt',
 ] as const
 
-async function getGithubAppLinkByOrgId(organizationId: OrganizationId) {
-  return (
-    (await db
-      .selectFrom('githubAppLinks')
-      .select(githubAppLinkColumns)
-      .where('organizationId', '=', organizationId)
-      .where('deletedAt', 'is', null)
-      .executeTakeFirst()) ?? null
-  )
+async function getGithubAppLinksByOrgId(organizationId: OrganizationId) {
+  return await db
+    .selectFrom('githubAppLinks')
+    .select(githubAppLinkColumns)
+    .where('organizationId', '=', organizationId)
+    .where('deletedAt', 'is', null)
+    .execute()
 }
 
 async function getAllGithubAppLinks() {
@@ -57,7 +58,7 @@ async function getAllGithubAppLinks() {
     .select(githubAppLinkColumns)
     .where('deletedAt', 'is', null)
     .execute()
-  return new Map(rows.map((r) => [r.organizationId, r]))
+  return Map.groupBy(rows, (r) => r.organizationId)
 }
 
 const integrationColumns = [
@@ -156,8 +157,8 @@ export const listAllOrganizations = async () => {
     orgs.map(async (org) => {
       const tenantData = await getTenantData(org.id as OrganizationId)
       const integration = integrationsMap.get(org.id) ?? null
-      const githubAppLink = appLinksMap.get(org.id) ?? null
-      return { ...org, ...tenantData, integration, githubAppLink }
+      const githubAppLinks = appLinksMap.get(org.id) ?? []
+      return { ...org, ...tenantData, integration, githubAppLinks }
     }),
   )
 }
@@ -169,14 +170,13 @@ export const getOrganization = async (organizationId: OrganizationId) => {
     .where('id', '=', organizationId)
     .executeTakeFirstOrThrow()
 
-  const [integration, githubAppLink, tenantData, botLogins] = await Promise.all(
-    [
+  const [integration, githubAppLinks, tenantData, botLogins] =
+    await Promise.all([
       getIntegrationByOrgId(organizationId),
-      getGithubAppLinkByOrgId(organizationId),
+      getGithubAppLinksByOrgId(organizationId),
       getTenantData(organizationId),
       getBotLogins(organizationId),
-    ],
-  )
+    ])
 
-  return { ...org, ...tenantData, botLogins, integration, githubAppLink }
+  return { ...org, ...tenantData, botLogins, integration, githubAppLinks }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,7 @@
   "include": ["**/*.ts", "**/*.tsx", ".react-router/types/**/*"],
   "exclude": ["node_modules", "opensrc"],
   "compilerOptions": {
-    "lib": ["DOM", "DOM.Iterable", "ES2022"],
+    "lib": ["DOM", "DOM.Iterable", "ES2024"],
     "types": ["@types/node", "vite/client"],
     "isolatedModules": true,
     "esModuleInterop": true,


### PR DESCRIPTION
## Summary

Issue #283 の実装 stack **PR 2/7** — query / mutation / Octokit 解決層を複数 installation 対応にする。アプリケーションの動作はまだ変えない（fallback で互換維持）。

設計根拠: [`docs/rdd/issue-283-multiple-github-accounts.md`](./docs/rdd/issue-283-multiple-github-accounts.md)
作業計画: [`docs/rdd/issue-283-work-plan.md`](./docs/rdd/issue-283-work-plan.md)

依存: #288 (PR 1: schema)

## 変更内容

### query 層 (`app/services/github-integration-queries.server.ts`)

- `getGithubAppLinks(orgId)` 配列返却（ORDER BY createdAt ASC で決定的順序）
- `getGithubAppLinkByInstallationId(installationId)` 追加
- `assertInstallationBelongsToOrg(orgId, installationId)` 追加 — クライアント由来の `installationId` をサーバ側で検証する境界 guard
- `getGithubAppLink()` は最古の active link を返す互換 shim（`@deprecated`）

### mutation 層 (`app/services/github-app-mutations.server.ts`)

- `disconnectGithubAppLink(orgId, installationId)` 追加 — 単一 installation の soft-delete + 最後の active を失った時のみ `method='token'` に戻す + audit log 書き込み
- 1 transaction 内で完結（idempotent）
- `disconnectGithubApp()` は legacy UI 互換 wrapper として 1 transaction で全 link 一括 soft-delete に書き換え（`@deprecated`）

### audit log writer (`app/services/github-app-link-events.server.ts`) 新規追加

- `logGithubAppLinkEvent()` helper
- event_type / source / status の string union 型を export
- `Kysely<DB> | Transaction<DB>` を受け取り、呼び出し側のトランザクションに乗せられる
- PR 1 で追加した `github_app_link_events` table の **初回 writer**（disconnect 経由）

### Octokit 解決 (`app/services/github-octokit.server.ts`)

- `resolveOctokitForInstallation(installationId)` 追加
- `resolveOctokitForRepository({ integration, githubAppLinks, repository })` 追加 — repository ごとの解決
  - `repository.githubInstallationId` がセットされている場合は厳密にそれを使う（suspended は弾く）
  - `github_app` モードで未割当の repository に対する移行期間 fallback:
    - active link 1 件 → そのまま使う
    - 0 件 → エラー（**PAT 自動 fallback はしない**、RDD ルール）
    - 2+ 件 → エラー（曖昧、明示的な assignment が必要）
  - `token` モード: `privateToken` があれば PAT、無ければ未接続エラー
- `IntegrationForOctokit.method` を `'token' | 'github_app' | (string & {})` のユニオンに型を絞る
- `resolveOctokitFromOrg()` は legacy 互換 wrapper（`@deprecated`、PR 4 で削除予定）

### batch shape 更新 (`batch/db/queries.ts`)

- `getGithubAppLinkByOrgId` → `getGithubAppLinksByOrgId`（配列返却）
- `getAllGithubAppLinks` を `Map.groupBy` で書き換え
- `getOrganization()` / `listAllOrganizations()` が `githubAppLinks: []` を返すよう変更

### crawl / backfill ジョブ (`app/services/jobs/{crawl,backfill}.server.ts`)

- 単一 Octokit 共有から per-repository 解決に変更
- `load-organization` step 内で `github_app + active 0` / `token + privateToken null` の早期エラー検出
- repository ループ内で `resolveOctokitForRepository()` を呼び、解決失敗時は warn ログ + skip（crawl 全体は止めない）

### tsconfig

- `lib` を `ES2024` に bump（`Map.groupBy` を使うため）

### tests

- `app/services/github-octokit.server.test.ts` に `resolveOctokitForRepository` の 11 ケース追加
  - 明示 installation id (一致 / 不一致 / suspended)
  - 移行期間 fallback (active 1 / 0 / 2+ / suspended 除外)
  - token モード (PAT あり / なし)
  - integration null

## 満たす受入条件

- **#6**: `crawl.server.ts` / `backfill.server.ts` が repository ごとに対応 installation の Octokit を使う

## Stack 位置

```text
PR 1 (#288): schema
└ [PR 2: query/octokit] ← this PR
  └ PR 3 (webhook/membership)
    └ PR 4 (UI)
      └ PR 5 (repo UI)
        └ PR 6 (backfill)
          └ PR 7 (strict)
```

## 後続 PR への影響

- PR 3: webhook handler 群がここで追加した `getGithubAppLinkByInstallationId` / `logGithubAppLinkEvent` / canonical reassignment helper（PR 3 で実装）を使う
- PR 4: UI loader / action から `getGithubAppLink()` を `getGithubAppLinks()` に移行 + `assertInstallationBelongsToOrg` を loader 境界で呼ぶ
- PR 7: 移行期間 fallback (`activeLinks.length === 1` 分岐) を削除し、`github_installation_id IS NULL` を strict エラーにする

## テスト

- [x] \`pnpm validate\` (lint / format / typecheck / build / test 全 331 tests)
- [x] \`resolveOctokitForRepository\` の主要 11 ケースをユニットテストで検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **新機能**
  * GitHub Appのリンク接続・切断イベントに対する監査ログ機能を追加しました。

* **バグ修正**
  * リポジトリごとのGitHub認証解決ロジックを改善し、複数のアクティブなリンク存在時のエラーハンドリングを強化しました。
  * GitHub Appの削除状態をより厳密に追跡するようにしました。

* **改善**
  * GitHub統合に関する検証とエラー処理を堅牢化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
