### PR TITLE
fix: set github_installation_id during membership initialization

### DIFF
--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -134,17 +134,20 @@ const insertMembership = async (
     .execute()
 }
 
-const seedRepository = async (canonicalInstallationId: number) => {
+const seedRepository = async (
+  canonicalInstallationId: number | null,
+  opts: { id?: string; owner?: string; repo?: string } = {},
+) => {
   const { getTenantDb } = await import('~/app/services/tenant-db.server')
   const tenantDb = getTenantDb(ORG_ID)
   await tenantDb
     .insertInto('repositories')
     .values({
-      id: REPO_ID,
+      id: opts.id ?? REPO_ID,
       integrationId: 'int-1',
       provider: 'github',
-      owner: 'octo',
-      repo: 'hello',
+      owner: opts.owner ?? 'octo',
+      repo: opts.repo ?? 'hello',
       githubInstallationId: canonicalInstallationId,
       updatedAt: '2026-04-07T00:00:00Z',
     })
@@ -707,22 +710,7 @@ describe('initializeMembershipsForInstallation', () => {
   })
 
   test('sets github_installation_id for repos with null value', async () => {
-    const { getTenantDb } = await import('~/app/services/tenant-db.server')
-    const tenantDb = getTenantDb(ORG_ID)
-
-    // Seed a repository without github_installation_id (PAT-era repo)
-    await tenantDb
-      .insertInto('repositories')
-      .values({
-        id: 'repo-pat',
-        integrationId: 'int-1',
-        provider: 'github',
-        owner: 'octo',
-        repo: 'hello',
-        githubInstallationId: null,
-        updatedAt: '2026-04-07T00:00:00Z',
-      })
-      .execute()
+    await seedRepository(null, { id: 'repo-pat' })
 
     const matched = await initializeMembershipsForInstallation({
       organizationId: ORG_ID,
@@ -732,7 +720,9 @@ describe('initializeMembershipsForInstallation', () => {
 
     expect(matched).toEqual(['repo-pat'])
 
-    // Verify membership was created
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const tenantDb = getTenantDb(ORG_ID)
+
     const memberships = await tenantDb
       .selectFrom('repositoryInstallationMemberships')
       .selectAll()
@@ -740,7 +730,6 @@ describe('initializeMembershipsForInstallation', () => {
     expect(memberships).toHaveLength(1)
     expect(memberships[0].installationId).toBe(INSTALLATION_ID)
 
-    // Verify github_installation_id was set
     const repo = await tenantDb
       .selectFrom('repositories')
       .select('githubInstallationId')
@@ -750,22 +739,11 @@ describe('initializeMembershipsForInstallation', () => {
   })
 
   test('does not overwrite existing github_installation_id', async () => {
-    const { getTenantDb } = await import('~/app/services/tenant-db.server')
-    const tenantDb = getTenantDb(ORG_ID)
     const EXISTING_INSTALLATION = 999
-
-    await tenantDb
-      .insertInto('repositories')
-      .values({
-        id: 'repo-existing',
-        integrationId: 'int-1',
-        provider: 'github',
-        owner: 'octo',
-        repo: 'world',
-        githubInstallationId: EXISTING_INSTALLATION,
-        updatedAt: '2026-04-07T00:00:00Z',
-      })
-      .execute()
+    await seedRepository(EXISTING_INSTALLATION, {
+      id: 'repo-existing',
+      repo: 'world',
+    })
 
     await initializeMembershipsForInstallation({
       organizationId: ORG_ID,
@@ -773,7 +751,8 @@ describe('initializeMembershipsForInstallation', () => {
       repositories: [{ owner: 'octo', name: 'world' }],
     })
 
-    const repo = await tenantDb
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const repo = await getTenantDb(ORG_ID)
       .selectFrom('repositories')
       .select('githubInstallationId')
       .where('id', '=', 'repo-existing')

--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -752,12 +752,24 @@ describe('initializeMembershipsForInstallation', () => {
     })
 
     const { getTenantDb } = await import('~/app/services/tenant-db.server')
-    const repo = await getTenantDb(ORG_ID)
+    const tenantDb = getTenantDb(ORG_ID)
+
+    const repo = await tenantDb
       .selectFrom('repositories')
       .select('githubInstallationId')
       .where('id', '=', 'repo-existing')
       .executeTakeFirstOrThrow()
     expect(repo.githubInstallationId).toBe(EXISTING_INSTALLATION)
+
+    const membership = await tenantDb
+      .selectFrom('repositoryInstallationMemberships')
+      .selectAll()
+      .where('repositoryId', '=', 'repo-existing')
+      .where('installationId', '=', INSTALLATION_ID)
+      .executeTakeFirst()
+    expect(membership).toBeDefined()
+    expect(membership?.repositoryId).toBe('repo-existing')
+    expect(membership?.installationId).toBe(INSTALLATION_ID)
   })
 
   test('empty repositories array is a no-op', async () => {

--- a/app/services/github-app-membership.server.test.ts
+++ b/app/services/github-app-membership.server.test.ts
@@ -15,6 +15,7 @@ import { closeDb, db } from '~/app/services/db.server'
 import { closeAllTenantDbs } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 import {
+  initializeMembershipsForInstallation,
   reassignBrokenRepository,
   reassignCanonicalAfterLinkLoss,
 } from './github-app-membership.server'
@@ -690,5 +691,111 @@ describe('reassignBrokenRepository', () => {
       .selectAll()
       .execute()
     expect(events).toHaveLength(0)
+  })
+})
+
+describe('initializeMembershipsForInstallation', () => {
+  const INSTALLATION_ID = 500
+
+  beforeEach(async () => {
+    await db.deleteFrom('githubAppLinkEvents').execute()
+    await db.deleteFrom('githubAppLinks').execute()
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const tenantDb = getTenantDb(ORG_ID)
+    await tenantDb.deleteFrom('repositoryInstallationMemberships').execute()
+    await tenantDb.deleteFrom('repositories').execute()
+  })
+
+  test('sets github_installation_id for repos with null value', async () => {
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const tenantDb = getTenantDb(ORG_ID)
+
+    // Seed a repository without github_installation_id (PAT-era repo)
+    await tenantDb
+      .insertInto('repositories')
+      .values({
+        id: 'repo-pat',
+        integrationId: 'int-1',
+        provider: 'github',
+        owner: 'octo',
+        repo: 'hello',
+        githubInstallationId: null,
+        updatedAt: '2026-04-07T00:00:00Z',
+      })
+      .execute()
+
+    const matched = await initializeMembershipsForInstallation({
+      organizationId: ORG_ID,
+      installationId: INSTALLATION_ID,
+      repositories: [{ owner: 'octo', name: 'hello' }],
+    })
+
+    expect(matched).toEqual(['repo-pat'])
+
+    // Verify membership was created
+    const memberships = await tenantDb
+      .selectFrom('repositoryInstallationMemberships')
+      .selectAll()
+      .execute()
+    expect(memberships).toHaveLength(1)
+    expect(memberships[0].installationId).toBe(INSTALLATION_ID)
+
+    // Verify github_installation_id was set
+    const repo = await tenantDb
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', 'repo-pat')
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBe(INSTALLATION_ID)
+  })
+
+  test('does not overwrite existing github_installation_id', async () => {
+    const { getTenantDb } = await import('~/app/services/tenant-db.server')
+    const tenantDb = getTenantDb(ORG_ID)
+    const EXISTING_INSTALLATION = 999
+
+    await tenantDb
+      .insertInto('repositories')
+      .values({
+        id: 'repo-existing',
+        integrationId: 'int-1',
+        provider: 'github',
+        owner: 'octo',
+        repo: 'world',
+        githubInstallationId: EXISTING_INSTALLATION,
+        updatedAt: '2026-04-07T00:00:00Z',
+      })
+      .execute()
+
+    await initializeMembershipsForInstallation({
+      organizationId: ORG_ID,
+      installationId: INSTALLATION_ID,
+      repositories: [{ owner: 'octo', name: 'world' }],
+    })
+
+    const repo = await tenantDb
+      .selectFrom('repositories')
+      .select('githubInstallationId')
+      .where('id', '=', 'repo-existing')
+      .executeTakeFirstOrThrow()
+    expect(repo.githubInstallationId).toBe(EXISTING_INSTALLATION)
+  })
+
+  test('empty repositories array is a no-op', async () => {
+    const result = await initializeMembershipsForInstallation({
+      organizationId: ORG_ID,
+      installationId: INSTALLATION_ID,
+      repositories: [],
+    })
+    expect(result).toEqual([])
+  })
+
+  test('unmatched repositories are silently skipped', async () => {
+    const result = await initializeMembershipsForInstallation({
+      organizationId: ORG_ID,
+      installationId: INSTALLATION_ID,
+      repositories: [{ owner: 'no-such', name: 'repo' }],
+    })
+    expect(result).toEqual([])
   })
 })

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -342,6 +342,7 @@ export async function initializeMembershipsForInstallation(input: {
 
   if (matched.length === 0) return []
 
+  const matchedIds = matched.map((r) => r.id)
   const now = new Date().toISOString()
   await tenantDb
     .insertInto('repositoryInstallationMemberships')
@@ -359,19 +360,12 @@ export async function initializeMembershipsForInstallation(input: {
     )
     .execute()
 
-  // Set github_installation_id for repositories that don't have one yet.
-  // Without this, switching from PAT to GitHub App leaves all repositories
-  // with github_installation_id = null, which the UI treats as "broken".
   await tenantDb
     .updateTable('repositories')
     .set({ githubInstallationId: input.installationId })
-    .where(
-      'id',
-      'in',
-      matched.map((r) => r.id),
-    )
+    .where('id', 'in', matchedIds)
     .where('githubInstallationId', 'is', null)
     .execute()
 
-  return matched.map((r) => r.id)
+  return matchedIds
 }

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -359,5 +359,19 @@ export async function initializeMembershipsForInstallation(input: {
     )
     .execute()
 
+  // Set github_installation_id for repositories that don't have one yet.
+  // Without this, switching from PAT to GitHub App leaves all repositories
+  // with github_installation_id = null, which the UI treats as "broken".
+  await tenantDb
+    .updateTable('repositories')
+    .set({ githubInstallationId: input.installationId })
+    .where(
+      'id',
+      'in',
+      matched.map((r) => r.id),
+    )
+    .where('githubInstallationId', 'is', null)
+    .execute()
+
   return matched.map((r) => r.id)
 }

--- a/app/services/github-app-membership.server.ts
+++ b/app/services/github-app-membership.server.ts
@@ -344,28 +344,30 @@ export async function initializeMembershipsForInstallation(input: {
 
   const matchedIds = matched.map((r) => r.id)
   const now = new Date().toISOString()
-  await tenantDb
-    .insertInto('repositoryInstallationMemberships')
-    .values(
-      matched.map((repo) => ({
-        repositoryId: repo.id,
-        installationId: input.installationId,
-      })),
-    )
-    .onConflict((oc) =>
-      oc.columns(['repositoryId', 'installationId']).doUpdateSet({
-        deletedAt: null,
-        updatedAt: now,
-      }),
-    )
-    .execute()
+  await tenantDb.transaction().execute(async (tx) => {
+    await tx
+      .insertInto('repositoryInstallationMemberships')
+      .values(
+        matched.map((repo) => ({
+          repositoryId: repo.id,
+          installationId: input.installationId,
+        })),
+      )
+      .onConflict((oc) =>
+        oc.columns(['repositoryId', 'installationId']).doUpdateSet({
+          deletedAt: null,
+          updatedAt: now,
+        }),
+      )
+      .execute()
 
-  await tenantDb
-    .updateTable('repositories')
-    .set({ githubInstallationId: input.installationId })
-    .where('id', 'in', matchedIds)
-    .where('githubInstallationId', 'is', null)
-    .execute()
+    await tx
+      .updateTable('repositories')
+      .set({ githubInstallationId: input.installationId })
+      .where('id', 'in', matchedIds)
+      .where('githubInstallationId', 'is', null)
+      .execute()
+  })
 
   return matchedIds
 }


### PR DESCRIPTION
## Summary
- `initializeMembershipsForInstallation()` が `repository_installation_memberships` に行を挿入するだけで `repositories.github_installation_id` をセットしていなかったため、PAT → GitHub App 切替直後に全リポジトリが broken 表示になっていた
- membership upsert 後に `github_installation_id` が null のリポジトリを更新するように修正
- 既存の `github_installation_id` は上書きしない（null の場合のみセット）

Closes #301

## Test plan
- [x] `pnpm validate` パス（351テスト）
- [x] `initializeMembershipsForInstallation` のテスト4件追加:
  - null → installationId にセットされる
  - 既存値は上書きされない
  - 空配列は no-op
  - 未登録リポジトリはスキップ

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **Bug Fixes**
  * メンバーシップ初期化処理を改善し、該当リポジトリのインストールIDを「未設定」の場合のみ設定するようになりました。既存の非NULL値は上書きされません。処理は一貫したトランザクション内で行われます。

* **Tests**
  * 初期化の挙動を検証する新しいテスト群を追加しました（マッチする/非マッチ/空配列、既存IDの不上書き、返却値の検証を含む）。各テストでデータベースのクリーンアップを行い隔離を強化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->