### PR TITLE
feat: Review Stacks の No reviewer バケットを3区分に分割 (#286)

### DIFF
--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -130,6 +130,7 @@ export interface PRBlockData {
   title: string
   url: string
   author?: string
+  authorDisplayName?: string
   createdAt: string
   complexity: string | null
   /** true = has reviewer, false = no reviewer (ring style), undefined = unknown (solid) */
@@ -230,7 +231,9 @@ export function PRPopoverContent({
       </div>
       <p className="text-muted-foreground truncate text-xs">{pr.title}</p>
       <div className="text-muted-foreground flex flex-wrap gap-x-2 text-xs">
-        {showAuthor && pr.author && <span>by {pr.author}</span>}
+        {showAuthor && pr.author && (
+          <span>by {pr.authorDisplayName ?? pr.author}</span>
+        )}
         <span>{ageDays}d ago</span>
         {statusShape && (
           <span className={statusShape.text}>{statusShape.label}</span>

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -13,6 +13,7 @@ export interface BlockColor {
   bg: string
   ring: string
   bgFaint: string
+  text: string
 }
 
 export const SIZE_BLOCK_COLORS: Record<string, BlockColor> = {
@@ -20,25 +21,39 @@ export const SIZE_BLOCK_COLORS: Record<string, BlockColor> = {
     bg: 'bg-slate-400',
     ring: 'ring-slate-400',
     bgFaint: 'bg-slate-400/20',
+    text: 'text-slate-400',
   },
   S: {
     bg: 'bg-emerald-500',
     ring: 'ring-emerald-500',
     bgFaint: 'bg-emerald-500/20',
+    text: 'text-emerald-500',
   },
-  M: { bg: 'bg-blue-500', ring: 'ring-blue-500', bgFaint: 'bg-blue-500/20' },
+  M: {
+    bg: 'bg-blue-500',
+    ring: 'ring-blue-500',
+    bgFaint: 'bg-blue-500/20',
+    text: 'text-blue-500',
+  },
   L: {
     bg: 'bg-amber-500',
     ring: 'ring-amber-500',
     bgFaint: 'bg-amber-500/20',
+    text: 'text-amber-500',
   },
-  XL: { bg: 'bg-red-500', ring: 'ring-red-500', bgFaint: 'bg-red-500/20' },
+  XL: {
+    bg: 'bg-red-500',
+    ring: 'ring-red-500',
+    bgFaint: 'bg-red-500/20',
+    text: 'text-red-500',
+  },
 }
 
 export const UNKNOWN_COLOR: BlockColor = {
   bg: 'bg-gray-300 dark:bg-gray-600',
   ring: 'ring-gray-400',
   bgFaint: 'bg-gray-400/20',
+  text: 'text-gray-400',
 }
 
 export const AGE_THRESHOLDS = [
@@ -47,6 +62,7 @@ export const AGE_THRESHOLDS = [
     bg: 'bg-blue-500',
     ring: 'ring-blue-500',
     bgFaint: 'bg-blue-500/20',
+    text: 'text-blue-500',
     label: '< 1d',
   },
   {
@@ -54,6 +70,7 @@ export const AGE_THRESHOLDS = [
     bg: 'bg-emerald-500',
     ring: 'ring-emerald-500',
     bgFaint: 'bg-emerald-500/20',
+    text: 'text-emerald-500',
     label: '1-3d',
   },
   {
@@ -61,6 +78,7 @@ export const AGE_THRESHOLDS = [
     bg: 'bg-amber-500',
     ring: 'ring-amber-500',
     bgFaint: 'bg-amber-500/20',
+    text: 'text-amber-500',
     label: '3-7d',
   },
   {
@@ -68,6 +86,7 @@ export const AGE_THRESHOLDS = [
     bg: 'bg-red-500',
     ring: 'ring-red-500',
     bgFaint: 'bg-red-500/20',
+    text: 'text-red-500',
     label: '7-14d',
   },
   {
@@ -75,6 +94,7 @@ export const AGE_THRESHOLDS = [
     bg: 'bg-purple-500',
     ring: 'ring-purple-500',
     bgFaint: 'bg-purple-500/20',
+    text: 'text-purple-500',
     label: '14-30d',
   },
   {
@@ -82,6 +102,7 @@ export const AGE_THRESHOLDS = [
     bg: 'bg-neutral-800',
     ring: 'ring-neutral-800',
     bgFaint: 'bg-neutral-800/20',
+    text: 'text-neutral-800',
     label: '31d+',
   },
 ] as const
@@ -94,20 +115,22 @@ function getSizeColor(complexity: string | null): BlockColor {
 function getAgeColor(createdAt: string): BlockColor {
   const days = dayjs().diff(dayjs.utc(createdAt), 'day', true)
   for (const t of AGE_THRESHOLDS) {
-    if (days < t.maxDays) return { bg: t.bg, ring: t.ring, bgFaint: t.bgFaint }
+    if (days < t.maxDays)
+      return { bg: t.bg, ring: t.ring, bgFaint: t.bgFaint, text: t.text }
   }
   const last = AGE_THRESHOLDS[AGE_THRESHOLDS.length - 1]
-  return { bg: last.bg, ring: last.ring, bgFaint: last.bgFaint }
+  return {
+    bg: last.bg,
+    ring: last.ring,
+    bgFaint: last.bgFaint,
+    text: last.text,
+  }
 }
 
 function getBlockColor(pr: PRBlockData, mode: PRBlockColorMode): BlockColor {
   return mode === 'size'
     ? getSizeColor(pr.complexity)
     : getAgeColor(pr.createdAt)
-}
-
-function ringToText(ringClass: string): string {
-  return ringClass.replace(/\bring-/g, 'text-')
 }
 
 export type PRReviewStatus =
@@ -312,7 +335,12 @@ export function PRBlock({
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
   dataPrKey?: string
 }) {
-  const { bg, ring, bgFaint } = getBlockColor(pr, colorMode)
+  const {
+    bg,
+    ring,
+    bgFaint,
+    text: blockTextColor,
+  } = getBlockColor(pr, colorMode)
   const statusShape = pr.reviewStatus
     ? REVIEW_STATUS_SHAPE[pr.reviewStatus]
     : undefined
@@ -340,7 +368,7 @@ export function PRBlock({
         >
           {statusShape?.icon && (
             <span
-              className={`text-[8px] leading-none font-bold ${ringToText(ring)}`}
+              className={`text-[8px] leading-none font-bold ${blockTextColor}`}
             >
               {statusShape.icon}
             </span>

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -106,6 +106,10 @@ function getBlockColor(pr: PRBlockData, mode: PRBlockColorMode): BlockColor {
     : getAgeColor(pr.createdAt)
 }
 
+function ringToText(ringClass: string): string {
+  return ringClass.replace(/\bring-/g, 'text-')
+}
+
 export type PRReviewStatus =
   | 'in-review'
   | 'unassigned'
@@ -148,7 +152,6 @@ interface ReviewStatusShape {
   legendSwatch: string
   /** Small icon rendered inside the block (e.g. ✓ for approved) */
   icon?: string
-  iconColor?: string
 }
 
 export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
@@ -174,7 +177,6 @@ export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
     legendSwatch:
       'size-3.5 rounded-full ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
     icon: '✓',
-    iconColor: 'text-emerald-600 dark:text-emerald-400',
   },
   'changes-pending': {
     label: 'Changes',
@@ -183,7 +185,6 @@ export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
     legendSwatch:
       'size-3.5 rounded-full ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
     icon: '✗',
-    iconColor: 'text-red-500',
   },
 }
 
@@ -339,7 +340,7 @@ export function PRBlock({
         >
           {statusShape?.icon && (
             <span
-              className={`text-[8px] leading-none font-bold ${statusShape.iconColor ?? ''}`}
+              className={`text-[8px] leading-none font-bold ${ringToText(ring)}`}
             >
               {statusShape.icon}
             </span>

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -244,7 +244,7 @@ export function PRPopoverContent({
           </span>
         )}
       </div>
-      <p className="text-muted-foreground line-clamp-3 text-xs">{pr.title}</p>
+      <p className="line-clamp-3 text-xs">{pr.title}</p>
       <div className="text-muted-foreground flex flex-wrap gap-x-2 text-xs">
         {showAuthor && pr.author && (
           <span className="inline-flex items-center gap-1">

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -244,7 +244,7 @@ export function PRPopoverContent({
           </span>
         )}
       </div>
-      <p className="text-muted-foreground truncate text-xs">{pr.title}</p>
+      <p className="text-muted-foreground line-clamp-3 text-xs">{pr.title}</p>
       <div className="text-muted-foreground flex flex-wrap gap-x-2 text-xs">
         {showAuthor && pr.author && (
           <span className="inline-flex items-center gap-1">

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -293,7 +293,7 @@ export function PRPopoverContent({
           {pr.reviewerStates.map((r) => {
             const style = REVIEW_STATE_STYLE[r.state]
             const when = r.submittedAt
-              ? dayjs.utc(r.submittedAt).format('YYYY/MM/DD HH:mm')
+              ? dayjs.utc(r.submittedAt).fromNow()
               : undefined
             return (
               <div key={r.login} className="flex items-center gap-2 text-xs">

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -139,29 +139,42 @@ export interface PRBlockData {
   reviewerStates?: PRReviewerStateEntry[]
 }
 
-interface ReviewStatusStyle {
+interface ReviewStatusShape {
   label: string
   text: string
-  ring?: string
+  /** Tailwind classes controlling shape (border-radius, rotation, etc.) */
+  shape: string
+  /** Legend swatch classes — shape + neutral fill for the legend row */
+  legendSwatch: string
 }
 
-const REVIEW_STATUS_STYLE: Partial<Record<PRReviewStatus, ReviewStatusStyle>> =
-  {
-    unassigned: {
-      label: 'レビュアー未アサイン',
-      text: 'text-amber-600 dark:text-amber-400',
-    },
-    'approved-awaiting-merge': {
-      label: 'Approve済み・マージ待ち',
-      text: 'text-emerald-600 dark:text-emerald-400',
-      ring: 'ring-[2px] ring-offset-1 ring-emerald-500',
-    },
-    'changes-pending': {
-      label: '作者対応待ち',
-      text: 'text-amber-600 dark:text-amber-400',
-      ring: 'ring-[2px] ring-offset-1 ring-amber-500',
-    },
-  }
+export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
+  'in-review': {
+    label: 'レビュー中',
+    text: 'text-muted-foreground',
+    shape: 'rounded-full',
+    legendSwatch: 'size-3 rounded-full bg-current',
+  },
+  unassigned: {
+    label: 'Unassigned',
+    text: 'text-amber-600 dark:text-amber-400',
+    shape: 'rounded-full',
+    legendSwatch:
+      'size-3 rounded-full ring-[1.5px] ring-inset ring-current bg-current/20',
+  },
+  'approved-awaiting-merge': {
+    label: 'Approved',
+    text: 'text-emerald-600 dark:text-emerald-400',
+    shape: 'rounded-sm',
+    legendSwatch: 'size-3 rounded-sm bg-current',
+  },
+  'changes-pending': {
+    label: 'Changes',
+    text: 'text-amber-600 dark:text-amber-400',
+    shape: 'rotate-45 rounded-sm',
+    legendSwatch: 'size-3 rotate-45 rounded-sm bg-current',
+  },
+}
 
 export const REVIEW_STATE_STYLE: Record<
   string,
@@ -192,8 +205,8 @@ export function PRPopoverContent({
 }) {
   const ageDays = Math.floor(dayjs().diff(dayjs.utc(pr.createdAt), 'day', true))
   const stateInfo = reviewState ? REVIEW_STATE_STYLE[reviewState] : null
-  const statusStyle = pr.reviewStatus
-    ? REVIEW_STATUS_STYLE[pr.reviewStatus]
+  const statusShape = pr.reviewStatus
+    ? REVIEW_STATUS_SHAPE[pr.reviewStatus]
     : undefined
   return (
     <div className="space-y-1">
@@ -217,8 +230,8 @@ export function PRPopoverContent({
       <div className="text-muted-foreground flex flex-wrap gap-x-2 text-xs">
         {showAuthor && pr.author && <span>by {pr.author}</span>}
         <span>{ageDays}d ago</span>
-        {statusStyle && (
-          <span className={statusStyle.text}>{statusStyle.label}</span>
+        {statusShape && (
+          <span className={statusShape.text}>{statusShape.label}</span>
         )}
       </div>
       {pr.reviewerStates && pr.reviewerStates.length > 0 && (
@@ -268,18 +281,17 @@ export function PRBlock({
   dataPrKey?: string
 }) {
   const { bg, ring, bgFaint } = getBlockColor(pr, colorMode)
-  const statusStyle = pr.reviewStatus
-    ? REVIEW_STATUS_STYLE[pr.reviewStatus]
+  const statusShape = pr.reviewStatus
+    ? REVIEW_STATUS_SHAPE[pr.reviewStatus]
     : undefined
-  const ariaLabel = statusStyle
-    ? `${pr.repo}#${pr.number} (${statusStyle.label})`
+  const shape = statusShape?.shape ?? 'rounded-full'
+  const ariaLabel = statusShape
+    ? `${pr.repo}#${pr.number} (${statusShape.label})`
     : `${pr.repo}#${pr.number}`
-  const baseClass =
-    pr.hasReviewer === false
+  const fillClass =
+    pr.reviewStatus === 'unassigned'
       ? `ring-[2px] ring-inset ${ring} ${bgFaint}`
-      : statusStyle?.ring
-        ? `${bg} ${statusStyle.ring}`
-        : bg
+      : bg
 
   return (
     <Popover>
@@ -287,7 +299,7 @@ export function PRBlock({
         <button
           type="button"
           data-pr-key={dataPrKey}
-          className={`size-4 shrink-0 rounded-full transition-all hover:scale-150 ${baseClass}`}
+          className={`size-4 shrink-0 transition-all hover:scale-150 ${shape} ${fillClass}`}
           aria-label={ariaLabel}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -105,6 +105,25 @@ function getBlockColor(pr: PRBlockData, mode: PRBlockColorMode): BlockColor {
     : getAgeColor(pr.createdAt)
 }
 
+export type PRReviewStatus =
+  | 'in-review'
+  | 'unassigned'
+  | 'approved-awaiting-merge'
+  | 'changes-pending'
+
+export type PRReviewerState =
+  | 'APPROVED'
+  | 'CHANGES_REQUESTED'
+  | 'COMMENTED'
+  | 'REQUESTED'
+
+export interface PRReviewerStateEntry {
+  login: string
+  displayName: string
+  state: PRReviewerState
+  submittedAt?: string
+}
+
 export interface PRBlockData {
   number: number
   repo: string
@@ -116,7 +135,33 @@ export interface PRBlockData {
   /** true = has reviewer, false = no reviewer (ring style), undefined = unknown (solid) */
   hasReviewer?: boolean
   reviewers?: string[]
+  reviewStatus?: PRReviewStatus
+  reviewerStates?: PRReviewerStateEntry[]
 }
+
+interface ReviewStatusStyle {
+  label: string
+  text: string
+  ring?: string
+}
+
+const REVIEW_STATUS_STYLE: Partial<Record<PRReviewStatus, ReviewStatusStyle>> =
+  {
+    unassigned: {
+      label: 'レビュアー未アサイン',
+      text: 'text-amber-600 dark:text-amber-400',
+    },
+    'approved-awaiting-merge': {
+      label: 'Approve済み・マージ待ち',
+      text: 'text-emerald-600 dark:text-emerald-400',
+      ring: 'ring-[2px] ring-offset-1 ring-emerald-500',
+    },
+    'changes-pending': {
+      label: '作者対応待ち',
+      text: 'text-amber-600 dark:text-amber-400',
+      ring: 'ring-[2px] ring-offset-1 ring-amber-500',
+    },
+  }
 
 export const REVIEW_STATE_STYLE: Record<
   string,
@@ -127,6 +172,11 @@ export const REVIEW_STATE_STYLE: Record<
   COMMENTED: {
     icon: '💬',
     text: 'Comment',
+    className: 'text-muted-foreground',
+  },
+  REQUESTED: {
+    icon: '⏳',
+    text: 'Requested',
     className: 'text-muted-foreground',
   },
 }
@@ -142,6 +192,9 @@ export function PRPopoverContent({
 }) {
   const ageDays = Math.floor(dayjs().diff(dayjs.utc(pr.createdAt), 'day', true))
   const stateInfo = reviewState ? REVIEW_STATE_STYLE[reviewState] : null
+  const statusStyle = pr.reviewStatus
+    ? REVIEW_STATUS_STYLE[pr.reviewStatus]
+    : undefined
   return (
     <div className="space-y-1">
       <div className="flex items-center gap-2">
@@ -164,15 +217,35 @@ export function PRPopoverContent({
       <div className="text-muted-foreground flex flex-wrap gap-x-2 text-xs">
         {showAuthor && pr.author && <span>by {pr.author}</span>}
         <span>{ageDays}d ago</span>
-        {pr.reviewers && pr.reviewers.length > 0 && (
-          <span>→ {pr.reviewers.join(', ')}</span>
-        )}
-        {pr.hasReviewer === false && (
-          <span className="text-amber-600 dark:text-amber-400">
-            no reviewer
-          </span>
+        {statusStyle && (
+          <span className={statusStyle.text}>{statusStyle.label}</span>
         )}
       </div>
+      {pr.reviewerStates && pr.reviewerStates.length > 0 && (
+        <div className="mt-1.5 space-y-0.5 border-t pt-1.5">
+          {pr.reviewerStates.map((r) => {
+            const style = REVIEW_STATE_STYLE[r.state]
+            const when = r.submittedAt
+              ? dayjs.utc(r.submittedAt).format('YYYY/MM/DD HH:mm')
+              : undefined
+            return (
+              <div key={r.login} className="flex items-center gap-2 text-xs">
+                <span
+                  className={`w-20 shrink-0 whitespace-nowrap ${style.className}`}
+                >
+                  {style.icon} {style.text}
+                </span>
+                <span className="truncate">{r.displayName}</span>
+                {when && (
+                  <span className="text-muted-foreground ml-auto shrink-0">
+                    {when}
+                  </span>
+                )}
+              </div>
+            )
+          })}
+        </div>
+      )}
     </div>
   )
 }
@@ -195,6 +268,18 @@ export function PRBlock({
   dataPrKey?: string
 }) {
   const { bg, ring, bgFaint } = getBlockColor(pr, colorMode)
+  const statusStyle = pr.reviewStatus
+    ? REVIEW_STATUS_STYLE[pr.reviewStatus]
+    : undefined
+  const ariaLabel = statusStyle
+    ? `${pr.repo}#${pr.number} (${statusStyle.label})`
+    : `${pr.repo}#${pr.number}`
+  const baseClass =
+    pr.hasReviewer === false
+      ? `ring-[2px] ring-inset ${ring} ${bgFaint}`
+      : statusStyle?.ring
+        ? `${bg} ${statusStyle.ring}`
+        : bg
 
   return (
     <Popover>
@@ -202,8 +287,8 @@ export function PRBlock({
         <button
           type="button"
           data-pr-key={dataPrKey}
-          className={`size-4 shrink-0 rounded-full transition-all hover:scale-150 ${pr.hasReviewer === false ? `ring-[2px] ring-inset ${ring} ${bgFaint}` : bg}`}
-          aria-label={`${pr.repo}#${pr.number}`}
+          className={`size-4 shrink-0 rounded-full transition-all hover:scale-150 ${baseClass}`}
+          aria-label={ariaLabel}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
           onClick={onClick}

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -153,28 +153,28 @@ export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
     label: 'レビュー中',
     text: 'text-muted-foreground',
     shape: 'rounded-full',
-    legendSwatch: 'size-3 rounded-full bg-current',
+    legendSwatch: 'size-3 rounded-full bg-gray-400 dark:bg-gray-500',
   },
   unassigned: {
     label: 'Unassigned',
     text: 'text-amber-600 dark:text-amber-400',
     shape: 'rounded-sm',
     legendSwatch:
-      'size-3 rounded-sm ring-[1.5px] ring-inset ring-current bg-current/20',
+      'size-3 rounded-sm ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
   },
   'approved-awaiting-merge': {
     label: 'Approved',
     text: 'text-emerald-600 dark:text-emerald-400',
     shape: 'rounded-full',
     legendSwatch:
-      'size-3 rounded-full ring-[1.5px] ring-inset ring-current bg-current/20',
+      'size-3 rounded-full ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
   },
   'changes-pending': {
     label: 'Changes',
     text: 'text-amber-600 dark:text-amber-400',
     shape: 'rotate-45 rounded-sm',
     legendSwatch:
-      'size-3 rotate-45 rounded-sm ring-[1.5px] ring-inset ring-current bg-current/20',
+      'size-3 rotate-45 rounded-sm ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
   },
 }
 

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -144,10 +144,11 @@ export interface PRBlockData {
 interface ReviewStatusShape {
   label: string
   text: string
-  /** Tailwind classes controlling shape (border-radius, rotation, etc.) */
   shape: string
-  /** Legend swatch classes — shape + neutral fill for the legend row */
   legendSwatch: string
+  /** Small icon rendered inside the block (e.g. ✓ for approved) */
+  icon?: string
+  iconColor?: string
 }
 
 export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
@@ -156,13 +157,15 @@ export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
     text: 'text-muted-foreground',
     shape: 'rounded-full',
     legendSwatch: 'size-3.5 rounded-full bg-gray-400 dark:bg-gray-500',
+    icon: undefined,
   },
   unassigned: {
     label: 'Unassigned',
     text: 'text-amber-600 dark:text-amber-400',
-    shape: 'rounded-[2px]',
+    shape: 'rounded-full',
     legendSwatch:
-      'size-3.5 rounded-[2px] ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
+      'size-3.5 rounded-full ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
+    icon: undefined,
   },
   'approved-awaiting-merge': {
     label: 'Approved',
@@ -170,13 +173,17 @@ export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
     shape: 'rounded-full',
     legendSwatch:
       'size-3.5 rounded-full ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
+    icon: '✓',
+    iconColor: 'text-emerald-600 dark:text-emerald-400',
   },
   'changes-pending': {
     label: 'Changes',
     text: 'text-amber-600 dark:text-amber-400',
-    shape: 'rotate-45 rounded-[2px]',
+    shape: 'rounded-full',
     legendSwatch:
-      'size-2.5 rotate-45 rounded-[2px] ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
+      'size-3.5 rounded-full ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
+    icon: '✗',
+    iconColor: 'text-red-500',
   },
 }
 
@@ -324,12 +331,20 @@ export function PRBlock({
         <button
           type="button"
           data-pr-key={dataPrKey}
-          className={`size-4 shrink-0 transition-all hover:scale-150 ${shape} ${fillClass}`}
+          className={`flex size-4 shrink-0 items-center justify-center transition-all hover:scale-150 ${shape} ${fillClass}`}
           aria-label={ariaLabel}
           onMouseEnter={onMouseEnter}
           onMouseLeave={onMouseLeave}
           onClick={onClick}
-        />
+        >
+          {statusShape?.icon && (
+            <span
+              className={`text-[8px] leading-none font-bold ${statusShape.iconColor ?? ''}`}
+            >
+              {statusShape.icon}
+            </span>
+          )}
+        </button>
       </PopoverTrigger>
       <PopoverContent side="top" className="w-72 p-3">
         <PRPopoverContent pr={pr} showAuthor={showAuthor} />

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -158,16 +158,16 @@ export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
   unassigned: {
     label: 'Unassigned',
     text: 'text-amber-600 dark:text-amber-400',
-    shape: 'rounded-full',
+    shape: 'rounded-sm',
     legendSwatch:
-      'size-3 rounded-full ring-[1.5px] ring-inset ring-current bg-current/20',
+      'size-3 rounded-sm ring-[1.5px] ring-inset ring-current bg-current/20',
   },
   'approved-awaiting-merge': {
     label: 'Approved',
     text: 'text-emerald-600 dark:text-emerald-400',
-    shape: 'rounded-sm',
+    shape: 'rounded-full',
     legendSwatch:
-      'size-3 rounded-sm ring-[1.5px] ring-inset ring-current bg-current/20',
+      'size-3 rounded-full ring-[1.5px] ring-inset ring-current bg-current/20',
   },
   'changes-pending': {
     label: 'Changes',

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -153,28 +153,28 @@ export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
     label: 'レビュー中',
     text: 'text-muted-foreground',
     shape: 'rounded-full',
-    legendSwatch: 'size-3 rounded-full bg-gray-400 dark:bg-gray-500',
+    legendSwatch: 'size-3.5 rounded-full bg-gray-400 dark:bg-gray-500',
   },
   unassigned: {
     label: 'Unassigned',
     text: 'text-amber-600 dark:text-amber-400',
-    shape: 'rounded-sm',
+    shape: 'rounded-[2px]',
     legendSwatch:
-      'size-3 rounded-sm ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
+      'size-3.5 rounded-[2px] ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
   },
   'approved-awaiting-merge': {
     label: 'Approved',
     text: 'text-emerald-600 dark:text-emerald-400',
     shape: 'rounded-full',
     legendSwatch:
-      'size-3 rounded-full ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
+      'size-3.5 rounded-full ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
   },
   'changes-pending': {
     label: 'Changes',
     text: 'text-amber-600 dark:text-amber-400',
-    shape: 'rotate-45 rounded-sm',
+    shape: 'rotate-45 rounded-[2px]',
     legendSwatch:
-      'size-3 rotate-45 rounded-sm ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
+      'size-2.5 rotate-45 rounded-[2px] ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
   },
 }
 

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -249,11 +249,9 @@ function GitHubAvatar({ login, size }: { login: string; size: number }) {
 
 export function PRPopoverContent({
   pr,
-  showAuthor,
   reviewState,
 }: {
   pr: PRBlockData
-  showAuthor?: boolean
   reviewState?: string
 }) {
   const createdAgo = dayjs.utc(pr.createdAt).fromNow()
@@ -281,7 +279,7 @@ export function PRPopoverContent({
       </div>
       <p className="line-clamp-3 text-xs">{pr.title}</p>
       <div className="text-muted-foreground flex flex-wrap gap-x-2 text-xs">
-        {showAuthor && pr.author && (
+        {pr.author && (
           <span className="inline-flex items-center gap-1">
             <GitHubAvatar login={pr.author} size={14} />
             {pr.authorDisplayName ?? pr.author}
@@ -325,7 +323,6 @@ export function PRPopoverContent({
 export function PRBlock({
   pr,
   colorMode = 'size',
-  showAuthor,
   onMouseEnter,
   onMouseLeave,
   onClick,
@@ -333,7 +330,6 @@ export function PRBlock({
 }: {
   pr: PRBlockData
   colorMode?: PRBlockColorMode
-  showAuthor?: boolean
   onMouseEnter?: (e: React.MouseEvent<HTMLButtonElement>) => void
   onMouseLeave?: () => void
   onClick?: (e: React.MouseEvent<HTMLButtonElement>) => void
@@ -380,7 +376,7 @@ export function PRBlock({
         </button>
       </PopoverTrigger>
       <PopoverContent side="top" className="w-72 p-3">
-        <PRPopoverContent pr={pr} showAuthor={showAuthor} />
+        <PRPopoverContent pr={pr} />
       </PopoverContent>
     </Popover>
   )

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -252,7 +252,7 @@ export function PRPopoverContent({
   showAuthor?: boolean
   reviewState?: string
 }) {
-  const ageDays = Math.floor(dayjs().diff(dayjs.utc(pr.createdAt), 'day', true))
+  const createdAgo = dayjs.utc(pr.createdAt).fromNow()
   const stateInfo = reviewState ? REVIEW_STATE_STYLE[reviewState] : null
   const statusShape = pr.reviewStatus
     ? REVIEW_STATUS_SHAPE[pr.reviewStatus]
@@ -283,7 +283,7 @@ export function PRPopoverContent({
             {pr.authorDisplayName ?? pr.author}
           </span>
         )}
-        <span>{ageDays}d ago</span>
+        <span>{createdAgo}</span>
         {statusShape && (
           <span className={statusShape.text}>{statusShape.label}</span>
         )}

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -1,4 +1,5 @@
 import { SizeBadge } from '~/app/components/size-badge'
+import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import {
   Popover,
   PopoverContent,
@@ -197,6 +198,20 @@ export const REVIEW_STATE_STYLE: Record<
   },
 }
 
+function GitHubAvatar({ login, size }: { login: string; size: number }) {
+  return (
+    <Avatar style={{ width: size, height: size }} className="shrink-0">
+      <AvatarImage src={`https://github.com/${login}.png`} alt={login} />
+      <AvatarFallback
+        className="text-[6px]"
+        style={{ width: size, height: size }}
+      >
+        {login.slice(0, 2)}
+      </AvatarFallback>
+    </Avatar>
+  )
+}
+
 export function PRPopoverContent({
   pr,
   showAuthor,
@@ -232,7 +247,10 @@ export function PRPopoverContent({
       <p className="text-muted-foreground truncate text-xs">{pr.title}</p>
       <div className="text-muted-foreground flex flex-wrap gap-x-2 text-xs">
         {showAuthor && pr.author && (
-          <span>by {pr.authorDisplayName ?? pr.author}</span>
+          <span className="inline-flex items-center gap-1">
+            <GitHubAvatar login={pr.author} size={14} />
+            {pr.authorDisplayName ?? pr.author}
+          </span>
         )}
         <span>{ageDays}d ago</span>
         {statusShape && (
@@ -253,6 +271,7 @@ export function PRPopoverContent({
                 >
                   {style.icon} {style.text}
                 </span>
+                <GitHubAvatar login={r.login} size={14} />
                 <span className="truncate">{r.displayName}</span>
                 {when && (
                   <span className="text-muted-foreground ml-auto shrink-0">

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -161,9 +161,6 @@ export interface PRBlockData {
   authorDisplayName?: string
   createdAt: string
   complexity: string | null
-  /** true = has reviewer, false = no reviewer (ring style), undefined = unknown (solid) */
-  hasReviewer?: boolean
-  reviewers?: string[]
   reviewStatus?: PRReviewStatus
   reviewerStates?: PRReviewerStateEntry[]
 }
@@ -209,6 +206,13 @@ export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
       'size-3.5 rounded-full ring-[1.5px] ring-inset ring-gray-400 bg-gray-400/20 dark:ring-gray-500 dark:bg-gray-500/20',
     icon: '✗',
   },
+}
+
+export const REVIEW_STATUS_PRIORITY: Record<PRReviewStatus, number> = {
+  'approved-awaiting-merge': 0,
+  'changes-pending': 1,
+  unassigned: 2,
+  'in-review': 3,
 }
 
 export const REVIEW_STATE_STYLE: Record<

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -166,13 +166,15 @@ export const REVIEW_STATUS_SHAPE: Record<PRReviewStatus, ReviewStatusShape> = {
     label: 'Approved',
     text: 'text-emerald-600 dark:text-emerald-400',
     shape: 'rounded-sm',
-    legendSwatch: 'size-3 rounded-sm bg-current',
+    legendSwatch:
+      'size-3 rounded-sm ring-[1.5px] ring-inset ring-current bg-current/20',
   },
   'changes-pending': {
     label: 'Changes',
     text: 'text-amber-600 dark:text-amber-400',
     shape: 'rotate-45 rounded-sm',
-    legendSwatch: 'size-3 rotate-45 rounded-sm bg-current',
+    legendSwatch:
+      'size-3 rotate-45 rounded-sm ring-[1.5px] ring-inset ring-current bg-current/20',
   },
 }
 
@@ -288,10 +290,11 @@ export function PRBlock({
   const ariaLabel = statusShape
     ? `${pr.repo}#${pr.number} (${statusShape.label})`
     : `${pr.repo}#${pr.number}`
-  const fillClass =
-    pr.reviewStatus === 'unassigned'
-      ? `ring-[2px] ring-inset ${ring} ${bgFaint}`
-      : bg
+  const isHollow =
+    pr.reviewStatus === 'unassigned' ||
+    pr.reviewStatus === 'approved-awaiting-merge' ||
+    pr.reviewStatus === 'changes-pending'
+  const fillClass = isHollow ? `ring-[2px] ring-inset ${ring} ${bgFaint}` : bg
 
   return (
     <Popover>

--- a/app/routes/$orgSlug/workload/$login/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/workload/$login/+functions/queries.server.ts
@@ -330,15 +330,5 @@ export const getBacklogDetails = async (
         .execute(),
     ])
 
-  const reviewerSet = new Set<string>()
-  for (const r of reviewerRows) {
-    reviewerSet.add(`${r.repositoryId}:${r.number}`)
-  }
-
-  const openPRs = openPRsRaw.map((pr) => ({
-    ...pr,
-    hasReviewer: reviewerSet.has(`${pr.repositoryId}:${pr.number}`),
-  }))
-
-  return { openPRs, pendingReviews, reviewHistory, reviewerRows }
+  return { openPRs: openPRsRaw, pendingReviews, reviewHistory, reviewerRows }
 }

--- a/app/routes/$orgSlug/workload/$login/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/workload/$login/+functions/queries.server.ts
@@ -165,87 +165,170 @@ export const getBacklogDetails = async (
 
   const loginLower = login.toLowerCase()
 
-  const [openPRsRaw, reviewerRows, pendingReviews] = await Promise.all([
-    tenantDb
-      .selectFrom('pullRequests')
-      .where((eb) =>
-        eb(eb.fn('lower', ['pullRequests.author']), '=', loginLower),
-      )
-      .where('mergedAt', 'is', null)
-      .where('closedAt', 'is', null)
-      .select([
-        'number',
-        'repositoryId',
-        'repo',
-        'title',
-        'url',
-        'pullRequestCreatedAt',
-        'complexity',
-      ])
-      .orderBy('pullRequestCreatedAt', 'asc')
-      .execute(),
+  const [openPRsRaw, reviewerRows, pendingReviews, reviewHistory] =
+    await Promise.all([
+      tenantDb
+        .selectFrom('pullRequests')
+        .where((eb) =>
+          eb(eb.fn('lower', ['pullRequests.author']), '=', loginLower),
+        )
+        .where('mergedAt', 'is', null)
+        .where('closedAt', 'is', null)
+        .select([
+          'number',
+          'repositoryId',
+          'repo',
+          'title',
+          'url',
+          'pullRequestCreatedAt',
+          'complexity',
+        ])
+        .orderBy('pullRequestCreatedAt', 'asc')
+        .execute(),
 
-    tenantDb
-      .selectFrom('pullRequestReviewers')
-      .innerJoin('pullRequests', (join) =>
-        join
-          .onRef(
-            'pullRequestReviewers.pullRequestNumber',
+      tenantDb
+        .selectFrom('pullRequestReviewers')
+        .innerJoin('pullRequests', (join) =>
+          join
+            .onRef(
+              'pullRequestReviewers.pullRequestNumber',
+              '=',
+              'pullRequests.number',
+            )
+            .onRef(
+              'pullRequestReviewers.repositoryId',
+              '=',
+              'pullRequests.repositoryId',
+            ),
+        )
+        .where((eb) =>
+          eb(eb.fn('lower', ['pullRequests.author']), '=', loginLower),
+        )
+        .where('pullRequests.mergedAt', 'is', null)
+        .where('pullRequests.closedAt', 'is', null)
+        .where('pullRequestReviewers.requestedAt', 'is not', null)
+        .leftJoin('companyGithubUsers', (join) =>
+          join.onRef(
+            (eb) => eb.fn('lower', ['pullRequestReviewers.reviewer']),
             '=',
-            'pullRequests.number',
-          )
-          .onRef(
-            'pullRequestReviewers.repositoryId',
-            '=',
-            'pullRequests.repositoryId',
+            (eb) => eb.fn('lower', ['companyGithubUsers.login']),
           ),
-      )
-      .where((eb) =>
-        eb(eb.fn('lower', ['pullRequests.author']), '=', loginLower),
-      )
-      .where('pullRequests.mergedAt', 'is', null)
-      .where('pullRequests.closedAt', 'is', null)
-      .where('pullRequestReviewers.requestedAt', 'is not', null)
-      .select([
-        'pullRequestReviewers.pullRequestNumber as number',
-        'pullRequestReviewers.repositoryId',
-      ])
-      .execute(),
+        )
+        .select([
+          'pullRequestReviewers.pullRequestNumber as number',
+          'pullRequestReviewers.repositoryId',
+          'pullRequestReviewers.reviewer',
+          'companyGithubUsers.displayName as reviewerDisplayName',
+        ])
+        .execute(),
 
-    tenantDb
-      .selectFrom('pullRequestReviewers')
-      .innerJoin('pullRequests', (join) =>
-        join
-          .onRef(
-            'pullRequestReviewers.pullRequestNumber',
+      tenantDb
+        .selectFrom('pullRequestReviewers')
+        .innerJoin('pullRequests', (join) =>
+          join
+            .onRef(
+              'pullRequestReviewers.pullRequestNumber',
+              '=',
+              'pullRequests.number',
+            )
+            .onRef(
+              'pullRequestReviewers.repositoryId',
+              '=',
+              'pullRequests.repositoryId',
+            ),
+        )
+        .where((eb) =>
+          eb(
+            eb.fn('lower', ['pullRequestReviewers.reviewer']),
             '=',
-            'pullRequests.number',
-          )
-          .onRef(
-            'pullRequestReviewers.repositoryId',
-            '=',
-            'pullRequests.repositoryId',
+            loginLower,
           ),
-      )
-      .where((eb) =>
-        eb(eb.fn('lower', ['pullRequestReviewers.reviewer']), '=', loginLower),
-      )
-      .where('pullRequestReviewers.requestedAt', 'is not', null)
-      .where('pullRequests.mergedAt', 'is', null)
-      .where('pullRequests.closedAt', 'is', null)
-      .select([
-        'pullRequests.number',
-        'pullRequests.repositoryId',
-        'pullRequests.repo',
-        'pullRequests.title',
-        'pullRequests.url',
-        'pullRequests.pullRequestCreatedAt',
-        'pullRequests.complexity',
-        'pullRequests.author',
-      ])
-      .orderBy('pullRequests.pullRequestCreatedAt', 'asc')
-      .execute(),
-  ])
+        )
+        .where('pullRequestReviewers.requestedAt', 'is not', null)
+        .where('pullRequests.mergedAt', 'is', null)
+        .where('pullRequests.closedAt', 'is', null)
+        .leftJoin('companyGithubUsers as authorUser', (join) =>
+          join.onRef(
+            (eb) => eb.fn('lower', ['pullRequests.author']),
+            '=',
+            (eb) => eb.fn('lower', ['authorUser.login']),
+          ),
+        )
+        .select([
+          'pullRequests.number',
+          'pullRequests.repositoryId',
+          'pullRequests.repo',
+          'pullRequests.title',
+          'pullRequests.url',
+          'pullRequests.pullRequestCreatedAt',
+          'pullRequests.complexity',
+          'pullRequests.author',
+          'authorUser.displayName as authorDisplayName',
+        ])
+        .orderBy('pullRequests.pullRequestCreatedAt', 'asc')
+        .execute(),
+
+      tenantDb
+        .selectFrom('pullRequestReviews')
+        .innerJoin('pullRequests', (join) =>
+          join
+            .onRef(
+              'pullRequestReviews.pullRequestNumber',
+              '=',
+              'pullRequests.number',
+            )
+            .onRef(
+              'pullRequestReviews.repositoryId',
+              '=',
+              'pullRequests.repositoryId',
+            ),
+        )
+        .where('pullRequests.mergedAt', 'is', null)
+        .where('pullRequests.closedAt', 'is', null)
+        .where((eb) =>
+          eb.or([
+            eb(eb.fn('lower', ['pullRequests.author']), '=', loginLower),
+            eb.exists(
+              eb
+                .selectFrom('pullRequestReviewers')
+                .whereRef(
+                  'pullRequestReviewers.pullRequestNumber',
+                  '=',
+                  'pullRequests.number',
+                )
+                .whereRef(
+                  'pullRequestReviewers.repositoryId',
+                  '=',
+                  'pullRequests.repositoryId',
+                )
+                .where((eb2) =>
+                  eb2(
+                    eb2.fn('lower', ['pullRequestReviewers.reviewer']),
+                    '=',
+                    loginLower,
+                  ),
+                )
+                .select(eb.lit(1).as('v')),
+            ),
+          ]),
+        )
+        .leftJoin('companyGithubUsers', (join) =>
+          join.onRef(
+            (eb) => eb.fn('lower', ['pullRequestReviews.reviewer']),
+            '=',
+            (eb) => eb.fn('lower', ['companyGithubUsers.login']),
+          ),
+        )
+        .select([
+          'pullRequestReviews.pullRequestNumber as number',
+          'pullRequestReviews.repositoryId',
+          'pullRequestReviews.reviewer',
+          'pullRequestReviews.state',
+          'pullRequestReviews.submittedAt',
+          'companyGithubUsers.displayName as reviewerDisplayName',
+        ])
+        .execute(),
+    ])
 
   const reviewerSet = new Set<string>()
   for (const r of reviewerRows) {
@@ -257,5 +340,5 @@ export const getBacklogDetails = async (
     hasReviewer: reviewerSet.has(`${pr.repositoryId}:${pr.number}`),
   }))
 
-  return { openPRs, pendingReviews }
+  return { openPRs, pendingReviews, reviewHistory, reviewerRows }
 }

--- a/app/routes/$orgSlug/workload/$login/index.tsx
+++ b/app/routes/$orgSlug/workload/$login/index.tsx
@@ -20,11 +20,13 @@ import {
   PRBlock,
   PRPopoverContent,
   REVIEW_STATE_STYLE,
+  REVIEW_STATUS_PRIORITY,
   type PRBlockData,
+  type PRReviewStatus,
 } from '~/app/routes/$orgSlug/+components/pr-block'
 import {
-  buildReviewerStatesMap,
-  classifyReviewStatus,
+  buildPRReviewerStatesMap,
+  classifyPRReviewStatus,
 } from '~/app/routes/$orgSlug/workload/+functions/aggregate-stacks'
 import {
   getBacklogDetails,
@@ -35,13 +37,6 @@ import {
   getUserProfile,
 } from './+functions/queries.server'
 import type { Route } from './+types/index'
-
-const REVIEW_STATUS_PRIORITY: Record<string, number> = {
-  'approved-awaiting-merge': 0,
-  'changes-pending': 1,
-  unassigned: 2,
-  'in-review': 3,
-}
 
 export const handle = {
   breadcrumb: (data: Awaited<ReturnType<typeof loader>>) => ({
@@ -85,7 +80,7 @@ export const loader = async ({
   }
 
   // Enrich backlog PRs with reviewStatus + reviewerStates
-  const reviewerStatesByPR = buildReviewerStatesMap(
+  const reviewerStatesByPR = buildPRReviewerStatesMap(
     backlog.reviewHistory,
     backlog.reviewerRows,
   )
@@ -96,7 +91,7 @@ export const loader = async ({
   const enrichedOpenPRs = backlog.openPRs.map((pr) => {
     const prKey = `${pr.repositoryId}:${pr.number}`
     const reviewerStates = reviewerStatesByPR.get(prKey)
-    const reviewStatus = classifyReviewStatus(
+    const reviewStatus = classifyPRReviewStatus(
       pendingReviewerPRKeys.has(prKey),
       reviewerStates,
       params.login,
@@ -169,25 +164,22 @@ export default function MemberWeeklyPage({
       T extends {
         complexity: string | null
         pullRequestCreatedAt: string
-        reviewStatus?: string
+        reviewStatus?: PRReviewStatus
       },
     >(
       prs: T[],
     ): T[] => {
-      return [...prs]
-        .sort((a, b) => {
-          if (colorMode === 'size') {
-            const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? 99
-            const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? 99
-            return bi - ai
-          }
-          return a.pullRequestCreatedAt.localeCompare(b.pullRequestCreatedAt)
-        })
-        .sort((a, b) => {
-          const pa = REVIEW_STATUS_PRIORITY[a.reviewStatus ?? 'in-review'] ?? 3
-          const pb = REVIEW_STATUS_PRIORITY[b.reviewStatus ?? 'in-review'] ?? 3
-          return pa - pb
-        })
+      return [...prs].sort((a, b) => {
+        const pa = REVIEW_STATUS_PRIORITY[a.reviewStatus ?? 'in-review'] ?? 3
+        const pb = REVIEW_STATUS_PRIORITY[b.reviewStatus ?? 'in-review'] ?? 3
+        if (pa !== pb) return pa - pb
+        if (colorMode === 'size') {
+          const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? 99
+          const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? 99
+          return bi - ai
+        }
+        return a.pullRequestCreatedAt.localeCompare(b.pullRequestCreatedAt)
+      })
     }
   }, [colorMode])
 
@@ -366,7 +358,6 @@ export default function MemberWeeklyPage({
                   url: pr.url,
                   createdAt: pr.pullRequestCreatedAt,
                   complexity: pr.complexity,
-                  hasReviewer: pr.hasReviewer,
                   reviewStatus: pr.reviewStatus,
                   reviewerStates: pr.reviewerStates,
                 }}

--- a/app/routes/$orgSlug/workload/$login/index.tsx
+++ b/app/routes/$orgSlug/workload/$login/index.tsx
@@ -381,7 +381,6 @@ export default function MemberWeeklyPage({
                   reviewStatus: pr.reviewStatus,
                   reviewerStates: pr.reviewerStates,
                 }}
-                showAuthor
               />
             ))}
           </BlockRow>
@@ -510,7 +509,6 @@ export default function MemberWeeklyPage({
                           createdAt: r.pullRequestCreatedAt,
                           complexity: r.complexity,
                         }}
-                        showAuthor
                         reviewState={r.state}
                         reviewCount={r.reviewCount}
                         suffix={REVIEW_STATE_STYLE[r.state]?.icon}
@@ -666,7 +664,6 @@ function CalendarItem({
   suffix,
   complexity,
   prData,
-  showAuthor,
   reviewState,
   reviewCount,
 }: {
@@ -676,7 +673,6 @@ function CalendarItem({
   suffix?: string
   complexity?: string | null
   prData?: PRBlockData
-  showAuthor?: boolean
   reviewState?: string
   reviewCount?: number
 }) {
@@ -722,11 +718,7 @@ function CalendarItem({
     <Popover>
       <PopoverTrigger asChild>{content}</PopoverTrigger>
       <PopoverContent side="top" className="w-72 p-3">
-        <PRPopoverContent
-          pr={prData}
-          showAuthor={showAuthor}
-          reviewState={reviewState}
-        />
+        <PRPopoverContent pr={prData} reviewState={reviewState} />
       </PopoverContent>
     </Popover>
   )

--- a/app/routes/$orgSlug/workload/$login/index.tsx
+++ b/app/routes/$orgSlug/workload/$login/index.tsx
@@ -23,6 +23,10 @@ import {
   type PRBlockData,
 } from '~/app/routes/$orgSlug/+components/pr-block'
 import {
+  buildReviewerStatesMap,
+  classifyReviewStatus,
+} from '~/app/routes/$orgSlug/workload/+functions/aggregate-stacks'
+import {
   getBacklogDetails,
   getClosedPRs,
   getCreatedPRs,
@@ -31,6 +35,13 @@ import {
   getUserProfile,
 } from './+functions/queries.server'
 import type { Route } from './+types/index'
+
+const REVIEW_STATUS_PRIORITY: Record<string, number> = {
+  'approved-awaiting-merge': 0,
+  'changes-pending': 1,
+  unassigned: 2,
+  'in-review': 3,
+}
 
 export const handle = {
   breadcrumb: (data: Awaited<ReturnType<typeof loader>>) => ({
@@ -73,13 +84,41 @@ export const loader = async ({
     holidays[dayjs(h.date).tz(timezone).format('YYYY-MM-DD')] = h.name
   }
 
+  // Enrich backlog PRs with reviewStatus + reviewerStates
+  const reviewerStatesByPR = buildReviewerStatesMap(
+    backlog.reviewHistory,
+    backlog.reviewerRows,
+  )
+  const pendingReviewerPRKeys = new Set<string>()
+  for (const r of backlog.reviewerRows) {
+    pendingReviewerPRKeys.add(`${r.repositoryId}:${r.number}`)
+  }
+  const enrichedOpenPRs = backlog.openPRs.map((pr) => {
+    const prKey = `${pr.repositoryId}:${pr.number}`
+    const reviewerStates = reviewerStatesByPR.get(prKey)
+    const reviewStatus = classifyReviewStatus(
+      pendingReviewerPRKeys.has(prKey),
+      reviewerStates,
+      params.login,
+    )
+    return { ...pr, reviewStatus, reviewerStates }
+  })
+  const enrichedPendingReviews = backlog.pendingReviews.map((pr) => {
+    const prKey = `${pr.repositoryId}:${pr.number}`
+    const reviewerStates = reviewerStatesByPR.get(prKey)
+    return { ...pr, reviewStatus: 'in-review' as const, reviewerStates }
+  })
+
   return {
     user,
     createdPRs,
     mergedPRs,
     closedPRs,
     reviews,
-    backlog,
+    backlog: {
+      openPRs: enrichedOpenPRs,
+      pendingReviews: enrichedPendingReviews,
+    },
     holidays,
     weekStart: weekStart.format('YYYY-MM-DD'),
     weekEnd: weekEnd.format('YYYY-MM-DD'),
@@ -125,29 +164,30 @@ export default function MemberWeeklyPage({
     })
   }
 
-  // Sort backlog PRs by color mode (assigned first, then by age or size)
   const sortBacklog = useMemo(() => {
     return <
       T extends {
         complexity: string | null
         pullRequestCreatedAt: string
-        hasReviewer?: boolean
+        reviewStatus?: string
       },
     >(
       prs: T[],
     ): T[] => {
-      const sorted = [...prs].sort((a, b) => {
-        if (colorMode === 'size') {
-          const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? 99
-          const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? 99
-          return bi - ai
-        }
-        // Older first (ascending createdAt = descending age)
-        return a.pullRequestCreatedAt.localeCompare(b.pullRequestCreatedAt)
-      })
-      const assigned = sorted.filter((p) => p.hasReviewer !== false)
-      const unassigned = sorted.filter((p) => p.hasReviewer === false)
-      return [...assigned, ...unassigned]
+      return [...prs]
+        .sort((a, b) => {
+          if (colorMode === 'size') {
+            const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? 99
+            const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? 99
+            return bi - ai
+          }
+          return a.pullRequestCreatedAt.localeCompare(b.pullRequestCreatedAt)
+        })
+        .sort((a, b) => {
+          const pa = REVIEW_STATUS_PRIORITY[a.reviewStatus ?? 'in-review'] ?? 3
+          const pb = REVIEW_STATUS_PRIORITY[b.reviewStatus ?? 'in-review'] ?? 3
+          return pa - pb
+        })
     }
   }, [colorMode])
 
@@ -327,6 +367,8 @@ export default function MemberWeeklyPage({
                   createdAt: pr.pullRequestCreatedAt,
                   complexity: pr.complexity,
                   hasReviewer: pr.hasReviewer,
+                  reviewStatus: pr.reviewStatus,
+                  reviewerStates: pr.reviewerStates,
                 }}
               />
             ))}
@@ -342,8 +384,11 @@ export default function MemberWeeklyPage({
                   title: pr.title,
                   url: pr.url,
                   author: pr.author,
+                  authorDisplayName: pr.authorDisplayName ?? undefined,
                   createdAt: pr.pullRequestCreatedAt,
                   complexity: pr.complexity,
+                  reviewStatus: pr.reviewStatus,
+                  reviewerStates: pr.reviewerStates,
                 }}
                 showAuthor
               />

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -477,13 +477,6 @@ export function TeamStacksChart({ data }: { data: TeamStacksData }) {
   } = data
   const reviewQueueBuckets: BucketConfig[] = [
     {
-      key: 'unassigned',
-      label: 'Unassigned',
-      prs: unassignedPRs,
-      labelColor: 'text-amber-700 dark:text-amber-400',
-      pillBg: 'bg-amber-100 dark:bg-amber-950',
-    },
-    {
       key: 'approved-awaiting-merge',
       label: 'Approved',
       prs: approvedAwaitingMergePRs,
@@ -496,6 +489,13 @@ export function TeamStacksChart({ data }: { data: TeamStacksData }) {
       prs: changesPendingPRs,
       labelColor: 'text-amber-700 dark:text-amber-400',
       pillBg: 'bg-amber-50 dark:bg-amber-950/50',
+    },
+    {
+      key: 'unassigned',
+      label: 'Unassigned',
+      prs: unassignedPRs,
+      labelColor: 'text-amber-700 dark:text-amber-400',
+      pillBg: 'bg-amber-100 dark:bg-amber-950',
     },
   ]
   const [searchParams, setSearchParams] = useSearchParams()

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -392,27 +392,11 @@ function BucketRow({
   )
 }
 
-const SHAPE_LEGEND_ITEMS: { key: string; label: string; swatch: string }[] = [
-  {
-    key: 'in-review',
-    label: REVIEW_STATUS_SHAPE['in-review'].label,
-    swatch: REVIEW_STATUS_SHAPE['in-review'].legendSwatch,
-  },
-  {
-    key: 'approved',
-    label: REVIEW_STATUS_SHAPE['approved-awaiting-merge'].label,
-    swatch: REVIEW_STATUS_SHAPE['approved-awaiting-merge'].legendSwatch,
-  },
-  {
-    key: 'changes',
-    label: REVIEW_STATUS_SHAPE['changes-pending'].label,
-    swatch: REVIEW_STATUS_SHAPE['changes-pending'].legendSwatch,
-  },
-  {
-    key: 'unassigned',
-    label: REVIEW_STATUS_SHAPE.unassigned.label,
-    swatch: REVIEW_STATUS_SHAPE.unassigned.legendSwatch,
-  },
+const SHAPE_LEGEND_ENTRIES = [
+  REVIEW_STATUS_SHAPE['in-review'],
+  REVIEW_STATUS_SHAPE['approved-awaiting-merge'],
+  REVIEW_STATUS_SHAPE['changes-pending'],
+  REVIEW_STATUS_SHAPE.unassigned,
 ]
 
 function Legend({ mode }: { mode: ColorMode }) {
@@ -446,10 +430,20 @@ function Legend({ mode }: { mode: ColorMode }) {
         <span className="text-muted-foreground">Limit</span>
       </div>
       <div className="text-muted-foreground">|</div>
-      {SHAPE_LEGEND_ITEMS.map((item) => (
-        <div key={item.key} className="flex items-center gap-1">
-          <div className={item.swatch} />
-          <span className="text-muted-foreground">{item.label}</span>
+      {SHAPE_LEGEND_ENTRIES.map((entry) => (
+        <div key={entry.label} className="flex items-center gap-1">
+          <div
+            className={`flex items-center justify-center ${entry.legendSwatch}`}
+          >
+            {entry.icon && (
+              <span
+                className={`text-[7px] leading-none font-bold ${entry.iconColor ?? ''}`}
+              >
+                {entry.icon}
+              </span>
+            )}
+          </div>
+          <span className="text-muted-foreground">{entry.label}</span>
         </div>
       ))}
     </div>

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -246,7 +246,8 @@ const PRBlock = memo(function PRBlock({
           createdAt: pr.createdAt,
           complexity: pr.complexity,
           hasReviewer: pr.hasReviewer,
-          reviewers: pr.reviewers,
+          reviewStatus: pr.reviewStatus,
+          reviewerStates: pr.reviewerStates,
         }}
         colorMode={colorMode}
         showAuthor={showAuthor}
@@ -259,22 +260,33 @@ const PRBlock = memo(function PRBlock({
   )
 })
 
+interface BucketConfig {
+  key: string
+  label: string
+  prs: StackPR[]
+  /** Tailwind text color for label */
+  labelColor: string
+  /** Tailwind border color for top divider */
+  borderColor: string
+}
+
 function StackColumn({
   title,
   stacks,
   personalLimit,
   showAuthor,
-  unassignedPRs,
+  buckets,
 }: {
   title: string
   stacks: PersonStack[]
   personalLimit: number
   showAuthor?: boolean
-  unassignedPRs?: StackPR[]
+  buckets?: BucketConfig[]
 }) {
-  const hasUnassigned = unassignedPRs && unassignedPRs.length > 0
+  const activeBuckets = buckets?.filter((b) => b.prs.length > 0) ?? []
+  const hasBuckets = activeBuckets.length > 0
 
-  if (stacks.length === 0 && !hasUnassigned) {
+  if (stacks.length === 0 && !hasBuckets) {
     return (
       <div>
         <h3 className="text-muted-foreground mb-2 text-sm font-medium">
@@ -302,13 +314,31 @@ function StackColumn({
             showAuthor={showAuthor}
           />
         ))}
-        {hasUnassigned && <UnassignedRows prs={unassignedPRs} />}
+        {activeBuckets.map((bucket) => (
+          <BucketRow
+            key={bucket.key}
+            label={bucket.label}
+            prs={bucket.prs}
+            labelColor={bucket.labelColor}
+            borderColor={bucket.borderColor}
+          />
+        ))}
       </div>
     </div>
   )
 }
 
-function UnassignedRows({ prs }: { prs: StackPR[] }) {
+function BucketRow({
+  label,
+  prs,
+  labelColor,
+  borderColor,
+}: {
+  label: string
+  prs: StackPR[]
+  labelColor: string
+  borderColor: string
+}) {
   const colorMode = useContext(ColorModeContext)
   const hovered = useContext(HoveredContext)
   const selected = useContext(SelectedContext)
@@ -328,11 +358,11 @@ function UnassignedRows({ prs }: { prs: StackPR[] }) {
   return (
     <div
       ref={rowRef}
-      className={`mt-3 border-t-2 border-dashed border-amber-400 pt-2 transition-colors ${isRelated ? 'bg-accent rounded' : ''}`}
+      className={`mt-3 border-t-2 border-dashed ${borderColor} pt-2 transition-colors ${isRelated ? 'bg-accent rounded' : ''}`}
     >
       <div className="flex items-center gap-3 py-1.5">
-        <span className="w-28 shrink-0 text-sm font-medium text-amber-600 dark:text-amber-400">
-          No reviewer
+        <span className={`w-28 shrink-0 text-sm font-medium ${labelColor}`}>
+          {label}
         </span>
         <span className="text-muted-foreground w-8 shrink-0 text-right font-mono text-sm">
           {prs.length}
@@ -391,9 +421,35 @@ export function TeamStacksChart({ data }: { data: TeamStacksData }) {
     authorStacks,
     reviewerStacks,
     unassignedPRs,
+    approvedAwaitingMergePRs,
+    changesPendingPRs,
     personalLimit,
     insight,
+    autoMergeSuggestion,
   } = data
+  const reviewQueueBuckets: BucketConfig[] = [
+    {
+      key: 'unassigned',
+      label: 'Unassigned',
+      prs: unassignedPRs,
+      labelColor: 'text-amber-600 dark:text-amber-400',
+      borderColor: 'border-amber-400',
+    },
+    {
+      key: 'approved-awaiting-merge',
+      label: 'Approved / Merge待ち',
+      prs: approvedAwaitingMergePRs,
+      labelColor: 'text-emerald-600 dark:text-emerald-400',
+      borderColor: 'border-emerald-400',
+    },
+    {
+      key: 'changes-pending',
+      label: '作者対応待ち',
+      prs: changesPendingPRs,
+      labelColor: 'text-muted-foreground',
+      borderColor: 'border-muted-foreground/40',
+    },
+  ]
   const [searchParams, setSearchParams] = useSearchParams()
   const colorMode: ColorMode =
     searchParams.get('view') === 'size' ? 'size' : 'age'
@@ -478,7 +534,7 @@ export function TeamStacksChart({ data }: { data: TeamStacksData }) {
                       stacks={reviewerStacks}
                       personalLimit={personalLimit}
                       showAuthor
-                      unassignedPRs={unassignedPRs}
+                      buckets={reviewQueueBuckets}
                     />
                   </div>
                   <div className="flex flex-wrap items-center justify-between gap-x-4 gap-y-2">
@@ -514,7 +570,9 @@ export function TeamStacksChart({ data }: { data: TeamStacksData }) {
                     </p>
                   </div>
                   {insight && (
-                    <p className="text-muted-foreground text-center text-sm">
+                    <p
+                      className={`text-center text-sm ${autoMergeSuggestion ? 'text-emerald-700 dark:text-emerald-400' : 'text-muted-foreground'}`}
+                    >
                       {insight}
                     </p>
                   )}

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -77,14 +77,20 @@ const SetSelectedContext = createContext<
 >(() => {})
 const ColorModeContext = createContext<ColorMode>('age')
 
+const REVIEW_STATUS_PRIORITY: Record<string, number> = {
+  'approved-awaiting-merge': 0,
+  'changes-pending': 1,
+  unassigned: 2,
+  'in-review': 3,
+}
+
 function sortPRs(prs: StackPR[], mode: ColorMode): StackPR[] {
   const baseSorted = mode === 'size' ? sortBySize(prs) : sortByAge(prs)
-  const assigned: StackPR[] = []
-  const unassigned: StackPR[] = []
-  for (const p of baseSorted) {
-    ;(p.hasReviewer === false ? unassigned : assigned).push(p)
-  }
-  return [...assigned, ...unassigned]
+  return [...baseSorted].sort((a, b) => {
+    const pa = REVIEW_STATUS_PRIORITY[a.reviewStatus ?? 'in-review'] ?? 3
+    const pb = REVIEW_STATUS_PRIORITY[b.reviewStatus ?? 'in-review'] ?? 3
+    return pa - pb
+  })
 }
 
 // --- Scroll helper ---

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -436,9 +436,7 @@ function Legend({ mode }: { mode: ColorMode }) {
             className={`flex items-center justify-center ${entry.legendSwatch}`}
           >
             {entry.icon && (
-              <span
-                className={`text-[7px] leading-none font-bold ${entry.iconColor ?? ''}`}
-              >
+              <span className="text-[7px] leading-none font-bold text-gray-500 dark:text-gray-400">
                 {entry.icon}
               </span>
             )}

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -391,35 +391,26 @@ function BucketRow({
   )
 }
 
-const SHAPE_LEGEND_ITEMS: {
-  key: string
-  label: string
-  swatch: string
-  color: string
-}[] = [
+const SHAPE_LEGEND_ITEMS: { key: string; label: string; swatch: string }[] = [
   {
     key: 'in-review',
     label: REVIEW_STATUS_SHAPE['in-review'].label,
     swatch: REVIEW_STATUS_SHAPE['in-review'].legendSwatch,
-    color: 'text-muted-foreground',
-  },
-  {
-    key: 'unassigned',
-    label: REVIEW_STATUS_SHAPE.unassigned.label,
-    swatch: REVIEW_STATUS_SHAPE.unassigned.legendSwatch,
-    color: REVIEW_STATUS_SHAPE.unassigned.text,
   },
   {
     key: 'approved',
     label: REVIEW_STATUS_SHAPE['approved-awaiting-merge'].label,
     swatch: REVIEW_STATUS_SHAPE['approved-awaiting-merge'].legendSwatch,
-    color: REVIEW_STATUS_SHAPE['approved-awaiting-merge'].text,
   },
   {
     key: 'changes',
     label: REVIEW_STATUS_SHAPE['changes-pending'].label,
     swatch: REVIEW_STATUS_SHAPE['changes-pending'].legendSwatch,
-    color: REVIEW_STATUS_SHAPE['changes-pending'].text,
+  },
+  {
+    key: 'unassigned',
+    label: REVIEW_STATUS_SHAPE.unassigned.label,
+    swatch: REVIEW_STATUS_SHAPE.unassigned.legendSwatch,
   },
 ]
 
@@ -455,9 +446,9 @@ function Legend({ mode }: { mode: ColorMode }) {
       </div>
       <div className="text-muted-foreground">|</div>
       {SHAPE_LEGEND_ITEMS.map((item) => (
-        <div key={item.key} className={`flex items-center gap-1 ${item.color}`}>
+        <div key={item.key} className="flex items-center gap-1">
           <div className={item.swatch} />
-          <span>{item.label}</span>
+          <span className="text-muted-foreground">{item.label}</span>
         </div>
       ))}
     </div>

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -161,11 +161,9 @@ function MemberLink({
 function StackRow({
   stack,
   personalLimit,
-  showAuthor,
 }: {
   stack: PersonStack
   personalLimit: number
-  showAuthor?: boolean
 }) {
   const colorMode = useContext(ColorModeContext)
   const hovered = useContext(HoveredContext)
@@ -209,7 +207,6 @@ function StackRow({
             key={`${pr.repo}:${pr.number}`}
             pr={pr}
             showLimitLine={i === personalLimit && isOver}
-            showAuthor={showAuthor}
           />
         ))}
       </div>
@@ -222,11 +219,9 @@ function StackRow({
 const PRBlock = memo(function PRBlock({
   pr,
   showLimitLine,
-  showAuthor,
 }: {
   pr: StackPR
   showLimitLine: boolean
-  showAuthor?: boolean
 }) {
   const colorMode = useContext(ColorModeContext)
   const setHovered = useContext(SetHoveredContext)
@@ -252,7 +247,6 @@ const PRBlock = memo(function PRBlock({
           reviewerStates: pr.reviewerStates,
         }}
         colorMode={colorMode}
-        showAuthor={showAuthor}
         dataPrKey={prKey}
         onMouseEnter={() => setHovered({ prKey, author: pr.author })}
         onMouseLeave={() => setHovered(null)}
@@ -276,13 +270,11 @@ function StackColumn({
   title,
   stacks,
   personalLimit,
-  showAuthor,
   buckets,
 }: {
   title: string
   stacks: PersonStack[]
   personalLimit: number
-  showAuthor?: boolean
   buckets?: BucketConfig[]
 }) {
   const activeBuckets = buckets?.filter((b) => b.prs.length > 0) ?? []
@@ -313,7 +305,6 @@ function StackColumn({
             key={stack.login}
             stack={stack}
             personalLimit={personalLimit}
-            showAuthor={showAuthor}
           />
         ))}
         {activeBuckets.map((bucket) => (
@@ -377,7 +368,6 @@ function BucketRow({
               key={`${pr.repo}:${pr.number}`}
               pr={pr}
               showLimitLine={false}
-              showAuthor
             />
           ))}
         </div>
@@ -559,7 +549,6 @@ export function TeamStacksChart({ data }: { data: TeamStacksData }) {
                       title="Review Queue (pending)"
                       stacks={reviewerStacks}
                       personalLimit={personalLimit}
-                      showAuthor
                       buckets={reviewQueueBuckets}
                     />
                   </div>

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -21,6 +21,7 @@ import type {
 import {
   AGE_THRESHOLDS,
   PRBlock as PRBlockBase,
+  REVIEW_STATUS_SHAPE,
   SIZE_BLOCK_COLORS,
   UNKNOWN_COLOR,
   type PRBlockColorMode as ColorMode,
@@ -264,10 +265,10 @@ interface BucketConfig {
   key: string
   label: string
   prs: StackPR[]
-  /** Tailwind text color for label */
+  /** Tailwind text color for label pill */
   labelColor: string
-  /** Tailwind border color for top divider */
-  borderColor: string
+  /** Tailwind bg for label pill */
+  pillBg: string
 }
 
 function StackColumn({
@@ -320,7 +321,7 @@ function StackColumn({
             label={bucket.label}
             prs={bucket.prs}
             labelColor={bucket.labelColor}
-            borderColor={bucket.borderColor}
+            pillBg={bucket.pillBg}
           />
         ))}
       </div>
@@ -332,12 +333,12 @@ function BucketRow({
   label,
   prs,
   labelColor,
-  borderColor,
+  pillBg,
 }: {
   label: string
   prs: StackPR[]
   labelColor: string
-  borderColor: string
+  pillBg: string
 }) {
   const colorMode = useContext(ColorModeContext)
   const hovered = useContext(HoveredContext)
@@ -358,14 +359,16 @@ function BucketRow({
   return (
     <div
       ref={rowRef}
-      className={`mt-3 border-t-2 border-dashed ${borderColor} pt-2 transition-colors ${isRelated ? 'bg-accent rounded' : ''}`}
+      className={`mt-2 pt-1 transition-colors ${isRelated ? 'bg-accent rounded' : ''}`}
     >
       <div className="flex items-center gap-3 py-1.5">
-        <span className={`w-28 shrink-0 text-sm font-medium ${labelColor}`}>
+        <span
+          className={`inline-flex w-28 shrink-0 items-center justify-center rounded-full px-2 py-0.5 text-xs font-medium ${pillBg} ${labelColor}`}
+        >
           {label}
-        </span>
-        <span className="text-muted-foreground w-8 shrink-0 text-right font-mono text-sm">
-          {prs.length}
+          <span className="text-muted-foreground ml-1 font-mono">
+            {prs.length}
+          </span>
         </span>
         <div className="flex min-w-0 flex-1 flex-wrap items-center gap-0.5">
           {sortedPRs.map((pr) => (
@@ -382,9 +385,41 @@ function BucketRow({
   )
 }
 
+const SHAPE_LEGEND_ITEMS: {
+  key: string
+  label: string
+  swatch: string
+  color: string
+}[] = [
+  {
+    key: 'in-review',
+    label: REVIEW_STATUS_SHAPE['in-review'].label,
+    swatch: REVIEW_STATUS_SHAPE['in-review'].legendSwatch,
+    color: 'text-muted-foreground',
+  },
+  {
+    key: 'unassigned',
+    label: REVIEW_STATUS_SHAPE.unassigned.label,
+    swatch: REVIEW_STATUS_SHAPE.unassigned.legendSwatch,
+    color: REVIEW_STATUS_SHAPE.unassigned.text,
+  },
+  {
+    key: 'approved',
+    label: REVIEW_STATUS_SHAPE['approved-awaiting-merge'].label,
+    swatch: REVIEW_STATUS_SHAPE['approved-awaiting-merge'].legendSwatch,
+    color: REVIEW_STATUS_SHAPE['approved-awaiting-merge'].text,
+  },
+  {
+    key: 'changes',
+    label: REVIEW_STATUS_SHAPE['changes-pending'].label,
+    swatch: REVIEW_STATUS_SHAPE['changes-pending'].legendSwatch,
+    color: REVIEW_STATUS_SHAPE['changes-pending'].text,
+  },
+]
+
 function Legend({ mode }: { mode: ColorMode }) {
   return (
-    <div className="flex flex-wrap items-center gap-3 text-xs">
+    <div className="flex flex-wrap items-center gap-x-3 gap-y-1 text-xs">
       {mode === 'size' ? (
         <>
           {PR_SIZE_LABELS.map((label) => (
@@ -412,6 +447,13 @@ function Legend({ mode }: { mode: ColorMode }) {
         <div className="h-4 w-px border-l-2 border-dashed border-red-400" />
         <span className="text-muted-foreground">Limit</span>
       </div>
+      <div className="text-muted-foreground">|</div>
+      {SHAPE_LEGEND_ITEMS.map((item) => (
+        <div key={item.key} className={`flex items-center gap-1 ${item.color}`}>
+          <div className={item.swatch} />
+          <span>{item.label}</span>
+        </div>
+      ))}
     </div>
   )
 }
@@ -432,22 +474,22 @@ export function TeamStacksChart({ data }: { data: TeamStacksData }) {
       key: 'unassigned',
       label: 'Unassigned',
       prs: unassignedPRs,
-      labelColor: 'text-amber-600 dark:text-amber-400',
-      borderColor: 'border-amber-400',
+      labelColor: 'text-amber-700 dark:text-amber-400',
+      pillBg: 'bg-amber-100 dark:bg-amber-950',
     },
     {
       key: 'approved-awaiting-merge',
-      label: 'Approved / Merge待ち',
+      label: 'Approved',
       prs: approvedAwaitingMergePRs,
-      labelColor: 'text-emerald-600 dark:text-emerald-400',
-      borderColor: 'border-emerald-400',
+      labelColor: 'text-emerald-700 dark:text-emerald-400',
+      pillBg: 'bg-emerald-100 dark:bg-emerald-950',
     },
     {
       key: 'changes-pending',
-      label: '作者対応待ち',
+      label: 'Changes',
       prs: changesPendingPRs,
-      labelColor: 'text-muted-foreground',
-      borderColor: 'border-muted-foreground/40',
+      labelColor: 'text-amber-700 dark:text-amber-400',
+      pillBg: 'bg-amber-50 dark:bg-amber-950/50',
     },
   ]
   const [searchParams, setSearchParams] = useSearchParams()

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -250,6 +250,7 @@ const PRBlock = memo(function PRBlock({
           title: pr.title,
           url: pr.url,
           author: pr.author,
+          authorDisplayName: pr.authorDisplayName,
           createdAt: pr.createdAt,
           complexity: pr.complexity,
           hasReviewer: pr.hasReviewer,

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -21,10 +21,12 @@ import type {
 import {
   AGE_THRESHOLDS,
   PRBlock as PRBlockBase,
+  REVIEW_STATUS_PRIORITY,
   REVIEW_STATUS_SHAPE,
   SIZE_BLOCK_COLORS,
   UNKNOWN_COLOR,
   type PRBlockColorMode as ColorMode,
+  type PRReviewStatus,
 } from '../../+components/pr-block'
 
 function sortBySize(prs: StackPR[]): StackPR[] {
@@ -76,13 +78,6 @@ const SetSelectedContext = createContext<
   ) => void
 >(() => {})
 const ColorModeContext = createContext<ColorMode>('age')
-
-const REVIEW_STATUS_PRIORITY: Record<string, number> = {
-  'approved-awaiting-merge': 0,
-  'changes-pending': 1,
-  unassigned: 2,
-  'in-review': 3,
-}
 
 function sortPRs(prs: StackPR[], mode: ColorMode): StackPR[] {
   const baseSorted = mode === 'size' ? sortBySize(prs) : sortByAge(prs)
@@ -253,7 +248,6 @@ const PRBlock = memo(function PRBlock({
           authorDisplayName: pr.authorDisplayName,
           createdAt: pr.createdAt,
           complexity: pr.complexity,
-          hasReviewer: pr.hasReviewer,
           reviewStatus: pr.reviewStatus,
           reviewerStates: pr.reviewerStates,
         }}
@@ -269,7 +263,7 @@ const PRBlock = memo(function PRBlock({
 })
 
 interface BucketConfig {
-  key: string
+  key: PRReviewStatus
   label: string
   prs: StackPR[]
   /** Tailwind text color for label pill */

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.test.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.test.ts
@@ -447,7 +447,7 @@ describe('aggregateTeamStacks', () => {
       expect(result.approvedAwaitingMergePRs).toHaveLength(0)
     })
 
-    test('commented only (no approve/changes) → changesPendingPRs', () => {
+    test('commented only (no approve/changes) → unassignedPRs', () => {
       const openPRs = [makePR({ number: 1 })]
       const reviewHistory = [
         makeReviewHistory({ reviewer: 'bob', state: 'COMMENTED' }),
@@ -458,8 +458,9 @@ describe('aggregateTeamStacks', () => {
         reviewHistory,
       })
 
-      expect(result.changesPendingPRs).toHaveLength(1)
-      expect(result.changesPendingPRs[0].reviewStatus).toBe('changes-pending')
+      expect(result.unassignedPRs).toHaveLength(1)
+      expect(result.unassignedPRs[0].reviewStatus).toBe('unassigned')
+      expect(result.changesPendingPRs).toHaveLength(0)
     })
 
     test('approved takes priority over changes_requested', () => {

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.test.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.test.ts
@@ -172,10 +172,8 @@ describe('aggregateTeamStacks', () => {
     const alice = result.authorStacks[0]
     const pr1 = alice.prs.find((p) => p.number === 1)
     const pr2 = alice.prs.find((p) => p.number === 2)
-    expect(pr1?.hasReviewer).toBe(true)
     expect(pr1?.reviewStatus).toBe('in-review')
     expect(pr1?.reviewerStates?.map((r) => r.login)).toEqual(['bob'])
-    expect(pr2?.hasReviewer).toBe(false)
     expect(pr2?.reviewStatus).toBe('unassigned')
     expect(pr2?.reviewerStates).toBeUndefined()
   })

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.test.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest'
-import { DEFAULT_PERSONAL_LIMIT, aggregateTeamStacks } from './aggregate-stacks'
+import {
+  AUTO_MERGE_SUGGESTION_THRESHOLD,
+  DEFAULT_PERSONAL_LIMIT,
+  aggregateTeamStacks,
+} from './aggregate-stacks'
 
 function makePR(
   overrides: Partial<{
@@ -12,7 +16,6 @@ function makePR(
     url: string
     pullRequestCreatedAt: string
     complexity: string | null
-    hasAnyReviewer: boolean
   }> = {},
 ) {
   return {
@@ -25,7 +28,27 @@ function makePR(
     url: 'https://github.com/org/repo/pull/1',
     pullRequestCreatedAt: '2026-03-01T00:00:00Z',
     complexity: null,
-    hasAnyReviewer: false,
+    ...overrides,
+  }
+}
+
+function makeReviewHistory(
+  overrides: Partial<{
+    number: number
+    repositoryId: string
+    reviewer: string
+    reviewerDisplayName: string | null
+    state: string
+    submittedAt: string
+  }> = {},
+) {
+  return {
+    number: 1,
+    repositoryId: 'repo-1',
+    reviewer: 'bob',
+    reviewerDisplayName: null,
+    state: 'APPROVED',
+    submittedAt: '2026-03-02T00:00:00Z',
     ...overrides,
   }
 }
@@ -61,23 +84,26 @@ function makeReview(
 
 describe('aggregateTeamStacks', () => {
   test('empty data returns empty stacks and no insight', () => {
-    const result = aggregateTeamStacks([], [])
+    const result = aggregateTeamStacks({ openPRs: [], pendingReviews: [] })
     expect(result).toEqual({
       authorStacks: [],
       reviewerStacks: [],
       unassignedPRs: [],
+      approvedAwaitingMergePRs: [],
+      changesPendingPRs: [],
       personalLimit: DEFAULT_PERSONAL_LIMIT,
       insight: null,
+      autoMergeSuggestion: false,
     })
   })
 
   test('groups open PRs by author', () => {
-    const prs = [
+    const openPRs = [
       makePR({ author: 'alice', number: 1 }),
       makePR({ author: 'alice', number: 2 }),
       makePR({ author: 'bob', number: 3 }),
     ]
-    const result = aggregateTeamStacks(prs, [])
+    const result = aggregateTeamStacks({ openPRs, pendingReviews: [] })
 
     expect(result.authorStacks).toHaveLength(2)
     const alice = result.authorStacks.find((s) => s.login === 'alice')
@@ -87,23 +113,23 @@ describe('aggregateTeamStacks', () => {
   })
 
   test('author stacks sorted by PR count descending', () => {
-    const prs = [
+    const openPRs = [
       makePR({ author: 'bob', number: 1 }),
       makePR({ author: 'alice', number: 2 }),
       makePR({ author: 'alice', number: 3 }),
       makePR({ author: 'alice', number: 4 }),
     ]
-    const result = aggregateTeamStacks(prs, [])
+    const result = aggregateTeamStacks({ openPRs, pendingReviews: [] })
     expect(result.authorStacks[0].login).toBe('alice')
     expect(result.authorStacks[1].login).toBe('bob')
   })
 
   test('uses authorDisplayName when available, falls back to login', () => {
-    const prs = [
+    const openPRs = [
       makePR({ author: 'alice', authorDisplayName: 'Alice Smith' }),
       makePR({ author: 'bob', authorDisplayName: null, number: 2 }),
     ]
-    const result = aggregateTeamStacks(prs, [])
+    const result = aggregateTeamStacks({ openPRs, pendingReviews: [] })
     const alice = result.authorStacks.find((s) => s.login === 'alice')
     const bob = result.authorStacks.find((s) => s.login === 'bob')
     expect(alice?.displayName).toBe('Alice Smith')
@@ -111,12 +137,12 @@ describe('aggregateTeamStacks', () => {
   })
 
   test('groups pending reviews by reviewer', () => {
-    const reviews = [
+    const pendingReviews = [
       makeReview({ reviewer: 'bob', number: 1 }),
       makeReview({ reviewer: 'bob', number: 2 }),
       makeReview({ reviewer: 'carol', number: 3 }),
     ]
-    const result = aggregateTeamStacks([], reviews)
+    const result = aggregateTeamStacks({ openPRs: [], pendingReviews })
 
     expect(result.reviewerStacks).toHaveLength(2)
     const bob = result.reviewerStacks.find((s) => s.login === 'bob')
@@ -126,119 +152,488 @@ describe('aggregateTeamStacks', () => {
   })
 
   test('deduplicates reviewer entries for the same PR', () => {
-    const reviews = [
+    const pendingReviews = [
       makeReview({ reviewer: 'bob', number: 1, repositoryId: 'repo-1' }),
       makeReview({ reviewer: 'bob', number: 1, repositoryId: 'repo-1' }),
     ]
-    const result = aggregateTeamStacks([], reviews)
+    const result = aggregateTeamStacks({ openPRs: [], pendingReviews })
     const bob = result.reviewerStacks.find((s) => s.login === 'bob')
     expect(bob?.prs).toHaveLength(1)
   })
 
   test('marks PRs with reviewers in author stacks', () => {
-    const prs = [
-      makePR({ author: 'alice', number: 1, hasAnyReviewer: true }),
-      makePR({ author: 'alice', number: 2, hasAnyReviewer: false }),
+    const openPRs = [
+      makePR({ author: 'alice', number: 1 }),
+      makePR({ author: 'alice', number: 2 }),
     ]
-    const reviews = [makeReview({ reviewer: 'bob', number: 1 })]
-    const result = aggregateTeamStacks(prs, reviews)
+    const pendingReviews = [makeReview({ reviewer: 'bob', number: 1 })]
+    const result = aggregateTeamStacks({ openPRs, pendingReviews })
 
     const alice = result.authorStacks[0]
     const pr1 = alice.prs.find((p) => p.number === 1)
     const pr2 = alice.prs.find((p) => p.number === 2)
     expect(pr1?.hasReviewer).toBe(true)
-    expect(pr1?.reviewers).toEqual(['bob'])
+    expect(pr1?.reviewStatus).toBe('in-review')
+    expect(pr1?.reviewerStates?.map((r) => r.login)).toEqual(['bob'])
     expect(pr2?.hasReviewer).toBe(false)
-    expect(pr2?.reviewers).toBeUndefined()
+    expect(pr2?.reviewStatus).toBe('unassigned')
+    expect(pr2?.reviewerStates).toBeUndefined()
   })
 
   test('collects multiple reviewers for same PR', () => {
-    const prs = [makePR({ author: 'alice', number: 1, hasAnyReviewer: true })]
-    const reviews = [
+    const openPRs = [makePR({ author: 'alice', number: 1 })]
+    const pendingReviews = [
       makeReview({ reviewer: 'bob', number: 1 }),
       makeReview({ reviewer: 'carol', number: 1 }),
     ]
-    const result = aggregateTeamStacks(prs, reviews)
+    const result = aggregateTeamStacks({ openPRs, pendingReviews })
 
     const pr = result.authorStacks[0].prs[0]
-    expect(pr.reviewers).toHaveLength(2)
-    expect(pr.reviewers).toContain('bob')
-    expect(pr.reviewers).toContain('carol')
+    const logins = pr.reviewerStates?.map((r) => r.login)
+    expect(logins).toHaveLength(2)
+    expect(logins).toContain('bob')
+    expect(logins).toContain('carol')
   })
 
-  test('identifies unassigned PRs (never had a reviewer)', () => {
-    const prs = [
-      makePR({ author: 'alice', number: 1, hasAnyReviewer: true }),
-      makePR({ author: 'alice', number: 2, hasAnyReviewer: false }),
-    ]
-    const reviews = [makeReview({ reviewer: 'bob', number: 1 })]
-    const result = aggregateTeamStacks(prs, reviews)
+  describe('reviewerStates (per-reviewer state for popover)', () => {
+    test('attaches latest state per reviewer from review history', () => {
+      const openPRs = [makePR({ author: 'alice', number: 1 })]
+      const pendingReviews = [makeReview({ reviewer: 'bob', number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({
+          reviewer: 'bob',
+          state: 'COMMENTED',
+          submittedAt: '2026-03-02T00:00:00Z',
+        }),
+        makeReviewHistory({
+          reviewer: 'bob',
+          state: 'APPROVED',
+          submittedAt: '2026-03-05T00:00:00Z',
+        }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews,
+        reviewHistory,
+      })
 
-    expect(result.unassignedPRs).toHaveLength(1)
-    expect(result.unassignedPRs[0].number).toBe(2)
+      const pr = result.authorStacks[0].prs[0]
+      expect(pr.reviewerStates).toHaveLength(1)
+      expect(pr.reviewerStates?.[0]).toMatchObject({
+        login: 'bob',
+        state: 'APPROVED',
+        submittedAt: '2026-03-05T00:00:00Z',
+      })
+    })
+
+    test('REQUESTED reviewer (no submitted review) appears without submittedAt', () => {
+      const openPRs = [makePR({ author: 'alice', number: 1 })]
+      const pendingReviews = [makeReview({ reviewer: 'carol', number: 1 })]
+      const result = aggregateTeamStacks({ openPRs, pendingReviews })
+
+      const pr = result.authorStacks[0].prs[0]
+      expect(pr.reviewerStates).toEqual([
+        {
+          login: 'carol',
+          displayName: 'carol',
+          state: 'REQUESTED',
+        },
+      ])
+    })
+
+    test('reviewer with submitted review overrides REQUESTED from pending list', () => {
+      const openPRs = [makePR({ author: 'alice', number: 1 })]
+      const pendingReviews = [makeReview({ reviewer: 'bob', number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({
+          reviewer: 'bob',
+          state: 'CHANGES_REQUESTED',
+          submittedAt: '2026-03-03T00:00:00Z',
+        }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews,
+        reviewHistory,
+      })
+
+      const pr = result.authorStacks[0].prs[0]
+      expect(pr.reviewerStates).toHaveLength(1)
+      expect(pr.reviewerStates?.[0].state).toBe('CHANGES_REQUESTED')
+    })
+
+    test('multiple reviewers sorted by state priority', () => {
+      const openPRs = [makePR({ author: 'alice', number: 1 })]
+      const pendingReviews = [makeReview({ reviewer: 'dave', number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({
+          reviewer: 'bob',
+          state: 'APPROVED',
+          submittedAt: '2026-03-05T00:00:00Z',
+        }),
+        makeReviewHistory({
+          reviewer: 'carol',
+          state: 'COMMENTED',
+          submittedAt: '2026-03-05T00:00:00Z',
+        }),
+        makeReviewHistory({
+          reviewer: 'ellen',
+          state: 'CHANGES_REQUESTED',
+          submittedAt: '2026-03-05T00:00:00Z',
+        }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews,
+        reviewHistory,
+      })
+
+      const states = result.authorStacks[0].prs[0].reviewerStates?.map(
+        (r) => r.state,
+      )
+      expect(states).toEqual([
+        'APPROVED',
+        'CHANGES_REQUESTED',
+        'COMMENTED',
+        'REQUESTED',
+      ])
+    })
+
+    test('DISMISSED / PENDING review states are filtered out', () => {
+      const openPRs = [makePR({ author: 'alice', number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({ reviewer: 'bob', state: 'DISMISSED' }),
+        makeReviewHistory({ reviewer: 'carol', state: 'PENDING' }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.authorStacks[0].prs[0].reviewerStates).toBeUndefined()
+    })
+
+    test('bucket PRs also carry reviewerStates', () => {
+      const openPRs = [makePR({ number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({
+          reviewer: 'bob',
+          state: 'APPROVED',
+          submittedAt: '2026-03-05T00:00:00Z',
+        }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.approvedAwaitingMergePRs[0].reviewerStates?.[0].state).toBe(
+        'APPROVED',
+      )
+    })
+
+    test('case-insensitive reviewer matching', () => {
+      const openPRs = [makePR({ author: 'alice', number: 1 })]
+      const pendingReviews = [makeReview({ reviewer: 'Bob', number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({
+          reviewer: 'bob',
+          state: 'APPROVED',
+          submittedAt: '2026-03-05T00:00:00Z',
+        }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews,
+        reviewHistory,
+      })
+
+      const states = result.authorStacks[0].prs[0].reviewerStates
+      expect(states).toHaveLength(1)
+      expect(states?.[0].state).toBe('APPROVED')
+    })
   })
 
-  test('generates insight when authors exceed personal limit', () => {
-    const prs = [
-      makePR({ author: 'alice', number: 1, hasAnyReviewer: true }),
-      makePR({ author: 'alice', number: 2, hasAnyReviewer: true }),
-      makePR({ author: 'alice', number: 3, hasAnyReviewer: true }),
-    ]
-    const reviews = [
-      makeReview({ reviewer: 'bob', number: 1 }),
-      makeReview({ reviewer: 'bob', number: 2 }),
-      makeReview({ reviewer: 'bob', number: 3 }),
-    ]
-    const result = aggregateTeamStacks(prs, reviews, 2)
+  describe('review status buckets', () => {
+    test('truly unassigned → unassignedPRs', () => {
+      const openPRs = [makePR({ number: 1 })]
+      const result = aggregateTeamStacks({ openPRs, pendingReviews: [] })
 
-    expect(result.insight).toContain('1人が目安（2件）を超過中')
+      expect(result.unassignedPRs).toHaveLength(1)
+      expect(result.unassignedPRs[0].reviewStatus).toBe('unassigned')
+      expect(result.approvedAwaitingMergePRs).toHaveLength(0)
+      expect(result.changesPendingPRs).toHaveLength(0)
+    })
+
+    test('approved with no current reviewer → approvedAwaitingMergePRs', () => {
+      const openPRs = [makePR({ number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({ reviewer: 'bob', state: 'APPROVED' }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.approvedAwaitingMergePRs).toHaveLength(1)
+      expect(result.approvedAwaitingMergePRs[0].reviewStatus).toBe(
+        'approved-awaiting-merge',
+      )
+      expect(result.unassignedPRs).toHaveLength(0)
+      expect(result.changesPendingPRs).toHaveLength(0)
+    })
+
+    test('changes_requested only → changesPendingPRs', () => {
+      const openPRs = [makePR({ number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({ reviewer: 'bob', state: 'CHANGES_REQUESTED' }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.changesPendingPRs).toHaveLength(1)
+      expect(result.changesPendingPRs[0].reviewStatus).toBe('changes-pending')
+      expect(result.unassignedPRs).toHaveLength(0)
+      expect(result.approvedAwaitingMergePRs).toHaveLength(0)
+    })
+
+    test('commented only (no approve/changes) → changesPendingPRs', () => {
+      const openPRs = [makePR({ number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({ reviewer: 'bob', state: 'COMMENTED' }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.changesPendingPRs).toHaveLength(1)
+      expect(result.changesPendingPRs[0].reviewStatus).toBe('changes-pending')
+    })
+
+    test('approved takes priority over changes_requested', () => {
+      const openPRs = [makePR({ number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({
+          reviewer: 'bob',
+          state: 'APPROVED',
+          submittedAt: '2026-03-05T00:00:00Z',
+        }),
+        makeReviewHistory({
+          reviewer: 'carol',
+          state: 'CHANGES_REQUESTED',
+          submittedAt: '2026-03-05T00:00:00Z',
+        }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.approvedAwaitingMergePRs).toHaveLength(1)
+      expect(result.changesPendingPRs).toHaveLength(0)
+    })
+
+    test('PRs with active review requests never appear in any bucket', () => {
+      const openPRs = [makePR({ number: 1 })]
+      const pendingReviews = [makeReview({ reviewer: 'bob', number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({ reviewer: 'carol', state: 'APPROVED' }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews,
+        reviewHistory,
+      })
+
+      expect(result.unassignedPRs).toHaveLength(0)
+      expect(result.approvedAwaitingMergePRs).toHaveLength(0)
+      expect(result.changesPendingPRs).toHaveLength(0)
+    })
+
+    test('author stack PRs carry reviewStatus for all buckets', () => {
+      const openPRs = [
+        makePR({ author: 'alice', number: 1 }),
+        makePR({ author: 'alice', number: 2 }),
+      ]
+      const reviewHistory = [
+        makeReviewHistory({ number: 1, reviewer: 'bob', state: 'APPROVED' }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+      const alice = result.authorStacks[0]
+      expect(alice.prs.find((p) => p.number === 1)?.reviewStatus).toBe(
+        'approved-awaiting-merge',
+      )
+      expect(alice.prs.find((p) => p.number === 2)?.reviewStatus).toBe(
+        'unassigned',
+      )
+    })
   })
 
-  test('generates insight when reviewer has concentrated reviews', () => {
-    const prs = [
-      makePR({ author: 'alice', number: 1, hasAnyReviewer: true }),
-      makePR({ author: 'alice', number: 2, hasAnyReviewer: true }),
-      makePR({ author: 'alice', number: 3, hasAnyReviewer: true }),
-    ]
-    const reviews = [
-      makeReview({ reviewer: 'bob', number: 1 }),
-      makeReview({ reviewer: 'bob', number: 2 }),
-      makeReview({ reviewer: 'bob', number: 3 }),
-    ]
-    const result = aggregateTeamStacks(prs, reviews, 2)
+  describe('insight generation', () => {
+    test('generates insight when authors exceed personal limit', () => {
+      const openPRs = [
+        makePR({ author: 'alice', number: 1 }),
+        makePR({ author: 'alice', number: 2 }),
+        makePR({ author: 'alice', number: 3 }),
+      ]
+      const pendingReviews = [
+        makeReview({ reviewer: 'bob', number: 1 }),
+        makeReview({ reviewer: 'bob', number: 2 }),
+        makeReview({ reviewer: 'bob', number: 3 }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews,
+        personalLimit: 2,
+      })
 
-    expect(result.insight).toContain('bobに3件のレビューが集中')
-  })
+      expect(result.insight).toContain('1人が目安（2件）を超過中')
+    })
 
-  test('generates insight for unassigned PRs only', () => {
-    const prs = [makePR({ author: 'alice', number: 1 })]
-    const result = aggregateTeamStacks(prs, [])
+    test('generates insight when reviewer has concentrated reviews', () => {
+      const openPRs = [
+        makePR({ author: 'alice', number: 1 }),
+        makePR({ author: 'alice', number: 2 }),
+        makePR({ author: 'alice', number: 3 }),
+      ]
+      const pendingReviews = [
+        makeReview({ reviewer: 'bob', number: 1 }),
+        makeReview({ reviewer: 'bob', number: 2 }),
+        makeReview({ reviewer: 'bob', number: 3 }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews,
+        personalLimit: 2,
+      })
 
-    expect(result.insight).toBe('1件のPRがレビュアー未アサイン。')
-  })
+      expect(result.insight).toContain('bobに3件のレビューが集中')
+    })
 
-  test('no insight when all within limit and all assigned', () => {
-    const prs = [
-      makePR({ author: 'alice', number: 1, hasAnyReviewer: true }),
-      makePR({ author: 'bob', number: 2, hasAnyReviewer: true }),
-    ]
-    const reviews = [
-      makeReview({ reviewer: 'carol', number: 1 }),
-      makeReview({ reviewer: 'carol', number: 2 }),
-    ]
-    const result = aggregateTeamStacks(prs, reviews, 5)
+    test('generates insight for truly unassigned PRs', () => {
+      const openPRs = [makePR({ author: 'alice', number: 1 })]
+      const result = aggregateTeamStacks({ openPRs, pendingReviews: [] })
 
-    expect(result.insight).toBeNull()
+      expect(result.insight).toContain('1件のPRがレビュアー未アサイン')
+    })
+
+    test('generates insight for approved-awaiting-merge PRs', () => {
+      const openPRs = [makePR({ number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({ reviewer: 'bob', state: 'APPROVED' }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.insight).toContain('1件がApprove済みマージ待ち')
+    })
+
+    test('generates insight for changes-pending PRs', () => {
+      const openPRs = [makePR({ number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({ reviewer: 'bob', state: 'CHANGES_REQUESTED' }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.insight).toContain('1件が作者対応待ち')
+    })
+
+    test('autoMergeSuggestion false when approvedAwaitingMerge below threshold', () => {
+      const openPRs = Array.from(
+        { length: AUTO_MERGE_SUGGESTION_THRESHOLD - 1 },
+        (_, i) => makePR({ number: i + 1 }),
+      )
+      const reviewHistory = openPRs.map((pr) =>
+        makeReviewHistory({
+          number: pr.number,
+          reviewer: 'bob',
+          state: 'APPROVED',
+        }),
+      )
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.autoMergeSuggestion).toBe(false)
+      expect(result.insight ?? '').not.toContain('auto-merge')
+    })
+
+    test('autoMergeSuggestion true when approvedAwaitingMerge at/above threshold', () => {
+      const openPRs = Array.from(
+        { length: AUTO_MERGE_SUGGESTION_THRESHOLD },
+        (_, i) => makePR({ number: i + 1 }),
+      )
+      const reviewHistory = openPRs.map((pr) =>
+        makeReviewHistory({
+          number: pr.number,
+          reviewer: 'bob',
+          state: 'APPROVED',
+        }),
+      )
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.autoMergeSuggestion).toBe(true)
+      expect(result.insight).toContain('auto-merge-on-approved')
+    })
+
+    test('no insight when all within limit and all in-review', () => {
+      const openPRs = [
+        makePR({ author: 'alice', number: 1 }),
+        makePR({ author: 'bob', number: 2 }),
+      ]
+      const pendingReviews = [
+        makeReview({ reviewer: 'carol', number: 1 }),
+        makeReview({ reviewer: 'carol', number: 2 }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews,
+        personalLimit: 5,
+      })
+
+      expect(result.insight).toBeNull()
+      expect(result.autoMergeSuggestion).toBe(false)
+    })
   })
 
   test('uses custom personalLimit', () => {
-    const prs = [makePR({ author: 'alice', number: 1 })]
-    const result = aggregateTeamStacks(prs, [], 10)
+    const openPRs = [makePR({ author: 'alice', number: 1 })]
+    const result = aggregateTeamStacks({
+      openPRs,
+      pendingReviews: [],
+      personalLimit: 10,
+    })
     expect(result.personalLimit).toBe(10)
   })
 
   test('uses DEFAULT_PERSONAL_LIMIT when not specified', () => {
-    const result = aggregateTeamStacks([], [])
+    const result = aggregateTeamStacks({ openPRs: [], pendingReviews: [] })
     expect(result.personalLimit).toBe(DEFAULT_PERSONAL_LIMIT)
   })
 })

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.test.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.test.ts
@@ -354,6 +354,50 @@ describe('aggregateTeamStacks', () => {
       expect(states).toHaveLength(1)
       expect(states?.[0].state).toBe('APPROVED')
     })
+
+    test('author self-comment only → treated as unassigned', () => {
+      const openPRs = [makePR({ author: 'alice', number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({
+          reviewer: 'alice',
+          state: 'COMMENTED',
+          submittedAt: '2026-03-02T00:00:00Z',
+        }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.unassignedPRs).toHaveLength(1)
+      expect(result.unassignedPRs[0].reviewStatus).toBe('unassigned')
+      expect(result.changesPendingPRs).toHaveLength(0)
+    })
+
+    test('author self-comment + other reviewer → uses other reviewer state', () => {
+      const openPRs = [makePR({ author: 'alice', number: 1 })]
+      const reviewHistory = [
+        makeReviewHistory({
+          reviewer: 'alice',
+          state: 'COMMENTED',
+          submittedAt: '2026-03-02T00:00:00Z',
+        }),
+        makeReviewHistory({
+          reviewer: 'bob',
+          state: 'CHANGES_REQUESTED',
+          submittedAt: '2026-03-03T00:00:00Z',
+        }),
+      ]
+      const result = aggregateTeamStacks({
+        openPRs,
+        pendingReviews: [],
+        reviewHistory,
+      })
+
+      expect(result.changesPendingPRs).toHaveLength(1)
+      expect(result.unassignedPRs).toHaveLength(0)
+    })
   })
 
   describe('review status buckets', () => {

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
@@ -14,6 +14,7 @@ export interface StackPR {
   title: string
   url: string
   author: string
+  authorDisplayName?: string
   createdAt: string
   complexity: string | null
   hasReviewer?: boolean
@@ -187,6 +188,12 @@ export function aggregateTeamStacks({
   for (const p of pendingReviews) {
     pendingReviewerPRKeys.add(`${p.repositoryId}:${p.number}`)
   }
+  const authorDisplayNameByLogin = new Map<string, string>()
+  for (const pr of openPRs) {
+    if (pr.authorDisplayName) {
+      authorDisplayNameByLogin.set(pr.author, pr.authorDisplayName)
+    }
+  }
 
   const authorMap = new Map<string, PersonStack>()
   const unassignedPRs: StackPR[] = []
@@ -208,6 +215,7 @@ export function aggregateTeamStacks({
       title: pr.title,
       url: pr.url,
       author: pr.author,
+      authorDisplayName: pr.authorDisplayName ?? undefined,
       createdAt: pr.pullRequestCreatedAt,
       complexity: pr.complexity,
       hasReviewer: hasPendingReviewer,
@@ -267,6 +275,7 @@ export function aggregateTeamStacks({
       title: row.title,
       url: row.url,
       author: row.author,
+      authorDisplayName: authorDisplayNameByLogin.get(row.author),
       createdAt: row.pullRequestCreatedAt,
       complexity: row.complexity,
       hasReviewer: true,

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
@@ -4,10 +4,6 @@ import type {
   PRReviewerStateEntry,
 } from '~/app/routes/$orgSlug/+components/pr-block'
 
-export type ReviewStatus = PRReviewStatus
-export type ReviewerState = PRReviewerState
-export type ReviewerStateEntry = PRReviewerStateEntry
-
 export interface StackPR {
   number: number
   repo: string
@@ -18,8 +14,8 @@ export interface StackPR {
   createdAt: string
   complexity: string | null
   hasReviewer?: boolean
-  reviewStatus?: ReviewStatus
-  reviewerStates?: ReviewerStateEntry[]
+  reviewStatus?: PRReviewStatus
+  reviewerStates?: PRReviewerStateEntry[]
 }
 
 export interface PersonStack {
@@ -77,27 +73,27 @@ export const DEFAULT_PERSONAL_LIMIT = 2
 /** approvedAwaitingMerge がこの件数を超えたら auto-merge 有効化サジェストを出す */
 export const AUTO_MERGE_SUGGESTION_THRESHOLD = 3
 
-const REVIEWER_STATE_SORT_ORDER: Record<ReviewerState, number> = {
+const REVIEWER_STATE_SORT_ORDER: Record<PRReviewerState, number> = {
   APPROVED: 0,
   CHANGES_REQUESTED: 1,
   COMMENTED: 2,
   REQUESTED: 3,
 }
 
-const SUBMITTED_REVIEW_STATES = new Set<ReviewerState>([
+const SUBMITTED_REVIEW_STATES = new Set<PRReviewerState>([
   'APPROVED',
   'CHANGES_REQUESTED',
   'COMMENTED',
 ])
 
-export function buildReviewerStatesMap(
+export function buildPRReviewerStatesMap(
   reviews: ReviewRow[],
   pendingReviews: Pick<
     PendingReviewRow,
     'repositoryId' | 'number' | 'reviewer' | 'reviewerDisplayName'
   >[],
-): Map<string, ReviewerStateEntry[]> {
-  const byPR = new Map<string, Map<string, ReviewerStateEntry>>()
+): Map<string, PRReviewerStateEntry[]> {
+  const byPR = new Map<string, Map<string, PRReviewerStateEntry>>()
   const getBucket = (prKey: string) => {
     let bucket = byPR.get(prKey)
     if (!bucket) {
@@ -108,7 +104,7 @@ export function buildReviewerStatesMap(
   }
 
   for (const r of reviews) {
-    const state = r.state as ReviewerState
+    const state = r.state as PRReviewerState
     // GitHub の DISMISSED / PENDING は Popover 表示対象外
     if (!SUBMITTED_REVIEW_STATES.has(state)) continue
     const prKey = `${r.repositoryId}:${r.number}`
@@ -137,7 +133,7 @@ export function buildReviewerStatesMap(
     })
   }
 
-  const result = new Map<string, ReviewerStateEntry[]>()
+  const result = new Map<string, PRReviewerStateEntry[]>()
   for (const [prKey, bucket] of byPR) {
     const entries = [...bucket.values()].sort((a, b) => {
       const d =
@@ -149,11 +145,11 @@ export function buildReviewerStatesMap(
   return result
 }
 
-export function classifyReviewStatus(
+export function classifyPRReviewStatus(
   hasPendingReviewer: boolean,
-  statesForPR: ReviewerStateEntry[] | undefined,
+  statesForPR: PRReviewerStateEntry[] | undefined,
   author: string,
-): ReviewStatus {
+): PRReviewStatus {
   if (hasPendingReviewer) return 'in-review'
   // author 自身のレビュー（COMMENTED 等）はレビューとしてカウントしない
   const authorKey = author.toLowerCase()
@@ -183,7 +179,7 @@ export function aggregateTeamStacks({
   reviewHistory = [],
   personalLimit = DEFAULT_PERSONAL_LIMIT,
 }: AggregateTeamStacksInput): TeamStacksData {
-  const reviewerStatesByPR = buildReviewerStatesMap(
+  const reviewerStatesByPR = buildPRReviewerStatesMap(
     reviewHistory,
     pendingReviews,
   )
@@ -207,7 +203,7 @@ export function aggregateTeamStacks({
     const prKey = `${pr.repositoryId}:${pr.number}`
     const reviewerStates = reviewerStatesByPR.get(prKey)
     const hasPendingReviewer = pendingReviewerPRKeys.has(prKey)
-    const reviewStatus = classifyReviewStatus(
+    const reviewStatus = classifyPRReviewStatus(
       hasPendingReviewer,
       reviewerStates,
       pr.author,

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
@@ -148,9 +148,15 @@ function buildReviewerStatesMap(
 function classifyReviewStatus(
   hasPendingReviewer: boolean,
   statesForPR: ReviewerStateEntry[] | undefined,
+  author: string,
 ): ReviewStatus {
   if (hasPendingReviewer) return 'in-review'
-  const submitted = statesForPR?.filter((s) => s.state !== 'REQUESTED') ?? []
+  // author 自身のレビュー（COMMENTED 等）はレビューとしてカウントしない
+  const authorKey = author.toLowerCase()
+  const submitted =
+    statesForPR?.filter(
+      (s) => s.state !== 'REQUESTED' && s.login.toLowerCase() !== authorKey,
+    ) ?? []
   if (submitted.some((s) => s.state === 'APPROVED'))
     return 'approved-awaiting-merge'
   if (submitted.length > 0) return 'changes-pending'
@@ -191,6 +197,7 @@ export function aggregateTeamStacks({
     const reviewStatus = classifyReviewStatus(
       hasPendingReviewer,
       reviewerStates,
+      pr.author,
     )
     const stackPR: StackPR = {
       number: pr.number,

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
@@ -90,9 +90,12 @@ const SUBMITTED_REVIEW_STATES = new Set<ReviewerState>([
   'COMMENTED',
 ])
 
-function buildReviewerStatesMap(
+export function buildReviewerStatesMap(
   reviews: ReviewRow[],
-  pendingReviews: PendingReviewRow[],
+  pendingReviews: Pick<
+    PendingReviewRow,
+    'repositoryId' | 'number' | 'reviewer' | 'reviewerDisplayName'
+  >[],
 ): Map<string, ReviewerStateEntry[]> {
   const byPR = new Map<string, Map<string, ReviewerStateEntry>>()
   const getBucket = (prKey: string) => {
@@ -146,7 +149,7 @@ function buildReviewerStatesMap(
   return result
 }
 
-function classifyReviewStatus(
+export function classifyReviewStatus(
   hasPendingReviewer: boolean,
   statesForPR: ReviewerStateEntry[] | undefined,
   author: string,

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
@@ -1,3 +1,13 @@
+import type {
+  PRReviewStatus,
+  PRReviewerState,
+  PRReviewerStateEntry,
+} from '~/app/routes/$orgSlug/+components/pr-block'
+
+export type ReviewStatus = PRReviewStatus
+export type ReviewerState = PRReviewerState
+export type ReviewerStateEntry = PRReviewerStateEntry
+
 export interface StackPR {
   number: number
   repo: string
@@ -7,7 +17,8 @@ export interface StackPR {
   createdAt: string
   complexity: string | null
   hasReviewer?: boolean
-  reviewers?: string[]
+  reviewStatus?: ReviewStatus
+  reviewerStates?: ReviewerStateEntry[]
 }
 
 export interface PersonStack {
@@ -20,8 +31,11 @@ export interface TeamStacksData {
   authorStacks: PersonStack[]
   reviewerStacks: PersonStack[]
   unassignedPRs: StackPR[]
+  approvedAwaitingMergePRs: StackPR[]
+  changesPendingPRs: StackPR[]
   personalLimit: number
   insight: string | null
+  autoMergeSuggestion: boolean
 }
 
 interface OpenPRRow {
@@ -34,8 +48,6 @@ interface OpenPRRow {
   url: string
   pullRequestCreatedAt: string
   complexity: string | null
-  /** Whether any reviewer has ever been assigned (not just pending) */
-  hasAnyReviewer: boolean
 }
 
 interface PendingReviewRow {
@@ -51,32 +63,148 @@ interface PendingReviewRow {
   complexity: string | null
 }
 
+interface ReviewRow {
+  number: number
+  repositoryId: string
+  reviewer: string
+  reviewerDisplayName: string | null
+  state: string
+  submittedAt: string
+}
+
 export const DEFAULT_PERSONAL_LIMIT = 2
+/** approvedAwaitingMerge がこの件数を超えたら auto-merge 有効化サジェストを出す */
+export const AUTO_MERGE_SUGGESTION_THRESHOLD = 3
 
-export function aggregateTeamStacks(
-  openPRs: OpenPRRow[],
-  reviewData: PendingReviewRow[],
-  personalLimit = DEFAULT_PERSONAL_LIMIT,
-): TeamStacksData {
-  // Build PR key → reviewer logins map
-  const prReviewerSets = new Map<string, Set<string>>()
-  for (const row of reviewData) {
-    const key = `${row.repositoryId}:${row.number}`
-    let reviewers = prReviewerSets.get(key)
-    if (!reviewers) {
-      reviewers = new Set()
-      prReviewerSets.set(key, reviewers)
+const REVIEWER_STATE_SORT_ORDER: Record<ReviewerState, number> = {
+  APPROVED: 0,
+  CHANGES_REQUESTED: 1,
+  COMMENTED: 2,
+  REQUESTED: 3,
+}
+
+const SUBMITTED_REVIEW_STATES = new Set<ReviewerState>([
+  'APPROVED',
+  'CHANGES_REQUESTED',
+  'COMMENTED',
+])
+
+function buildReviewerStatesMap(
+  reviews: ReviewRow[],
+  pendingReviews: PendingReviewRow[],
+): Map<string, ReviewerStateEntry[]> {
+  const byPR = new Map<string, Map<string, ReviewerStateEntry>>()
+  const getBucket = (prKey: string) => {
+    let bucket = byPR.get(prKey)
+    if (!bucket) {
+      bucket = new Map()
+      byPR.set(prKey, bucket)
     }
-    reviewers.add(row.reviewer)
-  }
-  const prReviewersMap = new Map<string, string[]>()
-  for (const [key, set] of prReviewerSets) {
-    prReviewersMap.set(key, [...set])
+    return bucket
   }
 
-  // Author stacks: open PRs grouped by author
+  for (const r of reviews) {
+    const state = r.state as ReviewerState
+    // GitHub の DISMISSED / PENDING は Popover 表示対象外
+    if (!SUBMITTED_REVIEW_STATES.has(state)) continue
+    const prKey = `${r.repositoryId}:${r.number}`
+    const reviewerKey = r.reviewer.toLowerCase()
+    const bucket = getBucket(prKey)
+    const existing = bucket.get(reviewerKey)
+    if (!existing || r.submittedAt > (existing.submittedAt ?? '')) {
+      bucket.set(reviewerKey, {
+        login: r.reviewer,
+        displayName: r.reviewerDisplayName ?? r.reviewer,
+        state,
+        submittedAt: r.submittedAt,
+      })
+    }
+  }
+
+  for (const p of pendingReviews) {
+    const prKey = `${p.repositoryId}:${p.number}`
+    const reviewerKey = p.reviewer.toLowerCase()
+    const bucket = getBucket(prKey)
+    if (bucket.has(reviewerKey)) continue
+    bucket.set(reviewerKey, {
+      login: p.reviewer,
+      displayName: p.reviewerDisplayName ?? p.reviewer,
+      state: 'REQUESTED',
+    })
+  }
+
+  const result = new Map<string, ReviewerStateEntry[]>()
+  for (const [prKey, bucket] of byPR) {
+    const entries = [...bucket.values()].sort((a, b) => {
+      const d =
+        REVIEWER_STATE_SORT_ORDER[a.state] - REVIEWER_STATE_SORT_ORDER[b.state]
+      return d !== 0 ? d : a.login.localeCompare(b.login)
+    })
+    result.set(prKey, entries)
+  }
+  return result
+}
+
+function classifyReviewStatus(
+  hasPendingReviewer: boolean,
+  statesForPR: ReviewerStateEntry[] | undefined,
+): ReviewStatus {
+  if (hasPendingReviewer) return 'in-review'
+  const submitted = statesForPR?.filter((s) => s.state !== 'REQUESTED') ?? []
+  if (submitted.some((s) => s.state === 'APPROVED'))
+    return 'approved-awaiting-merge'
+  if (submitted.length > 0) return 'changes-pending'
+  return 'unassigned'
+}
+
+export interface AggregateTeamStacksInput {
+  openPRs: OpenPRRow[]
+  pendingReviews: PendingReviewRow[]
+  reviewHistory?: ReviewRow[]
+  personalLimit?: number
+}
+
+export function aggregateTeamStacks({
+  openPRs,
+  pendingReviews,
+  reviewHistory = [],
+  personalLimit = DEFAULT_PERSONAL_LIMIT,
+}: AggregateTeamStacksInput): TeamStacksData {
+  const reviewerStatesByPR = buildReviewerStatesMap(
+    reviewHistory,
+    pendingReviews,
+  )
+  const pendingReviewerPRKeys = new Set<string>()
+  for (const p of pendingReviews) {
+    pendingReviewerPRKeys.add(`${p.repositoryId}:${p.number}`)
+  }
+
   const authorMap = new Map<string, PersonStack>()
+  const unassignedPRs: StackPR[] = []
+  const approvedAwaitingMergePRs: StackPR[] = []
+  const changesPendingPRs: StackPR[] = []
+
   for (const pr of openPRs) {
+    const prKey = `${pr.repositoryId}:${pr.number}`
+    const reviewerStates = reviewerStatesByPR.get(prKey)
+    const hasPendingReviewer = pendingReviewerPRKeys.has(prKey)
+    const reviewStatus = classifyReviewStatus(
+      hasPendingReviewer,
+      reviewerStates,
+    )
+    const stackPR: StackPR = {
+      number: pr.number,
+      repo: pr.repo,
+      title: pr.title,
+      url: pr.url,
+      author: pr.author,
+      createdAt: pr.pullRequestCreatedAt,
+      complexity: pr.complexity,
+      hasReviewer: hasPendingReviewer,
+      reviewStatus,
+      reviewerStates,
+    }
+
     let stack = authorMap.get(pr.author)
     if (!stack) {
       stack = {
@@ -86,28 +214,25 @@ export function aggregateTeamStacks(
       }
       authorMap.set(pr.author, stack)
     }
-    const prKey = `${pr.repositoryId}:${pr.number}`
-    const reviewers = prReviewersMap.get(prKey)
-    stack.prs.push({
-      number: pr.number,
-      repo: pr.repo,
-      title: pr.title,
-      url: pr.url,
-      author: pr.author,
-      createdAt: pr.pullRequestCreatedAt,
-      complexity: pr.complexity,
-      hasReviewer: pr.hasAnyReviewer,
-      reviewers,
-    })
+    stack.prs.push(stackPR)
+
+    if (!hasPendingReviewer) {
+      if (reviewStatus === 'approved-awaiting-merge') {
+        approvedAwaitingMergePRs.push(stackPR)
+      } else if (reviewStatus === 'changes-pending') {
+        changesPendingPRs.push(stackPR)
+      } else {
+        unassignedPRs.push(stackPR)
+      }
+    }
   }
   const authorStacks = [...authorMap.values()].sort(
     (a, b) => b.prs.length - a.prs.length,
   )
 
-  // Reviewer stacks: pending review assignments grouped by reviewer
   const reviewerMap = new Map<string, PersonStack>()
   const seenPRs = new Map<string, Set<string>>()
-  for (const row of reviewData) {
+  for (const row of pendingReviews) {
     const prKey = `${row.repositoryId}:${row.number}`
     let seen = seenPRs.get(row.reviewer)
     if (!seen) {
@@ -135,25 +260,13 @@ export function aggregateTeamStacks(
       createdAt: row.pullRequestCreatedAt,
       complexity: row.complexity,
       hasReviewer: true,
+      reviewStatus: 'in-review',
+      reviewerStates: reviewerStatesByPR.get(prKey),
     })
   }
   const reviewerStacks = [...reviewerMap.values()].sort(
     (a, b) => b.prs.length - a.prs.length,
   )
-
-  // Unassigned PRs: open PRs that have never had a reviewer assigned
-  const unassignedPRs: StackPR[] = openPRs
-    .filter((pr) => !pr.hasAnyReviewer)
-    .map((pr) => ({
-      number: pr.number,
-      repo: pr.repo,
-      title: pr.title,
-      url: pr.url,
-      author: pr.author,
-      createdAt: pr.pullRequestCreatedAt,
-      complexity: pr.complexity,
-      hasReviewer: false as const,
-    }))
 
   const overLimitAuthors = authorStacks.filter(
     (s) => s.prs.length > personalLimit,
@@ -162,31 +275,42 @@ export function aggregateTeamStacks(
     (s) => s.prs.length > personalLimit,
   ).length
 
-  let insight: string | null = null
-  if (overLimitAuthors > 0 || overLimitReviewers > 0) {
-    const parts: string[] = []
-    if (overLimitAuthors > 0) {
-      parts.push(`${overLimitAuthors}人が目安（${personalLimit}件）を超過中`)
-    }
-    if (overLimitReviewers > 0) {
-      const maxReviewer = reviewerStacks[0]
-      parts.push(
-        `${maxReviewer.displayName}に${maxReviewer.prs.length}件のレビューが集中`,
-      )
-    }
-    if (unassignedPRs.length > 0) {
-      parts.push(`${unassignedPRs.length}件のPRがレビュアー未アサイン`)
-    }
-    insight = `${parts.join('。')}。`
-  } else if (unassignedPRs.length > 0) {
-    insight = `${unassignedPRs.length}件のPRがレビュアー未アサイン。`
+  const autoMergeSuggestion =
+    approvedAwaitingMergePRs.length >= AUTO_MERGE_SUGGESTION_THRESHOLD
+
+  const parts: string[] = []
+  if (overLimitAuthors > 0) {
+    parts.push(`${overLimitAuthors}人が目安（${personalLimit}件）を超過中`)
   }
+  if (overLimitReviewers > 0) {
+    const maxReviewer = reviewerStacks[0]
+    parts.push(
+      `${maxReviewer.displayName}に${maxReviewer.prs.length}件のレビューが集中`,
+    )
+  }
+  if (unassignedPRs.length > 0) {
+    parts.push(`${unassignedPRs.length}件のPRがレビュアー未アサイン`)
+  }
+  if (approvedAwaitingMergePRs.length > 0) {
+    parts.push(`${approvedAwaitingMergePRs.length}件がApprove済みマージ待ち`)
+  }
+  if (changesPendingPRs.length > 0) {
+    parts.push(`${changesPendingPRs.length}件が作者対応待ち`)
+  }
+  if (autoMergeSuggestion) {
+    parts.push('auto-merge-on-approved の有効化を検討してください')
+  }
+
+  const insight = parts.length > 0 ? `${parts.join('。')}。` : null
 
   return {
     authorStacks,
     reviewerStacks,
     unassignedPRs,
+    approvedAwaitingMergePRs,
+    changesPendingPRs,
     personalLimit,
     insight,
+    autoMergeSuggestion,
   }
 }

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
@@ -13,7 +13,6 @@ export interface StackPR {
   authorDisplayName?: string
   createdAt: string
   complexity: string | null
-  hasReviewer?: boolean
   reviewStatus?: PRReviewStatus
   reviewerStates?: PRReviewerStateEntry[]
 }
@@ -217,7 +216,6 @@ export function aggregateTeamStacks({
       authorDisplayName: pr.authorDisplayName ?? undefined,
       createdAt: pr.pullRequestCreatedAt,
       complexity: pr.complexity,
-      hasReviewer: hasPendingReviewer,
       reviewStatus,
       reviewerStates,
     }
@@ -277,7 +275,6 @@ export function aggregateTeamStacks({
       authorDisplayName: authorDisplayNameByLogin.get(row.author),
       createdAt: row.pullRequestCreatedAt,
       complexity: row.complexity,
-      hasReviewer: true,
       reviewStatus: 'in-review',
       reviewerStates: reviewerStatesByPR.get(prKey),
     })

--- a/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
+++ b/app/routes/$orgSlug/workload/+functions/aggregate-stacks.ts
@@ -159,7 +159,10 @@ function classifyReviewStatus(
     ) ?? []
   if (submitted.some((s) => s.state === 'APPROVED'))
     return 'approved-awaiting-merge'
-  if (submitted.length > 0) return 'changes-pending'
+  // CHANGES_REQUESTED が明示的にある場合のみ changes-pending。
+  // COMMENTED のみは実質未レビュー扱いで unassigned に統合。
+  if (submitted.some((s) => s.state === 'CHANGES_REQUESTED'))
+    return 'changes-pending'
   return 'unassigned'
 }
 

--- a/app/routes/$orgSlug/workload/+functions/stacks.server.ts
+++ b/app/routes/$orgSlug/workload/+functions/stacks.server.ts
@@ -1,18 +1,18 @@
-import { sql } from 'kysely'
 import { excludeBots } from '~/app/libs/tenant-query.server'
 import { getTenantDb } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
 /**
- * オープンPRタイムラインデータ（Team Stacks の Author 側用）
- * hasAnyReviewer: 一度でもレビュアーがアサインされたかどうか
+ * オープンPRの基本情報（Team Stacks の Author 側用）。
+ * レビュー状態は getOpenPullRequestReviews / getPendingReviewAssignments を
+ * 集約層で合流させて分類する。
  */
 export const getOpenPullRequests = async (
   organizationId: OrganizationId,
   teamId?: string | null,
 ) => {
   const tenantDb = getTenantDb(organizationId)
-  const rows = await tenantDb
+  return await tenantDb
     .selectFrom('pullRequests')
     .innerJoin('repositories', 'pullRequests.repositoryId', 'repositories.id')
     .leftJoin('companyGithubUsers', (join) =>
@@ -39,23 +39,7 @@ export const getOpenPullRequests = async (
       'pullRequests.complexity',
       'companyGithubUsers.displayName as authorDisplayName',
     ])
-    .select(
-      sql<number>`exists(
-        select 1 from ${sql.ref('pullRequestReviewers')}
-        where ${sql.ref('pullRequestReviewers.pullRequestNumber')} = ${sql.ref('pullRequests.number')}
-        and ${sql.ref('pullRequestReviewers.repositoryId')} = ${sql.ref('pullRequests.repositoryId')}
-        and lower(${sql.ref('pullRequestReviewers.reviewer')}) not in (
-          select lower(${sql.ref('companyGithubUsers.login')}) from ${sql.ref('companyGithubUsers')}
-          where ${sql.ref('companyGithubUsers.type')} = 'Bot'
-        )
-      )`.as('hasAnyReviewer'),
-    )
     .execute()
-
-  return rows.map((row) => ({
-    ...row,
-    hasAnyReviewer: row.hasAnyReviewer === 1,
-  }))
 }
 
 /**
@@ -106,6 +90,55 @@ export const getPendingReviewAssignments = async (
       'pullRequests.author',
       'pullRequests.pullRequestCreatedAt',
       'pullRequests.complexity',
+      'companyGithubUsers.displayName as reviewerDisplayName',
+    ])
+    .execute()
+}
+
+/**
+ * オープンPRに対して実際に提出されたレビュー履歴（Bot の reviewer は除外）。
+ * Popover で reviewer ごとの state を表示するのと、バケット分類の両方で使う。
+ */
+export const getOpenPullRequestReviews = async (
+  organizationId: OrganizationId,
+  teamId?: string | null,
+) => {
+  const tenantDb = getTenantDb(organizationId)
+  return await tenantDb
+    .selectFrom('pullRequestReviews')
+    .innerJoin('pullRequests', (join) =>
+      join
+        .onRef(
+          'pullRequestReviews.pullRequestNumber',
+          '=',
+          'pullRequests.number',
+        )
+        .onRef(
+          'pullRequestReviews.repositoryId',
+          '=',
+          'pullRequests.repositoryId',
+        ),
+    )
+    .innerJoin('repositories', 'pullRequests.repositoryId', 'repositories.id')
+    .leftJoin('companyGithubUsers', (join) =>
+      join.onRef(
+        (eb) => eb.fn('lower', ['pullRequestReviews.reviewer']),
+        '=',
+        (eb) => eb.fn('lower', ['companyGithubUsers.login']),
+      ),
+    )
+    .where('pullRequests.mergedAt', 'is', null)
+    .where('pullRequests.closedAt', 'is', null)
+    .$if(teamId != null, (qb) =>
+      qb.where('repositories.teamId', '=', teamId as string),
+    )
+    .where(excludeBots)
+    .select([
+      'pullRequestReviews.pullRequestNumber as number',
+      'pullRequestReviews.repositoryId',
+      'pullRequestReviews.reviewer',
+      'pullRequestReviews.state',
+      'pullRequestReviews.submittedAt',
       'companyGithubUsers.displayName as reviewerDisplayName',
     ])
     .execute()

--- a/app/routes/$orgSlug/workload/index.tsx
+++ b/app/routes/$orgSlug/workload/index.tsx
@@ -13,6 +13,7 @@ import {
   aggregateTeamStacks,
 } from './+functions/aggregate-stacks'
 import {
+  getOpenPullRequestReviews,
   getOpenPullRequests,
   getPendingReviewAssignments,
 } from './+functions/stacks.server'
@@ -34,14 +35,16 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
       ? Math.max(...teams.map((t) => t.personalLimit))
       : DEFAULT_PERSONAL_LIMIT
 
-  const [openPRs, pendingReviews] = await Promise.all([
+  const [openPRs, pendingReviews, reviewHistory] = await Promise.all([
     getOpenPullRequests(organization.id, teamId),
     getPendingReviewAssignments(organization.id, teamId),
+    getOpenPullRequestReviews(organization.id, teamId),
   ])
 
   return {
     openPRs,
     pendingReviews,
+    reviewHistory,
     personalLimit,
   }
 }
@@ -49,10 +52,16 @@ export const loader = async ({ context }: Route.LoaderArgs) => {
 export const clientLoader = async ({
   serverLoader,
 }: Route.ClientLoaderArgs) => {
-  const { openPRs, pendingReviews, personalLimit } = await serverLoader()
+  const { openPRs, pendingReviews, reviewHistory, personalLimit } =
+    await serverLoader()
 
   return {
-    teamStacks: aggregateTeamStacks(openPRs, pendingReviews, personalLimit),
+    teamStacks: aggregateTeamStacks({
+      openPRs,
+      pendingReviews,
+      reviewHistory,
+      personalLimit,
+    }),
   }
 }
 clientLoader.hydrate = true as const


### PR DESCRIPTION
## Summary

Review Stacks の「No reviewer」バケットが実態と乖離していた問題を解決。レビュー依頼がない PR を `pullRequestReviews` の履歴から3区分に分類し、PR ブロックの視覚表現と Popover を大幅に強化。

- **Unassigned**: 真にレビュアー未アサイン（review 記録ゼロ、または author 自身の COMMENTED のみ）
- **Approved**: ≥1 APPROVED あり → マージするだけ（auto-merge サジェスト付き）
- **Changes**: CHANGES_REQUESTED が明示的にある PR → author の対応待ち

### データ層
- `stacks.server.ts`: 4つの EXISTS サブクエリを廃止、`getOpenPullRequestReviews` で全レビュー履歴を取得し JS で分類（パフォーマンス改善）
- `aggregate-stacks.ts`: `buildPRReviewerStatesMap` + `classifyPRReviewStatus` でバケット分類・reviewer ごとの最新 state を算出
- author 自身の COMMENTED は分類から除外（実質未レビュー扱い）
- COMMENTED のみの PR は Unassigned に統合（CHANGES_REQUESTED がある場合のみ Changes）

### UI
- PR ブロック: 全て丸に統一、approved (✓) / changes (✗) はアイコンで区別。アイコン色は age/size カラーと一致
- Review Queue 側: pill ラベルによる3セクション表示（Approved → Changes → Unassigned の順）
- Author 側: reviewStatus 優先でソート（approved → changes → unassigned → in-review）
- Popover: reviewer ごとの状態行（アイコン + GitHub アバター + displayName + fromNow 日時）、PR タイトル最大3行、author displayName 表示
- 凡例: 色（age/size）と形状（review status）を並列表示
- auto-merge 有効化サジェスト（approved ≥3件で emerald 色の insight）

### 個人ページ
- `workload/$login`: Current Load セクションでチーム画面と同じ reviewStatus + reviewerStates を表示
- `getBacklogDetails` に reviewHistory + reviewer displayName クエリを追加

### テスト
- 34件（バケット分類、reviewerStates、author self-comment 除外、insight、auto-merge サジェスト閾値）

Closes #286

## Test plan

- [x] Review Stacks 画面で3バケット（Approved / Changes / Unassigned）が正しく分類されている
- [x] Author 側の PR ブロックに ✓ / ✗ アイコンが表示され、色が age/size と一致
- [x] PR クリック時の Popover で reviewer ごとの状態・アバター・日時が表示される
- [x] 個人ページ（`/workload/:login`）でも同じ表示が反映されている
- [x] approved ≥3件の組織で auto-merge サジェストが表示される
- [x] `pnpm validate` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  - プルリクエストのレビューステータスをより詳細に表示（「レビュー中」「マージ待機中」「変更が必要」「未割り当て」）
  - レビュアーの個別状態とレビュー提出日時を表示
  - チームのレビューキューを複数のステータスカテゴリーで整理
  - 承認待機中のPRに対する自動マージの提案機能を追加
  - レビュアーとPR作成者の表示名を改善

<!-- end of auto-generated comment: release notes by coderabbit.ai -->