### PR TITLE
fix: All teams 表示時に personalLimit を全チームの最大値から導出する

### DIFF
--- a/app/routes/$orgSlug/workload/index.tsx
+++ b/app/routes/$orgSlug/workload/index.tsx
@@ -28,7 +28,11 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
     ? (teams.find((t) => t.id === teamParam) ?? null)
     : null
   const teamId = selectedTeam?.id ?? null
-  const personalLimit = selectedTeam?.personalLimit ?? DEFAULT_PERSONAL_LIMIT
+  const personalLimit = selectedTeam
+    ? selectedTeam.personalLimit
+    : teams.length > 0
+      ? Math.max(...teams.map((t) => t.personalLimit))
+      : DEFAULT_PERSONAL_LIMIT
 
   const [openPRs, pendingReviews] = await Promise.all([
     getOpenPullRequests(organization.id, teamId),


### PR DESCRIPTION
## Summary
- All teams 選択時に `personalLimit` が `DEFAULT_PERSONAL_LIMIT = 2` にフォールバックしていた問題を修正
- 全チームの `personalLimit` の `Math.max` を使用するように変更
- チームが0件の場合のみデフォルト値にフォールバック

Closes #295

## Test plan
- [x] 既存テスト通過 (`aggregate-stacks.test.ts`)
- [x] typecheck 通過
- [ ] All teams 表示で personalLimit が各チームの最大値になることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * チームが選択されていない場合の個人上限の計算ロジックを改善しました。利用可能なすべてのチームから最大の個人上限を使用するように変更されました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->