### PR TITLE
hotfix: data.db replica path resolution after #324

### DIFF
--- a/litestream.yml
+++ b/litestream.yml
@@ -9,9 +9,17 @@ retention:
   enabled: false
 
 dbs:
-  # Shared DB: organizations / members / integrations / githubAppLinks. Low write
-  # rate, user-facing data. Tight RPO.
-  - path: ${UPFLOW_DATA_DIR}/data.db
+  # Shared DB: organizations / members / integrations / githubAppLinks. Low
+  # write rate, user-facing data. Tight RPO.
+  #
+  # Using the dir+pattern form (rather than `path:`) so the replica resolves
+  # to ${LITESTREAM_REPLICA_PREFIX}/data.db/, matching the layout used for
+  # tenant DBs and the original *.db pattern that existed before the
+  # durably.db exclusion. The single-db `path:` form does not auto-append the
+  # database filename to the replica path, which would diverge from the
+  # existing R2 prefix and orphan prior backups.
+  - dir: ${UPFLOW_DATA_DIR}
+    pattern: 'data.db'
     replica:
       type: s3
       bucket: upflow-backups


### PR DESCRIPTION
## Issue (production impact)

After #324 deployed, `data.db` is no longer being replicated to R2. The previous container's writes (up to txid 3) are still on R2 at `production/litestream/data.db/`, but the new container is in a "monitor error" loop and is not pushing new transactions:

```
ERROR msg="monitor error" system=store db=data.db replica=s3
  error="open ltx file /upflow/data/.data.db-litestream/ltx/0/0000000000000001-0000000000000001.ltx:
         no such file or directory"
  hint="LTX file is missing. This can happen after VACUUM, manual checkpoint, or state corruption.
        Run 'litestream reset <db>' or delete the .sqlite-litestream directory and restart."
  consecutive_errors=2 backoff=1m0s
```

`tenant_*.db` continue to replicate normally; `durably.db` is correctly excluded as intended.

## Root cause

Litestream's two `dbs[]` entry forms resolve replica paths differently:

- **dir + pattern**: auto-appends the matched database filename to `replica.path`. With `path: ${LITESTREAM_REPLICA_PREFIX}` the resulting prefix is `production/litestream/<db_filename>/`.
- **Single-db `path:`**: uses `replica.path` literally, no auto-append. With the same `path: ${LITESTREAM_REPLICA_PREFIX}` the resulting prefix is `production/litestream/`.

#324 switched `data.db` to the single-db form, so its replica prefix changed from `production/litestream/data.db/` (existing) to `production/litestream/` (empty for data.db's purposes — tenant DBs occupy sibling subprefixes there). Litestream concluded its replica was at txid 0 and tried to re-upload from local txid 1, but that LTX file was already locally compacted away (`l0 retention enforced` events).

## Fix

Switch `data.db`'s entry back to the `dir + pattern` form with an explicit literal pattern of `'data.db'`. This:

- Resolves the replica to `production/litestream/data.db/`, matching the existing R2 prefix and the layout used for `tenant_*.db`
- Keeps the durably.db exclusion intact (the only patterns matched are `data.db` and `tenant_*.db`)
- Makes the two dbs[] entries structurally consistent

## Validation

- `pnpm exec prettier -c litestream.yml --experimental-cli`
- After merge & deploy: confirm `fly logs -a upflow | grep "monitor error"` is silent and `replica sync` for `data.db` shows `txid.replica == txid.db`.