### PR TITLE
fix: single-pass sort preserves age/size within status groups

### DIFF
--- a/app/routes/$orgSlug/workload/$login/index.tsx
+++ b/app/routes/$orgSlug/workload/$login/index.tsx
@@ -174,8 +174,8 @@ export default function MemberWeeklyPage({
         const pb = REVIEW_STATUS_PRIORITY[b.reviewStatus ?? 'in-review'] ?? 3
         if (pa !== pb) return pa - pb
         if (colorMode === 'size') {
-          const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? 99
-          const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? 99
+          const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? -1
+          const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? -1
           return bi - ai
         }
         return a.pullRequestCreatedAt.localeCompare(b.pullRequestCreatedAt)

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -29,24 +29,8 @@ import {
   type PRReviewStatus,
 } from '../../+components/pr-block'
 
-function sortBySize(prs: StackPR[]): StackPR[] {
-  return [...prs].sort((a, b) => {
-    const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? 99
-    const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? 99
-    return bi - ai
-  })
-}
-
-// --- Age mode ---
-
 function getAgeDays(pr: StackPR): number {
   return dayjs().diff(dayjs.utc(pr.createdAt), 'day', true)
-}
-
-function sortByAge(prs: StackPR[]): StackPR[] {
-  const withAge = prs.map((pr) => ({ pr, age: getAgeDays(pr) }))
-  withAge.sort((a, b) => b.age - a.age)
-  return withAge.map(({ pr }) => pr)
 }
 
 // --- Contexts ---
@@ -80,11 +64,16 @@ const SetSelectedContext = createContext<
 const ColorModeContext = createContext<ColorMode>('age')
 
 function sortPRs(prs: StackPR[], mode: ColorMode): StackPR[] {
-  const baseSorted = mode === 'size' ? sortBySize(prs) : sortByAge(prs)
-  return [...baseSorted].sort((a, b) => {
+  return [...prs].sort((a, b) => {
     const pa = REVIEW_STATUS_PRIORITY[a.reviewStatus ?? 'in-review'] ?? 3
     const pb = REVIEW_STATUS_PRIORITY[b.reviewStatus ?? 'in-review'] ?? 3
-    return pa - pb
+    if (pa !== pb) return pa - pb
+    if (mode === 'size') {
+      const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? 99
+      const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? 99
+      return bi - ai
+    }
+    return getAgeDays(b) - getAgeDays(a)
   })
 }
 

--- a/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
+++ b/app/routes/$orgSlug/workload/+components/team-stacks-chart.tsx
@@ -69,8 +69,8 @@ function sortPRs(prs: StackPR[], mode: ColorMode): StackPR[] {
     const pb = REVIEW_STATUS_PRIORITY[b.reviewStatus ?? 'in-review'] ?? 3
     if (pa !== pb) return pa - pb
     if (mode === 'size') {
-      const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? 99
-      const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? 99
+      const ai = PR_SIZE_RANK[a.complexity ?? ''] ?? -1
+      const bi = PR_SIZE_RANK[b.complexity ?? ''] ?? -1
       return bi - ai
     }
     return getAgeDays(b) - getAgeDays(a)


### PR DESCRIPTION
## Summary

- 2段 `.sort()` が status 優先ソートで age/size 順を壊していたのを単一コンパレータに統合
- 不要になった `sortBySize` / `sortByAge` 関数を削除（`sortPRs` 内にインライン化）

#305 のフォローアップ。

## Test plan

- [ ] Author 側 PR が status 優先（approved → changes → unassigned → in-review）かつ同一 status 内で age/size 順で並ぶ
- [ ] `pnpm validate` 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * プルリクエストの並べ替え処理を最適化しました。レビューステータスを優先順位として機能させ、その後にサイズまたは作成日時でソートするようにしました。これにより、ワークロード管理画面での表示順序がより効率的になります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->