### PR TITLE
feat: auto-uninstall GitHub App on disconnect

### DIFF
--- a/app/services/github-app-mutations.server.ts
+++ b/app/services/github-app-mutations.server.ts
@@ -5,6 +5,22 @@ import { createAppOctokit } from '~/app/services/github-octokit.server'
 import type { OrganizationId } from '~/app/types/organization'
 
 /**
+ * Best-effort: delete the installation on GitHub so webhooks stop.
+ * Fire-and-forget — the Upflow-side disconnect has already succeeded.
+ * The subsequent `installation.deleted` webhook is a no-op because
+ * the link is already soft-deleted.
+ */
+function tryDeleteGithubInstallations(installationIds: number[]) {
+  if (installationIds.length === 0) return
+  const appOctokit = createAppOctokit()
+  Promise.allSettled(
+    installationIds.map((id) =>
+      appOctokit.rest.apps.deleteInstallation({ installation_id: id }),
+    ),
+  ).catch(() => {})
+}
+
+/**
  * Soft-delete a single GitHub App installation link.
  *
  * Reverts `integrations.method` to `'token'` only when the deleted link was
@@ -61,22 +77,7 @@ export async function disconnectGithubAppLink(
   })
 
   clearOrgCache(organizationId)
-
-  // Best-effort: delete the installation on GitHub so webhooks stop and the
-  // user doesn't need to manually uninstall. The Upflow-side disconnect has
-  // already succeeded at this point. The subsequent `installation.deleted`
-  // webhook will be a no-op because the link is already soft-deleted.
-  try {
-    const appOctokit = createAppOctokit()
-    await appOctokit.rest.apps.deleteInstallation({
-      installation_id: installationId,
-    })
-  } catch (e) {
-    console.warn(
-      `[disconnectGithubAppLink] Failed to delete GitHub installation ${installationId}:`,
-      e,
-    )
-  }
+  tryDeleteGithubInstallations([installationId])
 }
 
 /**
@@ -92,17 +93,15 @@ export async function disconnectGithubAppLink(
 export async function disconnectGithubApp(organizationId: OrganizationId) {
   const now = new Date().toISOString()
 
-  const deletedInstallationIds: number[] = []
-
-  await db.transaction().execute(async (trx) => {
-    const links = await trx
+  const links = await db.transaction().execute(async (trx) => {
+    const rows = await trx
       .selectFrom('githubAppLinks')
       .select('installationId')
       .where('organizationId', '=', organizationId)
       .where('deletedAt', 'is', null)
       .execute()
 
-    if (links.length > 0) {
+    if (rows.length > 0) {
       await trx
         .updateTable('githubAppLinks')
         .set({ deletedAt: now, updatedAt: now })
@@ -117,7 +116,7 @@ export async function disconnectGithubApp(organizationId: OrganizationId) {
       .where('organizationId', '=', organizationId)
       .execute()
 
-    for (const link of links) {
+    for (const link of rows) {
       await logGithubAppLinkEvent(
         {
           organizationId,
@@ -129,18 +128,11 @@ export async function disconnectGithubApp(organizationId: OrganizationId) {
         },
         trx,
       )
-      deletedInstallationIds.push(link.installationId)
     }
+
+    return rows
   })
 
   clearOrgCache(organizationId)
-
-  if (deletedInstallationIds.length > 0) {
-    const appOctokit = createAppOctokit()
-    await Promise.allSettled(
-      deletedInstallationIds.map((id) =>
-        appOctokit.rest.apps.deleteInstallation({ installation_id: id }),
-      ),
-    )
-  }
+  tryDeleteGithubInstallations(links.map((l) => l.installationId))
 }

--- a/app/services/github-app-mutations.server.ts
+++ b/app/services/github-app-mutations.server.ts
@@ -12,12 +12,26 @@ import type { OrganizationId } from '~/app/types/organization'
  */
 function tryDeleteGithubInstallations(installationIds: number[]) {
   if (installationIds.length === 0) return
-  const appOctokit = createAppOctokit()
-  Promise.allSettled(
-    installationIds.map((id) =>
-      appOctokit.rest.apps.deleteInstallation({ installation_id: id }),
-    ),
-  ).catch(() => {})
+  try {
+    const appOctokit = createAppOctokit()
+    Promise.allSettled(
+      installationIds.map((id) =>
+        appOctokit.rest.apps
+          .deleteInstallation({ installation_id: id })
+          .catch((e) =>
+            console.warn(
+              `[tryDeleteGithubInstallations] Failed to delete installation ${id}:`,
+              e,
+            ),
+          ),
+      ),
+    )
+  } catch (e) {
+    console.warn(
+      '[tryDeleteGithubInstallations] Failed to initialize GitHub App client:',
+      e,
+    )
+  }
 }
 
 /**

--- a/app/services/github-app-mutations.server.ts
+++ b/app/services/github-app-mutations.server.ts
@@ -1,6 +1,7 @@
 import { clearOrgCache } from '~/app/services/cache.server'
 import { db } from '~/app/services/db.server'
 import { logGithubAppLinkEvent } from '~/app/services/github-app-link-events.server'
+import { createAppOctokit } from '~/app/services/github-octokit.server'
 import type { OrganizationId } from '~/app/types/organization'
 
 /**
@@ -60,6 +61,22 @@ export async function disconnectGithubAppLink(
   })
 
   clearOrgCache(organizationId)
+
+  // Best-effort: delete the installation on GitHub so webhooks stop and the
+  // user doesn't need to manually uninstall. The Upflow-side disconnect has
+  // already succeeded at this point. The subsequent `installation.deleted`
+  // webhook will be a no-op because the link is already soft-deleted.
+  try {
+    const appOctokit = createAppOctokit()
+    await appOctokit.rest.apps.deleteInstallation({
+      installation_id: installationId,
+    })
+  } catch (e) {
+    console.warn(
+      `[disconnectGithubAppLink] Failed to delete GitHub installation ${installationId}:`,
+      e,
+    )
+  }
 }
 
 /**
@@ -74,6 +91,8 @@ export async function disconnectGithubAppLink(
  */
 export async function disconnectGithubApp(organizationId: OrganizationId) {
   const now = new Date().toISOString()
+
+  const deletedInstallationIds: number[] = []
 
   await db.transaction().execute(async (trx) => {
     const links = await trx
@@ -110,8 +129,18 @@ export async function disconnectGithubApp(organizationId: OrganizationId) {
         },
         trx,
       )
+      deletedInstallationIds.push(link.installationId)
     }
   })
 
   clearOrgCache(organizationId)
+
+  if (deletedInstallationIds.length > 0) {
+    const appOctokit = createAppOctokit()
+    await Promise.allSettled(
+      deletedInstallationIds.map((id) =>
+        appOctokit.rest.apps.deleteInstallation({ installation_id: id }),
+      ),
+    )
+  }
 }


### PR DESCRIPTION
## Summary
- Upflow UI で GitHub App を disconnect した際、GitHub 側の installation も `DELETE /app/installations/{id}` で自動削除するようにした
- Upflow 側の soft-delete は先に完了するため、GitHub API が失敗しても disconnect 自体は成功する (best-effort)
- GitHub から飛ぶ `installation.deleted` webhook は、既に soft-delete 済みなので no-op
- `disconnectGithubAppLink` (個別) と `disconnectGithubApp` (一括) の両方を対応

Closes #299

## Test plan
- [x] `pnpm validate` パス (351テスト)
- [ ] 手動テスト: GitHub App を disconnect → GitHub 側の installation settings で削除されていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * GitHub アプリ切断時のクリーンアップを強化。組織側の削除（ソフトデリート）後に、関連する GitHub インストールをまとめて別途削除する試みを行うようになりました。
  * 削除はベストエフォートで実行され、失敗しても切断処理やユーザー操作には影響しません。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->