### PR TITLE
feat: Review Stacks の PR ポップオーバーに矢印を追加

### DIFF
--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -1,4 +1,5 @@
 import { MoreHorizontalIcon } from 'lucide-react'
+import { Popover as PopoverPrimitive } from 'radix-ui'
 import { createContext, useContext } from 'react'
 import { SizeBadge } from '~/app/components/size-badge'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
@@ -415,6 +416,7 @@ export function PRBlock({
       </PopoverTrigger>
       <PopoverContent side="top" className="w-72 p-3">
         <PRPopoverContent pr={pr} />
+        <PopoverPrimitive.Arrow className="bg-popover fill-popover border-border size-2.5 -translate-y-1/2 rotate-45 border-r border-b" />
       </PopoverContent>
     </Popover>
   )

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -359,6 +359,26 @@ export function PRPopoverContent({
   )
 }
 
+export function PRPopover({
+  pr,
+  reviewState,
+  children,
+}: {
+  pr: PRBlockData
+  reviewState?: string
+  children: React.ReactNode
+}) {
+  return (
+    <Popover>
+      <PopoverTrigger asChild>{children}</PopoverTrigger>
+      <PopoverContent side="top" className="w-72 p-3">
+        <PRPopoverContent pr={pr} reviewState={reviewState} />
+        <PopoverPrimitive.Arrow className="bg-popover fill-popover border-border size-2.5 -translate-y-1/2 rotate-45 border-r border-b" />
+      </PopoverContent>
+    </Popover>
+  )
+}
+
 export function PRBlock({
   pr,
   colorMode = 'size',
@@ -394,30 +414,24 @@ export function PRBlock({
   const fillClass = isHollow ? `ring-[2px] ring-inset ${ring} ${bgFaint}` : bg
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>
-        <button
-          type="button"
-          data-pr-key={dataPrKey}
-          className={`flex size-4 shrink-0 items-center justify-center transition-all hover:scale-150 ${shape} ${fillClass}`}
-          aria-label={ariaLabel}
-          onMouseEnter={onMouseEnter}
-          onMouseLeave={onMouseLeave}
-          onClick={onClick}
-        >
-          {statusShape?.icon && (
-            <span
-              className={`text-[8px] leading-none font-bold ${blockTextColor}`}
-            >
-              {statusShape.icon}
-            </span>
-          )}
-        </button>
-      </PopoverTrigger>
-      <PopoverContent side="top" className="w-72 p-3">
-        <PRPopoverContent pr={pr} />
-        <PopoverPrimitive.Arrow className="bg-popover fill-popover border-border size-2.5 -translate-y-1/2 rotate-45 border-r border-b" />
-      </PopoverContent>
-    </Popover>
+    <PRPopover pr={pr}>
+      <button
+        type="button"
+        data-pr-key={dataPrKey}
+        className={`flex size-4 shrink-0 items-center justify-center transition-all hover:scale-150 ${shape} ${fillClass}`}
+        aria-label={ariaLabel}
+        onMouseEnter={onMouseEnter}
+        onMouseLeave={onMouseLeave}
+        onClick={onClick}
+      >
+        {statusShape?.icon && (
+          <span
+            className={`text-[8px] leading-none font-bold ${blockTextColor}`}
+          >
+            {statusShape.icon}
+          </span>
+        )}
+      </button>
+    </PRPopover>
   )
 }

--- a/app/routes/$orgSlug/workload/$login/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/workload/$login/+functions/queries.server.ts
@@ -376,3 +376,125 @@ export const getBacklogDetails = async (
 
   return { openPRs: openPRsRaw, pendingReviews, reviewHistory, reviewerRows }
 }
+
+export interface PRKey {
+  repositoryId: string
+  number: number
+}
+
+export const getPRPopoverEnrichment = async (
+  organizationId: OrganizationId,
+  prKeys: PRKey[],
+) => {
+  if (prKeys.length === 0) {
+    return {
+      authors: [] as {
+        repositoryId: string
+        number: number
+        author: string
+        authorDisplayName: string | null
+      }[],
+      reviewHistory: [] as {
+        repositoryId: string
+        number: number
+        reviewer: string
+        state: string
+        submittedAt: string
+        reviewerDisplayName: string | null
+      }[],
+      reviewerRows: [] as {
+        repositoryId: string
+        number: number
+        reviewer: string
+        reviewerDisplayName: string | null
+      }[],
+    }
+  }
+  const tenantDb = getTenantDb(organizationId)
+
+  const [authors, reviewHistory, reviewerRows] = await Promise.all([
+    tenantDb
+      .selectFrom('pullRequests')
+      .leftJoin('companyGithubUsers as authorUser', (join) =>
+        join.onRef(
+          (eb) => eb.fn('lower', ['pullRequests.author']),
+          '=',
+          (eb) => eb.fn('lower', ['authorUser.login']),
+        ),
+      )
+      .where((eb) =>
+        eb.or(
+          prKeys.map((k) =>
+            eb.and([
+              eb('pullRequests.repositoryId', '=', k.repositoryId),
+              eb('pullRequests.number', '=', k.number),
+            ]),
+          ),
+        ),
+      )
+      .select([
+        'pullRequests.repositoryId',
+        'pullRequests.number',
+        'pullRequests.author',
+        'authorUser.displayName as authorDisplayName',
+      ])
+      .execute(),
+    tenantDb
+      .selectFrom('pullRequestReviews')
+      .leftJoin('companyGithubUsers', (join) =>
+        join.onRef(
+          (eb) => eb.fn('lower', ['pullRequestReviews.reviewer']),
+          '=',
+          (eb) => eb.fn('lower', ['companyGithubUsers.login']),
+        ),
+      )
+      .where((eb) =>
+        eb.or(
+          prKeys.map((k) =>
+            eb.and([
+              eb('pullRequestReviews.repositoryId', '=', k.repositoryId),
+              eb('pullRequestReviews.pullRequestNumber', '=', k.number),
+            ]),
+          ),
+        ),
+      )
+      .select([
+        'pullRequestReviews.repositoryId',
+        'pullRequestReviews.pullRequestNumber as number',
+        'pullRequestReviews.reviewer',
+        'pullRequestReviews.state',
+        'pullRequestReviews.submittedAt',
+        'companyGithubUsers.displayName as reviewerDisplayName',
+      ])
+      .execute(),
+    tenantDb
+      .selectFrom('pullRequestReviewers')
+      .leftJoin('companyGithubUsers', (join) =>
+        join.onRef(
+          (eb) => eb.fn('lower', ['pullRequestReviewers.reviewer']),
+          '=',
+          (eb) => eb.fn('lower', ['companyGithubUsers.login']),
+        ),
+      )
+      .where((eb) =>
+        eb.or(
+          prKeys.map((k) =>
+            eb.and([
+              eb('pullRequestReviewers.repositoryId', '=', k.repositoryId),
+              eb('pullRequestReviewers.pullRequestNumber', '=', k.number),
+            ]),
+          ),
+        ),
+      )
+      .where('pullRequestReviewers.requestedAt', 'is not', null)
+      .select([
+        'pullRequestReviewers.repositoryId',
+        'pullRequestReviewers.pullRequestNumber as number',
+        'pullRequestReviewers.reviewer',
+        'companyGithubUsers.displayName as reviewerDisplayName',
+      ])
+      .execute(),
+  ])
+
+  return { authors, reviewHistory, reviewerRows }
+}

--- a/app/routes/$orgSlug/workload/$login/index.tsx
+++ b/app/routes/$orgSlug/workload/$login/index.tsx
@@ -1,13 +1,8 @@
 import holiday_jp from '@holiday-jp/holiday_jp'
 import { useMemo } from 'react'
-import { Link, href, useSearchParams } from 'react-router'
+import { href, Link, useSearchParams } from 'react-router'
 import { SizeBadge } from '~/app/components/size-badge'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
-import {
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
-} from '~/app/components/ui/popover'
 import { HStack, Stack } from '~/app/components/ui/stack'
 import { ToggleGroup, ToggleGroupItem } from '~/app/components/ui/toggle-group'
 import WeeklyCalendar from '~/app/components/week-calendar'
@@ -23,10 +18,11 @@ import {
 import { orgContext, timezoneContext } from '~/app/middleware/context'
 import {
   PRBlock,
-  PRPopoverContent,
+  PRPopover,
   REVIEW_STATE_STYLE,
   REVIEW_STATUS_PRIORITY,
   type PRBlockData,
+  type PRReviewerStateEntry,
   type PRReviewStatus,
 } from '~/app/routes/$orgSlug/+components/pr-block'
 import { PrTitleFilterStatus } from '~/app/routes/$orgSlug/+components/pr-title-filter-status'
@@ -40,6 +36,7 @@ import {
   getClosedPRs,
   getCreatedPRs,
   getMergedPRs,
+  getPRPopoverEnrichment,
   getReviewsSubmitted,
   getUserProfile,
 } from './+functions/queries.server'
@@ -148,6 +145,54 @@ export const loader = async ({
     return { ...pr, reviewStatus: 'in-review' as const, reviewerStates }
   })
 
+  // Calendar PRs need the same enrichment as Review Stacks so the shared
+  // PRPopover shows author + reviewer states.
+  const calendarPRKeyMap = new Map<
+    string,
+    { repositoryId: string; number: number }
+  >()
+  for (const pr of [...createdPRs, ...mergedPRs, ...closedPRs, ...reviews]) {
+    calendarPRKeyMap.set(`${pr.repositoryId}:${pr.number}`, {
+      repositoryId: pr.repositoryId,
+      number: pr.number,
+    })
+  }
+  const enrichment = await getPRPopoverEnrichment(organization.id, [
+    ...calendarPRKeyMap.values(),
+  ])
+  const calendarReviewerStatesByPR = buildPRReviewerStatesMap(
+    enrichment.reviewHistory,
+    enrichment.reviewerRows,
+  )
+  const calendarPendingReviewerPRKeys = new Set<string>()
+  for (const r of enrichment.reviewerRows) {
+    calendarPendingReviewerPRKeys.add(`${r.repositoryId}:${r.number}`)
+  }
+  const calendarPRDataByKey = new Map<
+    string,
+    {
+      author: string
+      authorDisplayName: string | undefined
+      reviewStatus: PRReviewStatus
+      reviewerStates: PRReviewerStateEntry[]
+    }
+  >()
+  for (const a of enrichment.authors) {
+    const prKey = `${a.repositoryId}:${a.number}`
+    const reviewerStates = calendarReviewerStatesByPR.get(prKey)
+    const reviewStatus = classifyPRReviewStatus(
+      calendarPendingReviewerPRKeys.has(prKey),
+      reviewerStates,
+      a.author,
+    )
+    calendarPRDataByKey.set(prKey, {
+      author: a.author,
+      authorDisplayName: a.authorDisplayName ?? undefined,
+      reviewStatus,
+      reviewerStates: reviewerStates ?? [],
+    })
+  }
+
   return {
     user,
     createdPRs,
@@ -158,6 +203,7 @@ export const loader = async ({
       openPRs: enrichedOpenPRs,
       pendingReviews: enrichedPendingReviews,
     },
+    calendarPRDataByKey: Object.fromEntries(calendarPRDataByKey),
     holidays,
     weekStart: weekStart.format('YYYY-MM-DD'),
     weekEnd: weekEnd.format('YYYY-MM-DD'),
@@ -177,6 +223,7 @@ export default function MemberWeeklyPage({
     closedPRs,
     reviews,
     backlog,
+    calendarPRDataByKey,
     holidays,
     weekStart,
     excludedCount,
@@ -212,6 +259,24 @@ export default function MemberWeeklyPage({
       return prev
     })
   }
+
+  const buildCalendarPrData = (pr: {
+    number: number
+    repo: string
+    title: string
+    url: string
+    pullRequestCreatedAt: string
+    complexity: string | null
+    repositoryId: string
+  }): PRBlockData => ({
+    number: pr.number,
+    repo: pr.repo,
+    title: pr.title,
+    url: pr.url,
+    createdAt: pr.pullRequestCreatedAt,
+    complexity: pr.complexity,
+    ...calendarPRDataByKey[`${pr.repositoryId}:${pr.number}`],
+  })
 
   const sortBacklog = useMemo(() => {
     return <
@@ -527,14 +592,7 @@ export default function MemberWeeklyPage({
                         label={`#${pr.number}`}
                         title={pr.title}
                         complexity={pr.complexity}
-                        prData={{
-                          number: pr.number,
-                          repo: pr.repo,
-                          title: pr.title,
-                          url: pr.url,
-                          createdAt: pr.pullRequestCreatedAt,
-                          complexity: pr.complexity,
-                        }}
+                        prData={buildCalendarPrData(pr)}
                       />
                     ))}
                     {day.merged.map((pr) => (
@@ -544,14 +602,7 @@ export default function MemberWeeklyPage({
                         label={`#${pr.number}`}
                         title={pr.title}
                         complexity={pr.complexity}
-                        prData={{
-                          number: pr.number,
-                          repo: pr.repo,
-                          title: pr.title,
-                          url: pr.url,
-                          createdAt: pr.pullRequestCreatedAt,
-                          complexity: pr.complexity,
-                        }}
+                        prData={buildCalendarPrData(pr)}
                       />
                     ))}
                     {day.reviewed.map((r) => (
@@ -561,15 +612,7 @@ export default function MemberWeeklyPage({
                         label={`#${r.number}`}
                         title={r.title}
                         complexity={r.complexity}
-                        prData={{
-                          number: r.number,
-                          repo: r.repo,
-                          title: r.title,
-                          url: r.url,
-                          author: r.author,
-                          createdAt: r.pullRequestCreatedAt,
-                          complexity: r.complexity,
-                        }}
+                        prData={buildCalendarPrData(r)}
                         reviewState={r.state}
                         reviewCount={r.reviewCount}
                         suffix={REVIEW_STATE_STYLE[r.state]?.icon}
@@ -582,14 +625,7 @@ export default function MemberWeeklyPage({
                         label={`#${pr.number}`}
                         title={pr.title}
                         complexity={pr.complexity}
-                        prData={{
-                          number: pr.number,
-                          repo: pr.repo,
-                          title: pr.title,
-                          url: pr.url,
-                          createdAt: pr.pullRequestCreatedAt,
-                          complexity: pr.complexity,
-                        }}
+                        prData={buildCalendarPrData(pr)}
                       />
                     ))}
                   </div>
@@ -776,12 +812,9 @@ function CalendarItem({
   if (!prData) return content
 
   return (
-    <Popover>
-      <PopoverTrigger asChild>{content}</PopoverTrigger>
-      <PopoverContent side="top" className="w-72 p-3">
-        <PRPopoverContent pr={prData} reviewState={reviewState} />
-      </PopoverContent>
-    </Popover>
+    <PRPopover pr={prData} reviewState={reviewState}>
+      {content}
+    </PRPopover>
   )
 }
 


### PR DESCRIPTION
## Summary

- Review Stacks の PR ブロックをクリックして開くポップオーバーに、トリガー位置を指す矢印（吹き出しの三角）を追加
- スクショ共有時に「どの PR の情報か」が一目でわかるようにする
- `tooltip.tsx` と同じ回転スクエア方式（`size-2.5 rotate-45 border-r border-b`）で外側 V字エッジだけにボーダーを出す

## Test plan

- [ ] `/iris/workload` の Review Stacks で PR ブロックをクリックし、ポップオーバーの下端から矢印が PR ブロックを指していること
- [ ] 矢印の塗りが popover 背景と一致し、外側 V字エッジに border が見えること
- [ ] ポップオーバーが下に flip した場合（画面上端付近）も矢印の向きが追従すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **UI改善**
  * ポップオーバーコンポーネントに矢印インジケーターを追加しました。これにより、ユーザーはポップオーバーの参照元をより明確に認識できるようになります。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->