### PR TITLE
feat: PR タイトルフィルタ候補で Unicode letter prefix に対応 (#310)

### DIFF
--- a/app/libs/pr-title-filter.test.ts
+++ b/app/libs/pr-title-filter.test.ts
@@ -145,9 +145,10 @@ describe('extractPatternCandidates', () => {
 
   it('does not extract prefix starting with emoji', () => {
     const candidates = extractPatternCandidates('[🚀 release] deploy')
-    const values = candidates.map((c) => c.value)
-    expect(values).toContain('[🚀 release]')
-    expect(values.some((v) => v.endsWith('-'))).toBe(false)
+    expect(candidates.map((c) => c.value)).toContain('[🚀 release]')
+    const kinds = candidates.map((c) => c.kind)
+    expect(kinds).not.toContain('bracket-prefix')
+    expect(kinds).not.toContain('colon-prefix')
   })
 })
 

--- a/app/libs/pr-title-filter.test.ts
+++ b/app/libs/pr-title-filter.test.ts
@@ -114,6 +114,41 @@ describe('extractPatternCandidates', () => {
     const candidates = extractPatternCandidates('plain title without markers')
     expect(candidates).toEqual([])
   })
+
+  it('extracts Japanese bracket prefix', () => {
+    const candidates = extractPatternCandidates(
+      '[機能追加-001] ログイン画面の修正',
+    )
+    const values = candidates.map((c) => c.value)
+    expect(values).toContain('[機能追加-001]')
+    expect(values).toContain('[機能追加-')
+  })
+
+  it('extracts Japanese colon prefix', () => {
+    const candidates = extractPatternCandidates('機能追加: ログイン画面')
+    expect(candidates.map((c) => c.value)).toContain('機能追加:')
+  })
+
+  it('extracts accented bracket prefix', () => {
+    const candidates = extractPatternCandidates('[Café-42] update')
+    const values = candidates.map((c) => c.value)
+    expect(values).toContain('[Café-42]')
+    expect(values).toContain('[Café-')
+  })
+
+  it('extracts prefix with mixed ASCII and CJK letters', () => {
+    const candidates = extractPatternCandidates('[EPIC機能-001] refactor')
+    const values = candidates.map((c) => c.value)
+    expect(values).toContain('[EPIC機能-001]')
+    expect(values).toContain('[EPIC機能-')
+  })
+
+  it('does not extract prefix starting with emoji', () => {
+    const candidates = extractPatternCandidates('[🚀 release] deploy')
+    const values = candidates.map((c) => c.value)
+    expect(values).toContain('[🚀 release]')
+    expect(values.some((v) => v.endsWith('-'))).toBe(false)
+  })
 })
 
 describe('translatePrTitleFilterError', () => {

--- a/app/libs/pr-title-filter.ts
+++ b/app/libs/pr-title-filter.ts
@@ -51,8 +51,8 @@ export interface PatternCandidate {
 }
 
 const BRACKET_RE = /\[([^\]]+)\]/g
-const BRACKET_PREFIX_RE = /^\[([A-Za-z]+)[-_]/
-const COLON_PREFIX_RE = /^([A-Za-z]+):/
+const BRACKET_PREFIX_RE = /^\[(\p{L}+)[-_]/u
+const COLON_PREFIX_RE = /^(\p{L}+):/u
 
 export const extractPatternCandidates = (title: string): PatternCandidate[] => {
   const candidates: PatternCandidate[] = []


### PR DESCRIPTION
## Summary

- `extractPatternCandidates` の `BRACKET_PREFIX_RE` / `COLON_PREFIX_RE` を `[A-Za-z]+` から `\p{L}+` (Unicode letter) に変更
- 日本語・アクセント付き文字・CJK 混在プレフィックスが filter 候補チップに出るようになる
- 絵文字 (`[🚀 release]`) は `\p{L}` に含まれないので意図通り非対応のまま

Closes #310

## Test plan

- [x] `pnpm vitest run app/libs/pr-title-filter.test.ts` — 26 passed
- [x] `pnpm validate` — 全通過 (lint/format/typecheck/build/test 437 passed)
- [x] 日本語 bracket prefix (`[機能追加-`) が抽出される
- [x] 日本語 colon prefix (`機能追加:`) が抽出される
- [x] アクセント付き (`[Café-`) が抽出される
- [x] ASCII+CJK 混在 (`[EPIC機能-`) が抽出される
- [x] 絵文字プレフィックスは prefix 候補に出ない (bracket全体のみ)

🤖 Generated with [Claude Code](https://claude.com/claude-code)