### PR TITLE
Skip durably.db replication to stay in R2 free tier

### DIFF
--- a/docs/ops/litestream-r2.md
+++ b/docs/ops/litestream-r2.md
@@ -106,7 +106,11 @@ If R2 contains a `production/litestream/durably.db/` prefix from before durably 
 1. R2 → `upflow-backups` → navigate into `production/litestream/durably.db/`
 2. Select all objects (or the whole folder) and Delete
 
-Litestream manages its own LTX retention via compaction levels for the actively-replicated databases (`data.db`, `tenant_*.db`), so no recurring lifecycle rule is needed.
+## R2 Storage Growth
+
+Litestream's config in this repo sets `retention.enabled: false` so the running app does not need Delete permission on R2. Compaction still runs and merges level-0 LTX files into higher levels, but with retention disabled it only deletes the merged-away files **locally** (the `l0 retention enforced` lines in the logs); the originals on R2 are never removed. Compaction therefore keeps Class A PUT volume and live object count bounded, but R2 storage grows monotonically.
+
+At current write volume the growth is on the order of tens of MB per month for `data.db` + `tenant_*.db` combined, so the 10 GB free tier is not a near-term concern. When R2 storage approaches the limit, set up an R2 lifecycle rule to expire objects under `production/litestream/` past some retention horizon (e.g. 30 or 90 days) — the same operator-side action used for the one-off durably cleanup above, just made recurring.
 
 ## Restore Smoke Test
 

--- a/docs/ops/litestream-r2.md
+++ b/docs/ops/litestream-r2.md
@@ -6,13 +6,12 @@ upflow backs up SQLite databases to Cloudflare R2 with Litestream.
 
 Litestream is enabled only when `LITESTREAM_ENABLED=1`.
 
-The production config watches `${UPFLOW_DATA_DIR}` and replicates every SQLite database matching `*.db`, including:
+The production config replicates two classes of SQLite database:
 
-- `data.db`
-- `durably.db`
-- `tenant_*.db`
+- `data.db` — shared DB (organizations, members, integrations, githubAppLinks). Low write rate, tight RPO.
+- `tenant_*.db` — per-org analytics. Picked up dynamically via directory watch when new orgs are added.
 
-New tenant databases are picked up by Litestream directory watch.
+`durably.db` is **intentionally excluded** from replication. It holds in-flight `@coji/durably` job orchestration state, which Litestream would persist as roughly one level-0 LTX file per transaction — at hourly crawl cadence that accounts for about half of all R2 Class A operations. The data is regenerable: GitHub is the source of truth, and the next hourly crawl re-derives state via idempotent upserts. Worst-case loss on restore is whatever job was in flight at the moment of disaster, which the scheduler picks up on its next tick. Skipping durably keeps R2 PUT volume comfortably inside the free tier with headroom for organization growth.
 
 ## R2 Bucket
 
@@ -91,13 +90,23 @@ Look for Litestream startup and database discovery logs. Confirm R2 has objects 
 upflow-backups/production/litestream/
 ```
 
-The directory replica appends each database filename under the prefix, for example:
+Each replicated database appears as its own subprefix, for example:
 
 ```text
 production/litestream/data.db/
-production/litestream/durably.db/
 production/litestream/tenant_iris.db/
 ```
+
+A `production/litestream/durably.db/` prefix may exist as a remnant from earlier runs that replicated `durably.db`. It is no longer updated and can be cleaned up with an R2 lifecycle rule (see "Stale durably.db Cleanup" below) — credentials in production lack Delete permission by design, so the rule, not Litestream, is responsible for removal.
+
+## Stale durably.db Cleanup
+
+If R2 contains a `production/litestream/durably.db/` prefix from before durably was excluded, set up a lifecycle rule to expire it. Cloudflare Dashboard → R2 → `upflow-backups` → Settings → Object lifecycle rules:
+
+- Prefix: `production/litestream/durably.db/`
+- Action: **Delete objects** after `7 days` (or any short retention; the prefix is stale and will not get new writes)
+
+The rest of the bucket is left untouched — Litestream manages its own LTX retention via compaction levels for the active databases.
 
 ## Restore Smoke Test
 

--- a/docs/ops/litestream-r2.md
+++ b/docs/ops/litestream-r2.md
@@ -97,16 +97,16 @@ production/litestream/data.db/
 production/litestream/tenant_iris.db/
 ```
 
-A `production/litestream/durably.db/` prefix may exist as a remnant from earlier runs that replicated `durably.db`. It is no longer updated and can be cleaned up with an R2 lifecycle rule (see "Stale durably.db Cleanup" below) — credentials in production lack Delete permission by design, so the rule, not Litestream, is responsible for removal.
+A `production/litestream/durably.db/` prefix may exist as a remnant from earlier runs that replicated `durably.db`. It is no longer updated and is cleaned up manually as a one-off operator action (see "Stale durably.db Cleanup" below). Production credentials lack Delete permission by design, so this cleanup is performed with operator-level access, not by the running app.
 
 ## Stale durably.db Cleanup
 
-If R2 contains a `production/litestream/durably.db/` prefix from before durably was excluded, set up a lifecycle rule to expire it. Cloudflare Dashboard → R2 → `upflow-backups` → Settings → Object lifecycle rules:
+If R2 contains a `production/litestream/durably.db/` prefix from before durably was excluded, delete it once via the Cloudflare Dashboard:
 
-- Prefix: `production/litestream/durably.db/`
-- Action: **Delete objects** after `7 days` (or any short retention; the prefix is stale and will not get new writes)
+1. R2 → `upflow-backups` → navigate into `production/litestream/durably.db/`
+2. Select all objects (or the whole folder) and Delete
 
-The rest of the bucket is left untouched — Litestream manages its own LTX retention via compaction levels for the active databases.
+Litestream manages its own LTX retention via compaction levels for the actively-replicated databases (`data.db`, `tenant_*.db`), so no recurring lifecycle rule is needed.
 
 ## Restore Smoke Test
 

--- a/docs/ops/litestream-r2.md
+++ b/docs/ops/litestream-r2.md
@@ -97,20 +97,25 @@ production/litestream/data.db/
 production/litestream/tenant_iris.db/
 ```
 
-A `production/litestream/durably.db/` prefix may exist as a remnant from earlier runs that replicated `durably.db`. It is no longer updated and is cleaned up manually as a one-off operator action (see "Stale durably.db Cleanup" below). Production credentials lack Delete permission by design, so this cleanup is performed with operator-level access, not by the running app.
+A `production/litestream/durably.db/` prefix may exist as a remnant from earlier runs that replicated `durably.db`. It is no longer updated and is cleaned up by the lifecycle rule documented below.
 
-## Stale durably.db Cleanup
+## R2 Storage Management
 
-If R2 contains a `production/litestream/durably.db/` prefix from before durably was excluded, delete it once via the Cloudflare Dashboard:
+Litestream's config in this repo sets `retention.enabled: false` so the running app does not need Delete permission on R2. With retention disabled, Litestream never deletes from R2 — compaction merges level-0 LTX files into higher levels but only deletes the merged-away files **locally** (the `l0 retention enforced` lines in the logs, with `system=store`); the originals on R2 stay forever. Compaction therefore bounds Class A PUT volume and live object count but **R2 storage grows monotonically**.
 
-1. R2 → `upflow-backups` → navigate into `production/litestream/durably.db/`
-2. Select all objects (or the whole folder) and Delete
+Manage retention with an R2 lifecycle rule instead. Cloudflare Dashboard → R2 → `upflow-backups` → Settings → Object lifecycle rules:
 
-## R2 Storage Growth
+- Prefix: `production/litestream/`
+- Action: **Delete objects** after `30 days` (adjust per RPO needs; longer = larger restore window, more storage)
 
-Litestream's config in this repo sets `retention.enabled: false` so the running app does not need Delete permission on R2. Compaction still runs and merges level-0 LTX files into higher levels, but with retention disabled it only deletes the merged-away files **locally** (the `l0 retention enforced` lines in the logs); the originals on R2 are never removed. Compaction therefore keeps Class A PUT volume and live object count bounded, but R2 storage grows monotonically.
+This single rule covers both:
 
-At current write volume the growth is on the order of tens of MB per month for `data.db` + `tenant_*.db` combined, so the 10 GB free tier is not a near-term concern. When R2 storage approaches the limit, set up an R2 lifecycle rule to expire objects under `production/litestream/` past some retention horizon (e.g. 30 or 90 days) — the same operator-side action used for the one-off durably cleanup above, just made recurring.
+- **Ongoing retention** for actively-replicated DBs (`data.db`, `tenant_*.db`). Snapshots are taken every 24h, so a 30-day rule keeps ~30 daily snapshots plus the LTX chains between them.
+- **Stale `production/litestream/durably.db/` prefix** from before `durably.db` was excluded. Those objects age out and disappear within the retention window — no separate one-off cleanup is required (though a manual prefix delete via the Dashboard works if immediate removal is preferred).
+
+### Restore window
+
+After the lifecycle rule activates, point-in-time restore is bounded by the retention horizon. Restoring to a point older than the rule's retention is not possible (snapshots and LTX files have expired). For most incident-recovery scenarios 30 days is generous; do not set retention shorter than the typical incident detection time.
 
 ## Restore Smoke Test
 

--- a/litestream.yml
+++ b/litestream.yml
@@ -9,8 +9,21 @@ retention:
   enabled: false
 
 dbs:
+  # Shared DB: organizations / members / integrations / githubAppLinks. Low write
+  # rate, user-facing data. Tight RPO.
+  - path: ${UPFLOW_DATA_DIR}/data.db
+    replica:
+      type: s3
+      bucket: upflow-backups
+      path: ${LITESTREAM_REPLICA_PREFIX}
+      endpoint: ${AWS_ENDPOINT_URL_S3}
+      region: ${AWS_REGION}
+      sync-interval: 30s
+
+  # Tenant DBs: per-org analytics (repositories, pull_requests, etc.). Created
+  # dynamically as orgs are added — directory watch picks new files up.
   - dir: ${UPFLOW_DATA_DIR}
-    pattern: '*.db'
+    pattern: 'tenant_*.db'
     watch: true
     replica:
       type: s3
@@ -19,3 +32,14 @@ dbs:
       endpoint: ${AWS_ENDPOINT_URL_S3}
       region: ${AWS_REGION}
       sync-interval: 30s
+
+  # durably.db is intentionally NOT replicated:
+  # - It holds in-flight @coji/durably job orchestration state (per-step
+  #   transactions), generating one level-0 LTX file per commit. At hourly crawl
+  #   cadence this would account for roughly half of all R2 PUT operations.
+  # - The data is regenerable: GitHub is the source of truth, and the next
+  #   hourly crawl re-derives state via idempotent upserts. Worst-case loss on
+  #   restore is the in-flight job at the moment of disaster, which the
+  #   scheduler picks up on its next tick.
+  # - This keeps R2 Class A operations comfortably inside the free tier with
+  #   headroom for organization growth.


### PR DESCRIPTION
## Summary

- switch `litestream.yml` from `dir: + pattern: '*.db'` to two explicit entries: a `path:` for `data.db` and a `dir: + pattern: 'tenant_*.db'` for per-org tenant DBs (directory watch still picks new tenants up dynamically)
- intentionally exclude `durably.db` from replication to roughly halve R2 PUT volume
- update `docs/ops/litestream-r2.md` with the rationale, an explicit "R2 Storage Management" section, and a single R2 lifecycle rule that handles both ongoing retention and stale durably prefix cleanup

## Why

Litestream v0.5 creates one level-0 LTX file per WAL transaction. `durably.db` (the `@coji/durably` job orchestration DB) commits per step, so during the hourly crawl it produces ~30 PUTs/min and accounts for roughly half of all R2 Class A operations.

Verified from production logs (post-merge of #323):

```
ltx file uploaded ... db=durably.db level=0 minTXID=0x03 maxTXID=0x03 size=24503
ltx file uploaded ... db=durably.db level=0 minTXID=0x04 maxTXID=0x04 size=207
ltx file uploaded ... db=durably.db level=0 minTXID=0x05 maxTXID=0x05 size=26221
```

Each LTX has `min=max`, confirming one PUT per transaction. Bumping `sync-interval` does not meaningfully reduce this in our workload (durably checkpoints frequently).

`durably.db` is regenerable disaster-recovery-wise: GitHub is the source of truth, and the next hourly crawl re-derives state via idempotent upserts. Worst-case loss on restore is the job that was in flight at the moment of disaster.

After this change, R2 Class A usage is estimated at roughly half of current — well under the 1M / month free-tier ceiling, with comfortable headroom for organization growth.

## R2 storage management

`retention.enabled: false` in `litestream.yml` (kept that way so the running app's R2 token can stay R/W without Delete) means Litestream itself never deletes objects from R2 — compaction adds new merged files at higher levels and the originals stay indefinitely. The `l0 retention enforced` events in the logs are local Fly-volume cleanup (`system=store`), not R2.

The doc therefore recommends a single R2 lifecycle rule on `production/litestream/` with 30-day retention. The same rule:

- bounds ongoing storage growth for `data.db` and `tenant_*.db`
- ages out the stale `production/litestream/durably.db/` prefix from before durably was excluded — disappears within the retention window without a separate manual step

Trade-off documented: point-in-time restore is bounded by the retention horizon.

## Validation

- `pnpm exec prettier -c litestream.yml docs/ops/litestream-r2.md --experimental-cli`
- After merge & deploy: confirm `fly logs -a upflow | grep "db=durably.db"` shows no further `ltx file uploaded` events; `data.db` and `tenant_*.db` continue to replicate on 30s sync-interval.