### PR TITLE
feat: PR タイトルフィルタ Sheet trigger を throughput / analysis に展開 (#309)

### DIFF
--- a/app/routes/$orgSlug/+components/hide-prs-by-title-menu.tsx
+++ b/app/routes/$orgSlug/+components/hide-prs-by-title-menu.tsx
@@ -1,0 +1,73 @@
+import type { ColumnDef } from '@tanstack/react-table'
+import { MoreHorizontalIcon } from 'lucide-react'
+import { createContext, useContext } from 'react'
+import { Button } from '~/app/components/ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '~/app/components/ui/dropdown-menu'
+import { cn } from '~/app/libs/utils'
+
+/**
+ * `HidePRsByTitleMenu` 内で trigger を出すための context。
+ * null (provide されない) / null 値の場合はボタン非表示。admin のみ表示する親ページが value を設定する。
+ */
+export const PRHideByTitleFilterContext = createContext<
+  ((title: string) => void) | null
+>(null)
+
+export function HidePRsByTitleMenu({
+  title,
+  className,
+}: {
+  title: string
+  className?: string
+}) {
+  const onHideByTitle = useContext(PRHideByTitleFilterContext)
+  if (!onHideByTitle) return null
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          type="button"
+          size="icon"
+          variant="ghost"
+          className={cn('size-5', className)}
+          aria-label="More actions"
+        >
+          <MoreHorizontalIcon size={14} />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={() => onHideByTitle(title)}>
+          Hide PRs by title…
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}
+
+/**
+ * TanStack Table の末尾に差し込む「admin 専用 actions 列」を返す。
+ * 非 admin には空配列を返すので spread で呼び出し側に負担を残さない。
+ */
+export function hidePrActionsColumn<T>(
+  isAdmin: boolean,
+  getTitle: (row: T) => string | null | undefined,
+): ColumnDef<T>[] {
+  if (!isAdmin) return []
+  return [
+    {
+      id: 'actions',
+      header: '',
+      cell: ({ row }) => {
+        const title = getTitle(row.original)
+        return title ? <HidePRsByTitleMenu title={title} /> : null
+      },
+      enableHiding: false,
+      enableSorting: false,
+    },
+  ]
+}

--- a/app/routes/$orgSlug/+components/pr-block.test.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.test.tsx
@@ -10,8 +10,8 @@ import {
   vi,
   type Mock,
 } from 'vitest'
+import { PRHideByTitleFilterContext } from './hide-prs-by-title-menu'
 import {
-  PRHideByTitleFilterContext,
   PRPopover,
   PRPopoverContent,
   type PRPopoverData,

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -296,7 +296,7 @@ function PRPopoverSkeleton() {
   )
 }
 
-function HidePRsByTitleMenu({
+export function HidePRsByTitleMenu({
   title,
   className,
 }: {

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -1,17 +1,9 @@
-import { MoreHorizontalIcon } from 'lucide-react'
 import { Popover as PopoverPrimitive } from 'radix-ui'
-import { createContext, useContext, useRef, useState } from 'react'
+import { useRef, useState } from 'react'
 import { href, useFetcher, useParams } from 'react-router'
 import { SizeBadge } from '~/app/components/size-badge'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import { Badge } from '~/app/components/ui/badge'
-import { Button } from '~/app/components/ui/button'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '~/app/components/ui/dropdown-menu'
 import {
   Popover,
   PopoverContent,
@@ -19,15 +11,7 @@ import {
 } from '~/app/components/ui/popover'
 import { Skeleton } from '~/app/components/ui/skeleton'
 import dayjs from '~/app/libs/dayjs'
-import { cn } from '~/app/libs/utils'
-
-/**
- * PRPopoverContent 内で「タイトルパターンで除外」ボタンを出すための context。
- * null (provide されない) / null 値の場合はボタン非表示。admin のみ表示する親ページが value を設定する。
- */
-export const PRHideByTitleFilterContext = createContext<
-  ((title: string) => void) | null
->(null)
+import { HidePRsByTitleMenu } from './hide-prs-by-title-menu'
 
 export type PRBlockColorMode = 'size' | 'age'
 
@@ -293,37 +277,6 @@ function PRPopoverSkeleton() {
       <Skeleton className="h-3 w-full" />
       <Skeleton className="h-3 w-5/6" />
     </div>
-  )
-}
-
-export function HidePRsByTitleMenu({
-  title,
-  className,
-}: {
-  title: string
-  className?: string
-}) {
-  const onHideByTitle = useContext(PRHideByTitleFilterContext)
-  if (!onHideByTitle) return null
-  return (
-    <DropdownMenu>
-      <DropdownMenuTrigger asChild>
-        <Button
-          type="button"
-          size="icon"
-          variant="ghost"
-          className={cn('size-5', className)}
-          aria-label="More actions"
-        >
-          <MoreHorizontalIcon size={14} />
-        </Button>
-      </DropdownMenuTrigger>
-      <DropdownMenuContent align="end">
-        <DropdownMenuItem onSelect={() => onHideByTitle(title)}>
-          Hide PRs by title…
-        </DropdownMenuItem>
-      </DropdownMenuContent>
-    </DropdownMenu>
   )
 }
 

--- a/app/routes/$orgSlug/_layout.tsx
+++ b/app/routes/$orgSlug/_layout.tsx
@@ -14,7 +14,7 @@ import {
   timezoneContext,
 } from '~/app/middleware/context'
 import { orgMemberMiddleware } from '~/app/middleware/org-member'
-import { PRHideByTitleFilterContext } from '~/app/routes/$orgSlug/+components/pr-block'
+import { PRHideByTitleFilterContext } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
 import { PrTitleFilterSheet } from '~/app/routes/$orgSlug/+components/pr-title-filter-sheet'
 import { listTeams } from '~/app/routes/$orgSlug/settings/teams._index/queries.server'
 import type { Route } from './+types/_layout'

--- a/app/routes/$orgSlug/_layout.tsx
+++ b/app/routes/$orgSlug/_layout.tsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Outlet, href, useMatches } from 'react-router'
 import { AppSidebar } from '~/app/components/layout/app-sidebar'
 import { Header } from '~/app/components/layout/header'
@@ -5,6 +6,7 @@ import { Main } from '~/app/components/layout/main'
 import { SidebarProvider } from '~/app/components/ui/sidebar'
 import { useBreadcrumbs } from '~/app/hooks/use-breadcrumbs'
 import { getUserOrganizations } from '~/app/libs/auth.server'
+import { isOrgAdmin } from '~/app/libs/member-role'
 import { cn } from '~/app/libs/utils'
 import {
   orgContext,
@@ -12,6 +14,8 @@ import {
   timezoneContext,
 } from '~/app/middleware/context'
 import { orgMemberMiddleware } from '~/app/middleware/org-member'
+import { PRHideByTitleFilterContext } from '~/app/routes/$orgSlug/+components/pr-block'
+import { PrTitleFilterSheet } from '~/app/routes/$orgSlug/+components/pr-title-filter-sheet'
 import { listTeams } from '~/app/routes/$orgSlug/settings/teams._index/queries.server'
 import type { Route } from './+types/_layout'
 
@@ -64,6 +68,7 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
     timezone,
     teams,
     selectedTeamId,
+    isAdmin: isOrgAdmin(membership.role),
   }
 }
 
@@ -76,6 +81,7 @@ export default function OrgLayout({
     defaultOpen,
     teams,
     selectedTeamId,
+    isAdmin,
   },
 }: Route.ComponentProps) {
   const { Breadcrumbs } = useBreadcrumbs()
@@ -84,6 +90,15 @@ export default function OrgLayout({
     if (m.handle && typeof m.handle === 'object') Object.assign(acc, m.handle)
     return acc
   }, {}) as RouteHandle
+
+  const [sheetOpen, setSheetOpen] = useState(false)
+  const [sheetTitle, setSheetTitle] = useState<string | null>(null)
+  const openSheet = isAdmin
+    ? (title: string) => {
+        setSheetTitle(title)
+        setSheetOpen(true)
+      }
+    : null
 
   return (
     <SidebarProvider defaultOpen={defaultOpen}>
@@ -109,7 +124,16 @@ export default function OrgLayout({
           <Breadcrumbs />
         </Header>
         <Main fixed={handle.mainFixed}>
-          <Outlet />
+          <PRHideByTitleFilterContext.Provider value={openSheet}>
+            <Outlet />
+            {isAdmin && (
+              <PrTitleFilterSheet
+                open={sheetOpen}
+                onOpenChange={setSheetOpen}
+                pullRequestTitle={sheetTitle}
+              />
+            )}
+          </PRHideByTitleFilterContext.Provider>
         </Main>
       </div>
     </SidebarProvider>

--- a/app/routes/$orgSlug/_layout.tsx
+++ b/app/routes/$orgSlug/_layout.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useCallback, useState } from 'react'
 import { Outlet, href, useMatches } from 'react-router'
 import { AppSidebar } from '~/app/components/layout/app-sidebar'
 import { Header } from '~/app/components/layout/header'
@@ -93,12 +93,11 @@ export default function OrgLayout({
 
   const [sheetOpen, setSheetOpen] = useState(false)
   const [sheetTitle, setSheetTitle] = useState<string | null>(null)
-  const openSheet = isAdmin
-    ? (title: string) => {
-        setSheetTitle(title)
-        setSheetOpen(true)
-      }
-    : null
+  const openSheetImpl = useCallback((title: string) => {
+    setSheetTitle(title)
+    setSheetOpen(true)
+  }, [])
+  const openSheet = isAdmin ? openSheetImpl : null
 
   return (
     <SidebarProvider defaultOpen={defaultOpen}>

--- a/app/routes/$orgSlug/analysis/feedbacks/_index/+components/feedback-columns.tsx
+++ b/app/routes/$orgSlug/analysis/feedbacks/_index/+components/feedback-columns.tsx
@@ -13,7 +13,7 @@ import {
   type PRSizeLabel,
 } from '~/app/libs/pr-classify'
 import { cn } from '~/app/libs/utils'
-import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
+import { hidePrActionsColumn } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
 import type { FeedbackRow } from '../+functions/queries.server'
 
 function SizeBadgeInline({ size }: { size: string | null }) {
@@ -48,7 +48,7 @@ const columnHelper = createColumnHelper<FeedbackRow>()
 export function createFeedbackColumns(
   isAdmin: boolean,
 ): ColumnDef<FeedbackRow, unknown>[] {
-  const columns: ColumnDef<FeedbackRow, unknown>[] = [
+  return [
     columnHelper.accessor('repoName', {
       header: 'Repository',
       cell: (info) => (
@@ -141,20 +141,6 @@ export function createFeedbackColumns(
       ),
       enableSorting: true,
     }),
+    ...hidePrActionsColumn<FeedbackRow>(isAdmin, (r) => r.prTitle),
   ]
-
-  if (isAdmin) {
-    columns.push(
-      columnHelper.display({
-        id: 'actions',
-        header: '',
-        cell: (info) =>
-          info.row.original.prTitle ? (
-            <HidePRsByTitleMenu title={info.row.original.prTitle} />
-          ) : null,
-      }),
-    )
-  }
-
-  return columns
 }

--- a/app/routes/$orgSlug/analysis/feedbacks/_index/+components/feedback-columns.tsx
+++ b/app/routes/$orgSlug/analysis/feedbacks/_index/+components/feedback-columns.tsx
@@ -13,6 +13,7 @@ import {
   type PRSizeLabel,
 } from '~/app/libs/pr-classify'
 import { cn } from '~/app/libs/utils'
+import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
 import type { FeedbackRow } from '../+functions/queries.server'
 
 function SizeBadgeInline({ size }: { size: string | null }) {
@@ -44,97 +45,116 @@ function DirectionIcon({
 
 const columnHelper = createColumnHelper<FeedbackRow>()
 
-export const feedbackColumns: ColumnDef<FeedbackRow, unknown>[] = [
-  columnHelper.accessor('repoName', {
-    header: 'Repository',
-    cell: (info) => (
-      <span className="text-sm text-nowrap">
-        {info.row.original.repoOwner}/{info.getValue()}
-      </span>
-    ),
-    enableSorting: true,
-    id: 'repository',
-  }),
-  columnHelper.accessor('prTitle', {
-    header: 'PR',
-    cell: (info) => (
-      <a
-        href={info.row.original.prUrl}
-        target="_blank"
-        rel="noopener noreferrer"
-        className="hover:underline"
-      >
-        <span className="text-muted-foreground mr-1">
-          #{info.row.original.pullRequestNumber}
+export function createFeedbackColumns(
+  isAdmin: boolean,
+): ColumnDef<FeedbackRow, unknown>[] {
+  const columns: ColumnDef<FeedbackRow, unknown>[] = [
+    columnHelper.accessor('repoName', {
+      header: 'Repository',
+      cell: (info) => (
+        <span className="text-sm text-nowrap">
+          {info.row.original.repoOwner}/{info.getValue()}
         </span>
-        <span className="line-clamp-1">{info.getValue()}</span>
-      </a>
-    ),
-    enableSorting: false,
-  }),
-  columnHelper.accessor('originalComplexity', {
-    header: 'Original',
-    cell: (info) => <SizeBadgeInline size={info.getValue()} />,
-    enableSorting: false,
-  }),
-  columnHelper.display({
-    id: 'direction',
-    header: '',
-    cell: (info) => (
-      <DirectionIcon
-        original={info.row.original.originalComplexity}
-        corrected={info.row.original.correctedComplexity}
-      />
-    ),
-  }),
-  columnHelper.accessor('correctedComplexity', {
-    header: 'Corrected',
-    cell: (info) => <SizeBadgeInline size={info.getValue()} />,
-    enableSorting: false,
-  }),
-  columnHelper.accessor('reason', {
-    header: 'Reason',
-    cell: (info) => {
-      const value = info.getValue()
-      if (!value) return <span className="text-muted-foreground">—</span>
-      if (value.length <= 60) return <span className="text-sm">{value}</span>
-      return (
-        <Tooltip>
-          <TooltipTrigger asChild>
-            <span className="cursor-help text-sm">{value.slice(0, 60)}…</span>
-          </TooltipTrigger>
-          <TooltipContent className="max-w-xs">{value}</TooltipContent>
-        </Tooltip>
-      )
-    },
-    enableSorting: false,
-  }),
-  columnHelper.accessor('feedbackByLogin', {
-    header: 'By',
-    cell: (info) => {
-      const login = info.getValue()
-      if (!login) return <span className="text-muted-foreground">—</span>
-      const displayName = info.row.original.feedbackByDisplayName ?? login
-      return (
-        <div className="flex items-center gap-1.5">
-          <img
-            src={`https://github.com/${login}.png?size=32`}
-            alt={login}
-            className="h-5 w-5 rounded-full"
-          />
-          <span className="text-sm text-nowrap">{displayName}</span>
-        </div>
-      )
-    },
-    enableSorting: false,
-  }),
-  columnHelper.accessor('updatedAt', {
-    header: 'Updated',
-    cell: (info) => (
-      <span className="text-muted-foreground text-sm text-nowrap">
-        {dayjs.utc(info.getValue()).fromNow()}
-      </span>
-    ),
-    enableSorting: true,
-  }),
-] as ColumnDef<FeedbackRow, unknown>[]
+      ),
+      enableSorting: true,
+      id: 'repository',
+    }),
+    columnHelper.accessor('prTitle', {
+      header: 'PR',
+      cell: (info) => (
+        <a
+          href={info.row.original.prUrl}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="hover:underline"
+        >
+          <span className="text-muted-foreground mr-1">
+            #{info.row.original.pullRequestNumber}
+          </span>
+          <span className="line-clamp-1">{info.getValue()}</span>
+        </a>
+      ),
+      enableSorting: false,
+    }),
+    columnHelper.accessor('originalComplexity', {
+      header: 'Original',
+      cell: (info) => <SizeBadgeInline size={info.getValue()} />,
+      enableSorting: false,
+    }),
+    columnHelper.display({
+      id: 'direction',
+      header: '',
+      cell: (info) => (
+        <DirectionIcon
+          original={info.row.original.originalComplexity}
+          corrected={info.row.original.correctedComplexity}
+        />
+      ),
+    }),
+    columnHelper.accessor('correctedComplexity', {
+      header: 'Corrected',
+      cell: (info) => <SizeBadgeInline size={info.getValue()} />,
+      enableSorting: false,
+    }),
+    columnHelper.accessor('reason', {
+      header: 'Reason',
+      cell: (info) => {
+        const value = info.getValue()
+        if (!value) return <span className="text-muted-foreground">—</span>
+        if (value.length <= 60) return <span className="text-sm">{value}</span>
+        return (
+          <Tooltip>
+            <TooltipTrigger asChild>
+              <span className="cursor-help text-sm">{value.slice(0, 60)}…</span>
+            </TooltipTrigger>
+            <TooltipContent className="max-w-xs">{value}</TooltipContent>
+          </Tooltip>
+        )
+      },
+      enableSorting: false,
+    }),
+    columnHelper.accessor('feedbackByLogin', {
+      header: 'By',
+      cell: (info) => {
+        const login = info.getValue()
+        if (!login) return <span className="text-muted-foreground">—</span>
+        const displayName = info.row.original.feedbackByDisplayName ?? login
+        return (
+          <div className="flex items-center gap-1.5">
+            <img
+              src={`https://github.com/${login}.png?size=32`}
+              alt={login}
+              className="h-5 w-5 rounded-full"
+            />
+            <span className="text-sm text-nowrap">{displayName}</span>
+          </div>
+        )
+      },
+      enableSorting: false,
+    }),
+    columnHelper.accessor('updatedAt', {
+      header: 'Updated',
+      cell: (info) => (
+        <span className="text-muted-foreground text-sm text-nowrap">
+          {dayjs.utc(info.getValue()).fromNow()}
+        </span>
+      ),
+      enableSorting: true,
+    }),
+  ]
+
+  if (isAdmin) {
+    columns.push(
+      columnHelper.display({
+        id: 'actions',
+        header: '',
+        cell: (info) =>
+          info.row.original.prTitle ? (
+            <HidePRsByTitleMenu title={info.row.original.prTitle} />
+          ) : null,
+      }),
+    )
+  }
+
+  return columns
+}

--- a/app/routes/$orgSlug/analysis/feedbacks/_index/index.tsx
+++ b/app/routes/$orgSlug/analysis/feedbacks/_index/index.tsx
@@ -4,6 +4,7 @@ import {
   useReactTable,
 } from '@tanstack/react-table'
 import { ArrowDownIcon, ArrowUpDownIcon, ArrowUpIcon } from 'lucide-react'
+import { useMemo } from 'react'
 import { useSearchParams } from 'react-router'
 import {
   PageHeader,
@@ -41,7 +42,7 @@ import {
 } from '~/app/middleware/context'
 import { PrTitleFilterStatus } from '~/app/routes/$orgSlug/+components/pr-title-filter-status'
 import { DataTablePagination } from './+components/data-table-pagination'
-import { feedbackColumns } from './+components/feedback-columns'
+import { createFeedbackColumns } from './+components/feedback-columns'
 import { FeedbackSummaryCards } from './+components/feedback-summary-cards'
 import {
   countFeedbacks,
@@ -147,9 +148,10 @@ export default function FeedbacksPage({
   const [, setSearchParams] = useSearchParams()
   const { sort, updateSort } = useDataTableState()
 
+  const columns = useMemo(() => createFeedbackColumns(isAdmin), [isAdmin])
   const table = useReactTable({
     data: feedbacks,
-    columns: feedbackColumns,
+    columns,
     getCoreRowModel: getCoreRowModel(),
     manualSorting: true,
     manualPagination: true,
@@ -276,7 +278,7 @@ export default function FeedbacksPage({
                 ) : (
                   <TableRow>
                     <TableCell
-                      colSpan={feedbackColumns.length}
+                      colSpan={columns.length}
                       className="h-24 text-center"
                     >
                       No feedbacks found.

--- a/app/routes/$orgSlug/analysis/reviews/+components/pr-drill-down-sheet.tsx
+++ b/app/routes/$orgSlug/analysis/reviews/+components/pr-drill-down-sheet.tsx
@@ -10,7 +10,7 @@ import {
   SheetTitle,
 } from '~/app/components/ui/sheet'
 import { parseRiskAreas } from '~/app/libs/pr-classify'
-import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
+import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
 
 export interface DrillDownPR {
   number: number
@@ -85,19 +85,14 @@ export function PRDrillDownSheet({
                     </Avatar>
                     {pr.authorDisplayName ?? pr.author}
                   </span>
-                  {pr.reviewTime != null && pr.reviewTime > 0 && (
-                    <span className="text-muted-foreground ml-auto text-xs">
-                      {formatHours(pr.reviewTime * 24)}
-                    </span>
-                  )}
-                  <HidePRsByTitleMenu
-                    title={pr.title}
-                    className={
-                      pr.reviewTime != null && pr.reviewTime > 0
-                        ? ''
-                        : 'ml-auto'
-                    }
-                  />
+                  <div className="ml-auto flex items-center gap-2">
+                    {pr.reviewTime != null && pr.reviewTime > 0 && (
+                      <span className="text-muted-foreground text-xs">
+                        {formatHours(pr.reviewTime * 24)}
+                      </span>
+                    )}
+                    <HidePRsByTitleMenu title={pr.title} />
+                  </div>
                 </div>
                 <a
                   href={pr.url}

--- a/app/routes/$orgSlug/analysis/reviews/+components/pr-drill-down-sheet.tsx
+++ b/app/routes/$orgSlug/analysis/reviews/+components/pr-drill-down-sheet.tsx
@@ -10,6 +10,7 @@ import {
   SheetTitle,
 } from '~/app/components/ui/sheet'
 import { parseRiskAreas } from '~/app/libs/pr-classify'
+import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
 
 export interface DrillDownPR {
   number: number
@@ -89,6 +90,14 @@ export function PRDrillDownSheet({
                       {formatHours(pr.reviewTime * 24)}
                     </span>
                   )}
+                  <HidePRsByTitleMenu
+                    title={pr.title}
+                    className={
+                      pr.reviewTime != null && pr.reviewTime > 0
+                        ? ''
+                        : 'ml-auto'
+                    }
+                  />
                 </div>
                 <a
                   href={pr.url}

--- a/app/routes/$orgSlug/throughput/deployed/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/deployed/+columns.tsx
@@ -5,7 +5,7 @@ import { Badge, HStack } from '~/app/components/ui'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
-import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
+import { hidePrActionsColumn } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
 import type { PullRequest } from './index'
 
 export function createColumns(
@@ -13,7 +13,7 @@ export function createColumns(
   orgSlug: string,
   isAdmin: boolean,
 ): ColumnDef<PullRequest>[] {
-  const columns: ColumnDef<PullRequest>[] = [
+  return [
     {
       accessorKey: 'author',
       header: ({ column }) => (
@@ -173,20 +173,6 @@ export function createColumns(
       ),
       enableHiding: false,
     },
+    ...hidePrActionsColumn<PullRequest>(isAdmin, (r) => r.title),
   ]
-
-  if (isAdmin) {
-    columns.push({
-      id: 'actions',
-      header: '',
-      cell: ({ row }) =>
-        row.original.title ? (
-          <HidePRsByTitleMenu title={row.original.title} />
-        ) : null,
-      enableHiding: false,
-      enableSorting: false,
-    })
-  }
-
-  return columns
 }

--- a/app/routes/$orgSlug/throughput/deployed/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/deployed/+columns.tsx
@@ -5,13 +5,15 @@ import { Badge, HStack } from '~/app/components/ui'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
+import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
 import type { PullRequest } from './index'
 
 export function createColumns(
   timezone: string,
   orgSlug: string,
+  isAdmin: boolean,
 ): ColumnDef<PullRequest>[] {
-  return [
+  const columns: ColumnDef<PullRequest>[] = [
     {
       accessorKey: 'author',
       header: ({ column }) => (
@@ -172,4 +174,19 @@ export function createColumns(
       enableHiding: false,
     },
   ]
+
+  if (isAdmin) {
+    columns.push({
+      id: 'actions',
+      header: '',
+      cell: ({ row }) =>
+        row.original.title ? (
+          <HidePRsByTitleMenu title={row.original.title} />
+        ) : null,
+      enableHiding: false,
+      enableSorting: false,
+    })
+  }
+
+  return columns
 }

--- a/app/routes/$orgSlug/throughput/deployed/index.tsx
+++ b/app/routes/$orgSlug/throughput/deployed/index.tsx
@@ -144,8 +144,8 @@ export default function DeployedPage({
   const [, setSearchParams] = useSearchParams()
   const timezone = useTimezone()
   const columns = useMemo(
-    () => createColumns(timezone, orgSlug),
-    [timezone, orgSlug],
+    () => createColumns(timezone, orgSlug, isAdmin),
+    [timezone, orgSlug, isAdmin],
   )
 
   return (

--- a/app/routes/$orgSlug/throughput/merged/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/merged/+columns.tsx
@@ -5,13 +5,15 @@ import { Badge, HStack } from '~/app/components/ui'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
+import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
 import type { PullRequest } from './index'
 
 export function createColumns(
   timezone: string,
   orgSlug: string,
+  isAdmin: boolean,
 ): ColumnDef<PullRequest>[] {
-  return [
+  const columns: ColumnDef<PullRequest>[] = [
     {
       accessorKey: 'author',
       header: ({ column }) => (
@@ -162,4 +164,19 @@ export function createColumns(
       enableHiding: false,
     },
   ]
+
+  if (isAdmin) {
+    columns.push({
+      id: 'actions',
+      header: '',
+      cell: ({ row }) =>
+        row.original.title ? (
+          <HidePRsByTitleMenu title={row.original.title} />
+        ) : null,
+      enableHiding: false,
+      enableSorting: false,
+    })
+  }
+
+  return columns
 }

--- a/app/routes/$orgSlug/throughput/merged/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/merged/+columns.tsx
@@ -5,7 +5,7 @@ import { Badge, HStack } from '~/app/components/ui'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
-import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
+import { hidePrActionsColumn } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
 import type { PullRequest } from './index'
 
 export function createColumns(
@@ -13,7 +13,7 @@ export function createColumns(
   orgSlug: string,
   isAdmin: boolean,
 ): ColumnDef<PullRequest>[] {
-  const columns: ColumnDef<PullRequest>[] = [
+  return [
     {
       accessorKey: 'author',
       header: ({ column }) => (
@@ -163,20 +163,6 @@ export function createColumns(
       ),
       enableHiding: false,
     },
+    ...hidePrActionsColumn<PullRequest>(isAdmin, (r) => r.title),
   ]
-
-  if (isAdmin) {
-    columns.push({
-      id: 'actions',
-      header: '',
-      cell: ({ row }) =>
-        row.original.title ? (
-          <HidePRsByTitleMenu title={row.original.title} />
-        ) : null,
-      enableHiding: false,
-      enableSorting: false,
-    })
-  }
-
-  return columns
 }

--- a/app/routes/$orgSlug/throughput/merged/index.tsx
+++ b/app/routes/$orgSlug/throughput/merged/index.tsx
@@ -144,8 +144,8 @@ export default function OrganizationIndex({
   const [, setSearchParams] = useSearchParams()
   const timezone = useTimezone()
   const columns = useMemo(
-    () => createColumns(timezone, orgSlug),
-    [timezone, orgSlug],
+    () => createColumns(timezone, orgSlug, isAdmin),
+    [timezone, orgSlug, isAdmin],
   )
 
   return (

--- a/app/routes/$orgSlug/throughput/ongoing/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/ongoing/+columns.tsx
@@ -4,13 +4,15 @@ import { SizeBadgePopover } from '~/app/components/size-badge-popover'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
+import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
 import type { PullRequest } from './index'
 
 export function createColumns(
   timezone: string,
   orgSlug: string,
+  isAdmin: boolean,
 ): ColumnDef<PullRequest>[] {
-  return [
+  const columns: ColumnDef<PullRequest>[] = [
     {
       accessorKey: 'author',
       header: ({ column }) => (
@@ -146,4 +148,19 @@ export function createColumns(
       enableHiding: false,
     },
   ]
+
+  if (isAdmin) {
+    columns.push({
+      id: 'actions',
+      header: '',
+      cell: ({ row }) =>
+        row.original.title ? (
+          <HidePRsByTitleMenu title={row.original.title} />
+        ) : null,
+      enableHiding: false,
+      enableSorting: false,
+    })
+  }
+
+  return columns
 }

--- a/app/routes/$orgSlug/throughput/ongoing/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/ongoing/+columns.tsx
@@ -4,7 +4,7 @@ import { SizeBadgePopover } from '~/app/components/size-badge-popover'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
-import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/pr-block'
+import { hidePrActionsColumn } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
 import type { PullRequest } from './index'
 
 export function createColumns(
@@ -12,7 +12,7 @@ export function createColumns(
   orgSlug: string,
   isAdmin: boolean,
 ): ColumnDef<PullRequest>[] {
-  const columns: ColumnDef<PullRequest>[] = [
+  return [
     {
       accessorKey: 'author',
       header: ({ column }) => (
@@ -147,20 +147,6 @@ export function createColumns(
       ),
       enableHiding: false,
     },
+    ...hidePrActionsColumn<PullRequest>(isAdmin, (r) => r.title),
   ]
-
-  if (isAdmin) {
-    columns.push({
-      id: 'actions',
-      header: '',
-      cell: ({ row }) =>
-        row.original.title ? (
-          <HidePRsByTitleMenu title={row.original.title} />
-        ) : null,
-      enableHiding: false,
-      enableSorting: false,
-    })
-  }
-
-  return columns
 }

--- a/app/routes/$orgSlug/throughput/ongoing/index.tsx
+++ b/app/routes/$orgSlug/throughput/ongoing/index.tsx
@@ -104,8 +104,8 @@ export default function OngoingPage({
   const [, setSearchParams] = useSearchParams()
   const timezone = useTimezone()
   const columns = useMemo(
-    () => createColumns(timezone, orgSlug),
-    [timezone, orgSlug],
+    () => createColumns(timezone, orgSlug, isAdmin),
+    [timezone, orgSlug, isAdmin],
   )
 
   return (

--- a/app/routes/$orgSlug/workload/index.tsx
+++ b/app/routes/$orgSlug/workload/index.tsx
@@ -1,4 +1,3 @@
-import { useState } from 'react'
 import {
   PageHeader,
   PageHeaderActions,
@@ -13,8 +12,6 @@ import {
   loadPrFilterState,
 } from '~/app/libs/pr-title-filter.server'
 import { orgContext, teamContext } from '~/app/middleware/context'
-import { PRHideByTitleFilterContext } from '~/app/routes/$orgSlug/+components/pr-block'
-import { PrTitleFilterSheet } from '~/app/routes/$orgSlug/+components/pr-title-filter-sheet'
 import { PrTitleFilterStatus } from '~/app/routes/$orgSlug/+components/pr-title-filter-status'
 import { listTeams } from '~/app/routes/$orgSlug/settings/teams._index/queries.server'
 import { TeamStacksChart } from './+components/team-stacks-chart'
@@ -135,45 +132,27 @@ export default function ReviewStacksPage({
     isAdmin,
   },
 }: Route.ComponentProps) {
-  const [sheetOpen, setSheetOpen] = useState(false)
-  const [sheetTitle, setSheetTitle] = useState<string | null>(null)
-  const openSheet = isAdmin
-    ? (title: string) => {
-        setSheetTitle(title)
-        setSheetOpen(true)
-      }
-    : null
-
   return (
-    <PRHideByTitleFilterContext.Provider value={openSheet}>
-      <Stack>
-        <PageHeader>
-          <PageHeaderHeading>
-            <PageHeaderTitle>Review Stacks</PageHeaderTitle>
-            <PageHeaderDescription>
-              Monitor review workload balance across team members.
-            </PageHeaderDescription>
-          </PageHeaderHeading>
-          <PageHeaderActions>
-            <PrTitleFilterStatus
-              excludedCount={excludedCount}
-              filterActive={filterActive}
-              showFiltered={showFiltered}
-              hasAnyEnabledPattern={hasAnyEnabledPattern}
-              isAdmin={isAdmin}
-            />
-          </PageHeaderActions>
-        </PageHeader>
+    <Stack>
+      <PageHeader>
+        <PageHeaderHeading>
+          <PageHeaderTitle>Review Stacks</PageHeaderTitle>
+          <PageHeaderDescription>
+            Monitor review workload balance across team members.
+          </PageHeaderDescription>
+        </PageHeaderHeading>
+        <PageHeaderActions>
+          <PrTitleFilterStatus
+            excludedCount={excludedCount}
+            filterActive={filterActive}
+            showFiltered={showFiltered}
+            hasAnyEnabledPattern={hasAnyEnabledPattern}
+            isAdmin={isAdmin}
+          />
+        </PageHeaderActions>
+      </PageHeader>
 
-        <TeamStacksChart data={teamStacks} />
-      </Stack>
-      {isAdmin && (
-        <PrTitleFilterSheet
-          open={sheetOpen}
-          onOpenChange={setSheetOpen}
-          pullRequestTitle={sheetTitle}
-        />
-      )}
-    </PRHideByTitleFilterContext.Provider>
+      <TeamStacksChart data={teamStacks} />
+    </Stack>
   )
 }


### PR DESCRIPTION
## Summary

Phase 1 で Review Stacks のみに設置していた「Hide PRs by title…」Sheet trigger を、以下 5 画面に展開する。

- **throughput/ongoing** — DataTable に admin 専用 action 列を追加
- **throughput/merged** — 同上
- **throughput/deployed** — 同上
- **analysis/feedbacks** — DataTable に admin 専用 action 列を追加
- **analysis/reviews** — `PRDrillDownSheet` 内の PR 行に trigger を追加

### 共通化

各ページで重複していた Sheet + Provider の state を `_layout.tsx` に集約。`workload/index.tsx` から Sheet 関連コードを削除し、Review Stacks を含む全ての org 配下ページで `PRHideByTitleFilterContext` が共有される。

`HidePRsByTitleMenu` を `pr-block.tsx` から export して再利用可能に。

### 未対応: analysis/inventory

Issue の完了条件には 6 画面（analysis 3 含む）とあるが、inventory はチャートのみで PR drill-down UI を持たない。issue の検討事項にも「別経路を検討」とある通り、drill-down の設計自体がまず必要なため、別 issue に分離する。

Closes #309 (partial — inventory は follow-up)

## Test plan

- [x] \`pnpm validate\` — lint / format / typecheck / build / test 437 passed
- [ ] ローカルブラウザで admin として:
  - [ ] throughput/ongoing の ⋯ → Sheet が開き、タイトル候補が自動抽出される
  - [ ] throughput/merged 同上
  - [ ] throughput/deployed 同上
  - [ ] analysis/feedbacks 同上
  - [ ] analysis/reviews チャートの drill-down → PR 行 ⋯ → Sheet（Sheet 重ね表示）
  - [ ] Review Stacks (従来): PR popover の⋯からも引き続き起動可
  - [ ] 非 admin: いずれの画面でも ⋯ 列 / アクション非表示
- [ ] Sheet submit → `/{orgSlug}/settings/pr-filters` に新規フィルタが登録される

> ブラウザ検証は login が必要なため自動化できず、動作確認はレビュー時に実機で確認をお願いします。コードパス・型・ユニットテストは全て通過。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **新機能**
  * 管理者がプルリクエストをタイトルで非表示にできる機能を追加しました。複数のビュー（フィードバック分析、レビュー、スループットダッシュボード）で利用可能です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->