### PR TITLE
fix: use skipped_unknown_method for unknown integration methods

### DIFF
--- a/batch/commands/backfill-installation-membership.ts
+++ b/batch/commands/backfill-installation-membership.ts
@@ -21,6 +21,7 @@ type OrgSummary = {
   organizationName: string
   status:
     | 'skipped_token_method'
+    | 'skipped_unknown_method'
     | 'skipped_no_active_link'
     | 'skipped_multi_link_unmapped'
     | 'backfilled_single_link'
@@ -81,7 +82,7 @@ export async function backfillInstallationMembershipCommand(
         summaries.push({
           organizationId: org.organizationId,
           organizationName: org.organizationName,
-          status: 'skipped_token_method',
+          status: 'skipped_unknown_method',
           repositoryCount: 0,
           notes: `Unknown integration method: ${org.method}`,
         })


### PR DESCRIPTION
## Summary
- backfill CLI が unknown integration method に対して `skipped_token_method` ステータスを使っていたのを `skipped_unknown_method` に修正
- `OrgSummary` の status union に `'skipped_unknown_method'` を追加

Closes #298

## Test plan
- [x] `pnpm validate` パス
- 実害なし（unknown method の組織は現状存在しない）

🤖 Generated with [Claude Code](https://claude.com/claude-code)