### PR TITLE
chore(ci): bump pnpm/action-setup v4 → v5, inline toml reader

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         name: Install pnpm
 
       - name: ⎔ Setup node
@@ -41,7 +41,7 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         name: Install pnpm
 
       - name: ⎔ Setup node
@@ -62,7 +62,7 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         name: Install pnpm
 
       - name: ⎔ Setup node
@@ -89,7 +89,7 @@ jobs:
       - name: 🏄 Copy test env vars
         run: cp .env.example .env
 
-      - uses: pnpm/action-setup@v4
+      - uses: pnpm/action-setup@v5
         name: Install pnpm
 
       - name: ⎔ Setup node
@@ -124,16 +124,21 @@ jobs:
     # only build/deploy main branch on pushes
     if: ${{ github.ref == 'refs/heads/main' && github.event_name == 'push' }}
     runs-on: ubuntu-latest
+    outputs:
+      app_name: ${{ steps.app_name.outputs.value }}
     steps:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 
       - name: 👀 Read app name
-        uses: SebRollen/toml-action@v1.2.0
         id: app_name
-        with:
-          file: 'fly.toml'
-          field: 'app'
+        run: |
+          value=$(awk -F'"' '/^app = /{print $2; exit}' fly.toml)
+          if [ -z "$value" ]; then
+            echo "::error file=fly.toml::Could not read app name from fly.toml (expected 'app = \"...\"' line)"
+            exit 1
+          fi
+          echo "value=$value" >> "$GITHUB_OUTPUT"
 
       - name: 🐳 Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
@@ -172,16 +177,9 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@v6
 
-      - name: 👀 Read app name
-        uses: SebRollen/toml-action@v1.2.0
-        id: app_name
-        with:
-          file: 'fly.toml'
-          field: 'app'
-
       - name: 🚀 Deploy Production
         uses: superfly/flyctl-actions@1.5
         with:
-          args: 'deploy --image registry.fly.io/${{ steps.app_name.outputs.value }}:${{ github.ref_name }}-${{ github.sha }}'
+          args: 'deploy --image registry.fly.io/${{ needs.build.outputs.app_name }}:${{ github.ref_name }}-${{ github.sha }}'
         env:
           FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}


### PR DESCRIPTION
## Summary

GitHub Actions の Node.js 20 deprecation 対応 + 最新化の確認。

### 1. `pnpm/action-setup@v4` → `@v5`

Runner で Node.js 20 動作の warning が出ていた:

```
Node.js 20 actions are deprecated. ... pnpm/action-setup@v4
```

タイムライン:
- 2026-06-02: Node.js 24 が強制
- 2026-09-16: Node.js 20 がランナーから削除

v5.0.0 でアクション本体が Node.js 24 に更新 ([release notes](https://github.com/pnpm/action-setup/releases/tag/v5.0.0))。このプロジェクトは pnpm v10 なので最小修正の v5 に留めた (v6 は pnpm v11 サポート追加のため)。

### 2. `SebRollen/toml-action@v1.2.0` を inline shell に置き換え

このアクションも Node.js 20 (`runs: { using: 'node20' }`) で、v1.2.0 が最新のまま更新がない。同じ warning 予備軍。

`fly.toml` から `app` フィールドを読むだけの単純用途なので、`awk` による inline shell に置き換えて依存自体を撤去:

```yaml
- name: 👀 Read app name
  id: app_name
  run: |
    value=$(awk -F'"' '/^app = /{print $2; exit}' fly.toml)
    echo "value=$value" >> "$GITHUB_OUTPUT"
```

### 確認: 他のアクションは最新 major

| Action | 使用中 | 最新 major | Node |
|--|--|--|--|
| actions/checkout | v6 | v6 | 24 ✅ |
| actions/setup-node | v6 | v6 | 24 ✅ |
| pnpm/action-setup | v4 → **v5** | v6 (pnpm v11) | 24 ✅ |
| SebRollen/toml-action | v1.2.0 → **削除** | v1.2.0 (更新なし) | 20 ⚠️ |
| docker/setup-buildx-action | v4 | v4 | n/a (Docker) |
| docker/login-action | v4 | v4 | n/a (Docker) |
| docker/build-push-action | v7 | v7 | n/a (Docker) |
| superfly/flyctl-actions | 1.5 | 1.5 | n/a (Docker) |

## Test plan

- [ ] CI (lint / format / typecheck / vitest / build / deploy) が pass
- [ ] `build` と `deploy` job で app_name が `upflow` に解決され、Docker tag が正しく作られる
- [ ] deprecation warning が消える

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **メンテナンス**
  * CI/CDパイプラインのワークフローインフラストラクチャを更新しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->