### PR TITLE
Add Cycle Time analysis dashboard (#327)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -64,3 +64,7 @@ opensrc/
 data.db
 data.db-shm
 data.db-wal
+
+# Claude Code
+.claude
+

--- a/app/components/author-badge.tsx
+++ b/app/components/author-badge.tsx
@@ -2,14 +2,18 @@ import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 
 interface AuthorBadgeProps {
   login: string
-  displayName: string | null
+  displayName?: string | null
 }
 
+/**
+ * 24px GitHub avatar + display name (falls back to login). Used in tables
+ * across throughput and analysis screens.
+ */
 export function AuthorBadge({ login, displayName }: AuthorBadgeProps) {
   const name = displayName?.trim() || login
   return (
-    <div className="flex items-center gap-2">
-      <Avatar className="size-6">
+    <div className="flex min-w-0 items-center gap-2">
+      <Avatar className="size-6 shrink-0">
         <AvatarImage
           src={`https://github.com/${login}.png?size=48`}
           alt={login}
@@ -18,7 +22,7 @@ export function AuthorBadge({ login, displayName }: AuthorBadgeProps) {
           {login.slice(0, 2).toUpperCase()}
         </AvatarFallback>
       </Avatar>
-      <span className="line-clamp-1">{name}</span>
+      <span className="line-clamp-1 min-w-0">{name}</span>
     </div>
   )
 }

--- a/app/components/external-link.tsx
+++ b/app/components/external-link.tsx
@@ -1,0 +1,14 @@
+import type { ComponentProps } from 'react'
+
+/**
+ * Anchor that opens its target in a new tab with secure rel attributes
+ * applied. Centralises the `target="_blank" rel="noopener noreferrer"` pair
+ * so consumers can't forget either half.
+ */
+export function ExternalLink({ children, ...props }: ComponentProps<'a'>) {
+  return (
+    <a target="_blank" rel="noopener noreferrer" {...props}>
+      {children}
+    </a>
+  )
+}

--- a/app/components/layout/nav-config.ts
+++ b/app/components/layout/nav-config.ts
@@ -7,6 +7,7 @@ import {
   NotebookPenIcon,
   RocketIcon,
   SettingsIcon,
+  TimerIcon,
 } from 'lucide-react'
 import { href } from 'react-router'
 import type { NavGroupProps } from './types'
@@ -46,6 +47,11 @@ export function getNavConfig(orgSlug: string): NavGroupProps[] {
     {
       title: 'Analysis',
       items: [
+        {
+          title: 'Cycle Time',
+          url: href('/:orgSlug/analysis/cycle-time', { orgSlug }),
+          icon: TimerIcon,
+        },
         {
           title: 'Review Bottleneck',
           url: href('/:orgSlug/analysis/reviews', { orgSlug }),

--- a/app/libs/date-utils.ts
+++ b/app/libs/date-utils.ts
@@ -23,6 +23,17 @@ export const parseDate = (date: string | null, timeZone: string) => {
   return dt.tz(timeZone).startOf('day')
 }
 
+/**
+ * Start-of-week (Monday, 00:00) for a dayjs instance, preserving its
+ * existing timezone. Useful when you already have a tz-anchored dayjs
+ * and want to bucket by week without re-applying the timezone.
+ */
+export function startOfWeekMonday(d: dayjs.Dayjs): dayjs.Dayjs {
+  const day = d.day()
+  const diffToMonday = day === 0 ? -6 : 1 - day
+  return d.startOf('day').add(diffToMonday, 'day')
+}
+
 export function getStartOfWeek(now = new Date(), timezone: string) {
   const tzNow = dayjs(now).tz(timezone)
 

--- a/app/libs/format-pr.ts
+++ b/app/libs/format-pr.ts
@@ -1,0 +1,7 @@
+/**
+ * Canonical "repo#number" identifier for a pull request, used in tables,
+ * tooltips, and ARIA labels.
+ */
+export function formatPrIdentifier(repo: string, number: number): string {
+  return `${repo}#${number}`
+}

--- a/app/libs/stats.ts
+++ b/app/libs/stats.ts
@@ -10,3 +10,29 @@ export function median(values: number[]): number | null {
     ? sorted[mid]
     : (sorted[mid - 1] + sorted[mid]) / 2
 }
+
+/**
+ * Calculate the arithmetic mean of a numeric array.
+ * Returns null for empty arrays.
+ */
+export function average(values: number[]): number | null {
+  if (values.length === 0) return null
+  let sum = 0
+  for (const v of values) sum += v
+  return sum / values.length
+}
+
+/**
+ * Calculate the linearly-interpolated `p`-th percentile of a numeric array.
+ * `p` is in [0, 1] (e.g. 0.75 for p75). Returns null for empty arrays.
+ */
+export function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const rank = (sorted.length - 1) * p
+  const lower = Math.floor(rank)
+  const upper = Math.ceil(rank)
+  if (lower === upper) return sorted[lower]
+  const weight = rank - lower
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight
+}

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -11,6 +11,7 @@ import {
 } from '~/app/components/ui/popover'
 import { Skeleton } from '~/app/components/ui/skeleton'
 import dayjs from '~/app/libs/dayjs'
+import { formatPrIdentifier } from '~/app/libs/format-pr'
 import { HidePRsByTitleMenu } from './hide-prs-by-title-menu'
 
 export type PRBlockColorMode = 'size' | 'age'
@@ -288,8 +289,8 @@ function PRPopoverDegraded({
   fallback?: { title?: string; url?: string; repo?: string }
 }) {
   const linkLabel = fallback?.repo
-    ? `${fallback.repo}#${prKey.number}`
-    : `${prKey.repositoryId}#${prKey.number}`
+    ? formatPrIdentifier(fallback.repo, prKey.number)
+    : formatPrIdentifier(prKey.repositoryId, prKey.number)
   const linkHref = fallback?.url
 
   return (
@@ -338,7 +339,7 @@ export function PRPopoverContent({
           target="_blank"
           rel="noreferrer noopener"
         >
-          {pr.repo}#{pr.number}
+          {formatPrIdentifier(pr.repo, pr.number)}
         </a>
         <SizeBadge
           complexity={pr.complexity}
@@ -513,9 +514,8 @@ export function PRBlock({
     ? REVIEW_STATUS_SHAPE[pr.reviewStatus]
     : undefined
   const shape = statusShape?.shape ?? 'rounded-full'
-  const ariaLabel = statusShape
-    ? `${pr.repo}#${pr.number} (${statusShape.label})`
-    : `${pr.repo}#${pr.number}`
+  const prId = formatPrIdentifier(pr.repo, pr.number)
+  const ariaLabel = statusShape ? `${prId} (${statusShape.label})` : prId
   const isHollow =
     pr.reviewStatus === 'unassigned' ||
     pr.reviewStatus === 'approved-awaiting-merge' ||

--- a/app/routes/$orgSlug/+components/pr-block.tsx
+++ b/app/routes/$orgSlug/+components/pr-block.tsx
@@ -1,6 +1,7 @@
 import { Popover as PopoverPrimitive } from 'radix-ui'
 import { useRef, useState } from 'react'
 import { href, useFetcher, useParams } from 'react-router'
+import { ExternalLink } from '~/app/components/external-link'
 import { SizeBadge } from '~/app/components/size-badge'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import { Badge } from '~/app/components/ui/badge'
@@ -297,14 +298,9 @@ function PRPopoverDegraded({
     <div className="space-y-1 text-xs">
       <div className="flex items-center gap-2">
         {linkHref ? (
-          <a
-            href={linkHref}
-            className="font-medium hover:underline"
-            target="_blank"
-            rel="noreferrer noopener"
-          >
+          <ExternalLink href={linkHref} className="font-medium hover:underline">
             {linkLabel}
-          </a>
+          </ExternalLink>
         ) : (
           <span className="font-medium">{linkLabel}</span>
         )}
@@ -333,28 +329,24 @@ export function PRPopoverContent({
   return (
     <div className="space-y-2">
       <div className="flex items-center gap-2">
-        <a
+        <ExternalLink
           href={pr.url}
           className="text-xs font-medium hover:underline"
-          target="_blank"
-          rel="noreferrer noopener"
         >
           {formatPrIdentifier(pr.repo, pr.number)}
-        </a>
+        </ExternalLink>
         <SizeBadge
           complexity={pr.complexity}
           className="ml-auto px-1.5 py-0 text-[10px]"
         />
         <HidePRsByTitleMenu title={pr.title} />
       </div>
-      <a
+      <ExternalLink
         href={pr.url}
-        target="_blank"
-        rel="noreferrer noopener"
         className="line-clamp-3 text-xs hover:underline"
       >
         {pr.title}
-      </a>
+      </ExternalLink>
       <div className="text-muted-foreground flex flex-wrap items-center gap-x-2 text-xs">
         <span className="inline-flex items-center gap-1">
           <GitHubAvatar login={pr.author} size={14} />

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/author-badge.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/author-badge.tsx
@@ -1,0 +1,24 @@
+import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
+
+interface AuthorBadgeProps {
+  login: string
+  displayName: string | null
+}
+
+export function AuthorBadge({ login, displayName }: AuthorBadgeProps) {
+  const name = displayName?.trim() || login
+  return (
+    <div className="flex items-center gap-2">
+      <Avatar className="size-6">
+        <AvatarImage
+          src={`https://github.com/${login}.png?size=48`}
+          alt={login}
+        />
+        <AvatarFallback className="text-xs">
+          {login.slice(0, 2).toUpperCase()}
+        </AvatarFallback>
+      </Avatar>
+      <span className="line-clamp-1">{name}</span>
+    </div>
+  )
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/bottleneck-mix-card.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/bottleneck-mix-card.tsx
@@ -1,0 +1,74 @@
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/app/components/ui/card'
+import type { BottleneckMix, MetricMode } from '../+functions/aggregate'
+import { STAGE_COLOR_VAR, STAGE_LABEL, formatDays } from './stage-config'
+
+interface BottleneckMixCardProps {
+  mix: BottleneckMix
+  mode: MetricMode
+}
+
+export function BottleneckMixCard({ mix, mode }: BottleneckMixCardProps) {
+  const hasData = mix.sum > 0
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Bottleneck Mix</CardTitle>
+        <CardDescription>
+          Stage share by {mode} time across released PRs in this period.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {hasData ? (
+          <>
+            <div
+              className="flex h-7 w-full overflow-hidden rounded"
+              role="img"
+              aria-label="Cycle time stage composition"
+            >
+              {mix.slices.map((s) => (
+                <div
+                  key={s.stage}
+                  className="h-full flex-shrink-0"
+                  style={{
+                    width: `${(s.ratio * 100).toFixed(2)}%`,
+                    backgroundColor: STAGE_COLOR_VAR[s.stage],
+                  }}
+                  title={`${STAGE_LABEL[s.stage]} ${(s.ratio * 100).toFixed(0)}%`}
+                />
+              ))}
+            </div>
+            <ul className="mt-3 grid grid-cols-2 gap-2 text-sm sm:grid-cols-4">
+              {mix.slices.map((s) => (
+                <li key={s.stage} className="flex items-start gap-2">
+                  <span
+                    aria-hidden
+                    className="mt-1 inline-block size-2.5 shrink-0 rounded-[2px]"
+                    style={{ backgroundColor: STAGE_COLOR_VAR[s.stage] }}
+                  />
+                  <div className="flex flex-col leading-tight">
+                    <span className="font-medium">
+                      {(s.ratio * 100).toFixed(0)}%
+                    </span>
+                    <span className="text-muted-foreground text-xs">
+                      {STAGE_LABEL[s.stage]} · {formatDays(s.value)}
+                    </span>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          </>
+        ) : (
+          <p className="text-muted-foreground text-sm">
+            Not enough data to compute stage composition.
+          </p>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
@@ -1,4 +1,5 @@
 import { ArrowDownIcon, ArrowUpIcon, MinusIcon } from 'lucide-react'
+import { AuthorBadge } from '~/app/components/author-badge'
 import { Badge } from '~/app/components/ui/badge'
 import {
   Card,
@@ -21,7 +22,6 @@ import type {
   CycleTimeDelta,
   MetricMode,
 } from '../+functions/aggregate'
-import { AuthorBadge } from './author-badge'
 import {
   STAGE_COLOR_VAR,
   STAGE_LABEL,

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
@@ -1,0 +1,176 @@
+import { ArrowDownIcon, ArrowUpIcon, MinusIcon } from 'lucide-react'
+import { Badge } from '~/app/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/app/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/app/components/ui/table'
+import { cn } from '~/app/libs/utils'
+import type {
+  AuthorRow,
+  CycleTimeDelta,
+  MetricMode,
+} from '../+functions/aggregate'
+import {
+  STAGE_COLOR_VAR,
+  STAGE_LABEL,
+  formatDays,
+  formatSignedDays,
+  formatSignedPct,
+} from './stage-config'
+
+interface ByAuthorTableProps {
+  rows: AuthorRow[]
+  mode: MetricMode
+}
+
+export function ByAuthorTable({ rows, mode }: ByAuthorTableProps) {
+  const totalLabel = mode === 'median' ? 'Median Total' : 'Avg Total'
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>By Author</CardTitle>
+        <CardDescription>
+          Cycle time per author so you can spot who and which stage to follow up
+          with. Sorted by PR count.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No released pull requests in this period.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Author</TableHead>
+                  <TableHead className="text-right">PRs</TableHead>
+                  <TableHead className="min-w-[160px]">Composition</TableHead>
+                  <TableHead className="text-right">{totalLabel}</TableHead>
+                  <TableHead>Main driver</TableHead>
+                  <TableHead className="text-right">Review p75</TableHead>
+                  <TableHead className="text-right">vs prev</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={row.author}>
+                    <TableCell className="font-medium">
+                      {row.displayName}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {row.prCount}
+                    </TableCell>
+                    <TableCell>
+                      <CompositionBar composition={row.composition} />
+                    </TableCell>
+                    <TableCell className="text-right font-semibold tabular-nums">
+                      {formatDays(row.total)}
+                    </TableCell>
+                    <TableCell>
+                      <MainDriverPill driver={row.mainDriver} />
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatDays(row.reviewP75)}
+                    </TableCell>
+                    <TableCell className="text-right">
+                      <DeltaText delta={row.changeVsPrev} />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}
+
+function CompositionBar({
+  composition,
+}: {
+  composition: AuthorRow['composition']
+}) {
+  const hasAny = composition.some((c) => c.ratio > 0)
+  if (!hasAny) {
+    return <div className="bg-muted h-2 w-full rounded" aria-hidden />
+  }
+  return (
+    <div
+      className="bg-muted/40 flex h-2 w-full overflow-hidden rounded"
+      role="img"
+      aria-label="Stage composition"
+    >
+      {composition.map((c) => (
+        <div
+          key={c.stage}
+          className="h-full"
+          style={{
+            width: `${(c.ratio * 100).toFixed(2)}%`,
+            backgroundColor: STAGE_COLOR_VAR[c.stage],
+            opacity: 0.7,
+          }}
+          title={`${STAGE_LABEL[c.stage]} ${(c.ratio * 100).toFixed(0)}%`}
+        />
+      ))}
+    </div>
+  )
+}
+
+function MainDriverPill({ driver }: { driver: AuthorRow['mainDriver'] }) {
+  if (driver === null) {
+    return <span className="text-muted-foreground text-sm">—</span>
+  }
+  return (
+    <Badge
+      variant="outline"
+      className="font-normal"
+      style={{
+        borderColor: STAGE_COLOR_VAR[driver],
+        color: STAGE_COLOR_VAR[driver],
+      }}
+    >
+      {STAGE_LABEL[driver]}
+    </Badge>
+  )
+}
+
+function DeltaText({ delta }: { delta: CycleTimeDelta }) {
+  if (delta.diff === null) {
+    return <span className="text-muted-foreground text-sm">—</span>
+  }
+  const sign = delta.diff > 0 ? 'up' : delta.diff < 0 ? 'down' : 'flat'
+  const Icon =
+    sign === 'up' ? ArrowUpIcon : sign === 'down' ? ArrowDownIcon : MinusIcon
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center justify-end gap-1 text-xs font-medium tabular-nums',
+        sign === 'up' && 'text-rose-600 dark:text-rose-400',
+        sign === 'down' && 'text-emerald-600 dark:text-emerald-400',
+        sign === 'flat' && 'text-muted-foreground',
+      )}
+    >
+      <Icon className="size-3" />
+      <span>{formatSignedDays(delta.diff)}</span>
+      {delta.pct !== null && (
+        <span className="text-muted-foreground">
+          ({formatSignedPct(delta.pct)})
+        </span>
+      )}
+    </span>
+  )
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
@@ -22,6 +22,7 @@ import type {
   CycleTimeDelta,
   MetricMode,
 } from '../+functions/aggregate'
+import { CompositionBar } from './composition-bar'
 import {
   STAGE_COLOR_VAR,
   STAGE_LABEL,
@@ -100,37 +101,6 @@ export function ByAuthorTable({ rows, mode }: ByAuthorTableProps) {
         )}
       </CardContent>
     </Card>
-  )
-}
-
-function CompositionBar({
-  composition,
-}: {
-  composition: AuthorRow['composition']
-}) {
-  const hasAny = composition.some((c) => c.ratio > 0)
-  if (!hasAny) {
-    return <div className="bg-muted h-2 w-full rounded" aria-hidden />
-  }
-  return (
-    <div
-      className="bg-muted/40 flex h-2 w-full overflow-hidden rounded"
-      role="img"
-      aria-label="Stage composition"
-    >
-      {composition.map((c) => (
-        <div
-          key={c.stage}
-          className="h-full"
-          style={{
-            width: `${(c.ratio * 100).toFixed(2)}%`,
-            backgroundColor: STAGE_COLOR_VAR[c.stage],
-            opacity: 0.7,
-          }}
-          title={`${STAGE_LABEL[c.stage]} ${(c.ratio * 100).toFixed(0)}%`}
-        />
-      ))}
-    </div>
   )
 }
 

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
@@ -21,6 +21,7 @@ import type {
   CycleTimeDelta,
   MetricMode,
 } from '../+functions/aggregate'
+import { AuthorBadge } from './author-badge'
 import {
   STAGE_COLOR_VAR,
   STAGE_LABEL,
@@ -68,7 +69,10 @@ export function ByAuthorTable({ rows, mode }: ByAuthorTableProps) {
                 {rows.map((row) => (
                   <TableRow key={row.author}>
                     <TableCell className="font-medium">
-                      {row.displayName}
+                      <AuthorBadge
+                        login={row.author}
+                        displayName={row.displayName}
+                      />
                     </TableCell>
                     <TableCell className="text-right tabular-nums">
                       {row.prCount}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/composition-bar.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/composition-bar.tsx
@@ -1,0 +1,68 @@
+import type { CycleStage } from '../+functions/aggregate'
+import { STAGE_COLOR_VAR, STAGE_LABEL } from './stage-config'
+
+interface StageRatio {
+  stage: CycleStage
+  ratio: number
+}
+
+interface CompositionBarProps {
+  composition: StageRatio[]
+}
+
+/**
+ * Thin 4-segment bar showing relative time spent in each cycle-time stage.
+ * Used in By Author and Longest PRs tables to give a quiet at-a-glance
+ * profile without resorting to a full heatmap.
+ */
+export function CompositionBar({ composition }: CompositionBarProps) {
+  const hasAny = composition.some((c) => c.ratio > 0)
+  if (!hasAny) {
+    return <div className="bg-muted h-2 w-full rounded" aria-hidden />
+  }
+  return (
+    <div
+      className="bg-muted/40 flex h-2 w-full overflow-hidden rounded"
+      role="img"
+      aria-label="Stage composition"
+    >
+      {composition.map((c) => (
+        <div
+          key={c.stage}
+          className="h-full"
+          style={{
+            width: `${(c.ratio * 100).toFixed(2)}%`,
+            backgroundColor: STAGE_COLOR_VAR[c.stage],
+            opacity: 0.7,
+          }}
+          title={`${STAGE_LABEL[c.stage]} ${(c.ratio * 100).toFixed(0)}%`}
+        />
+      ))}
+    </div>
+  )
+}
+
+interface StageTimes {
+  codingTime: number | null
+  pickupTime: number | null
+  reviewTime: number | null
+  deployTime: number | null
+}
+
+/**
+ * Compute per-PR stage composition ratios from a row's raw stage times.
+ * Null stages count as zero; when all stages are null/zero, every ratio is 0.
+ */
+export function compositionFromStageTimes(times: StageTimes): StageRatio[] {
+  const c = times.codingTime ?? 0
+  const p = times.pickupTime ?? 0
+  const r = times.reviewTime ?? 0
+  const d = times.deployTime ?? 0
+  const sum = c + p + r + d
+  return [
+    { stage: 'coding', ratio: sum > 0 ? c / sum : 0 },
+    { stage: 'pickup', ratio: sum > 0 ? p / sum : 0 },
+    { stage: 'review', ratio: sum > 0 ? r / sum : 0 },
+    { stage: 'deploy', ratio: sum > 0 ? d / sum : 0 },
+  ]
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/composition-bar.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/composition-bar.tsx
@@ -1,10 +1,5 @@
-import type { CycleStage } from '../+functions/aggregate'
+import { STAGES, type StageRatio } from '../+functions/aggregate'
 import { STAGE_COLOR_VAR, STAGE_LABEL } from './stage-config'
-
-interface StageRatio {
-  stage: CycleStage
-  ratio: number
-}
 
 interface CompositionBarProps {
   composition: StageRatio[]
@@ -49,20 +44,22 @@ interface StageTimes {
   deployTime: number | null
 }
 
+const STAGE_TIME_KEY = {
+  coding: 'codingTime',
+  pickup: 'pickupTime',
+  review: 'reviewTime',
+  deploy: 'deployTime',
+} as const satisfies Record<StageRatio['stage'], keyof StageTimes>
+
 /**
  * Compute per-PR stage composition ratios from a row's raw stage times.
  * Null stages count as zero; when all stages are null/zero, every ratio is 0.
  */
 export function compositionFromStageTimes(times: StageTimes): StageRatio[] {
-  const c = times.codingTime ?? 0
-  const p = times.pickupTime ?? 0
-  const r = times.reviewTime ?? 0
-  const d = times.deployTime ?? 0
-  const sum = c + p + r + d
-  return [
-    { stage: 'coding', ratio: sum > 0 ? c / sum : 0 },
-    { stage: 'pickup', ratio: sum > 0 ? p / sum : 0 },
-    { stage: 'review', ratio: sum > 0 ? r / sum : 0 },
-    { stage: 'deploy', ratio: sum > 0 ? d / sum : 0 },
-  ]
+  const values = STAGES.map((stage) => times[STAGE_TIME_KEY[stage]] ?? 0)
+  const sum = values.reduce((s, v) => s + v, 0)
+  return STAGES.map((stage, i) => ({
+    stage,
+    ratio: sum > 0 ? values[i] / sum : 0,
+  }))
 }

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/insights-card.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/insights-card.tsx
@@ -1,0 +1,41 @@
+import { LightbulbIcon } from 'lucide-react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/app/components/ui/card'
+
+interface InsightsCardProps {
+  insights: string[]
+}
+
+export function InsightsCard({ insights }: InsightsCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Insights</CardTitle>
+        <CardDescription>
+          Auto-generated highlights based on the current period data.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {insights.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            Nothing notable surfaced for this period.
+          </p>
+        ) : (
+          <ul className="space-y-3">
+            {insights.map((text) => (
+              <li key={text} className="flex items-start gap-2 text-sm">
+                <LightbulbIcon className="text-muted-foreground mt-0.5 size-4 shrink-0" />
+                <span className="leading-snug">{text}</span>
+              </li>
+            ))}
+          </ul>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/kpi-cards.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/kpi-cards.tsx
@@ -1,0 +1,143 @@
+import { ArrowDownIcon, ArrowUpIcon, MinusIcon } from 'lucide-react'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/app/components/ui/card'
+import { cn } from '~/app/libs/utils'
+import type {
+  CycleTimeDelta,
+  CycleTimeKpi,
+  MetricMode,
+} from '../+functions/aggregate'
+import { formatDays, formatSignedDays, formatSignedPct } from './stage-config'
+
+interface KpiCardsProps {
+  kpi: CycleTimeKpi
+  mode: MetricMode
+  periodLabel: string
+}
+
+export function KpiCards({ kpi, mode, periodLabel }: KpiCardsProps) {
+  const totalLabel = mode === 'median' ? 'Median Total' : 'Avg Total'
+  return (
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <KpiCard
+        label={totalLabel}
+        value={formatDays(kpi.total)}
+        delta={kpi.totalDelta}
+        deltaInversed
+        periodLabel={periodLabel}
+      />
+      <KpiCard
+        label="PRs"
+        value={kpi.prCount.toString()}
+        delta={kpi.prCountDelta}
+        countMode
+        periodLabel={periodLabel}
+      />
+      <KpiCard
+        label={mode === 'median' ? 'Review (median)' : 'Review (avg)'}
+        value={formatDays(kpi.review)}
+        delta={kpi.reviewDelta}
+        deltaInversed
+        periodLabel={periodLabel}
+      />
+      <KpiCard
+        label={mode === 'median' ? 'Deploy (median)' : 'Deploy (avg)'}
+        value={formatDays(kpi.deploy)}
+        delta={kpi.deployDelta}
+        deltaInversed
+        periodLabel={periodLabel}
+      />
+    </div>
+  )
+}
+
+interface KpiCardProps {
+  label: string
+  value: string
+  delta: CycleTimeDelta
+  /** When true, a decrease is "good" (i.e. cycle time went down). */
+  deltaInversed?: boolean
+  /** Show count delta in raw integer instead of days. */
+  countMode?: boolean
+  periodLabel: string
+}
+
+function KpiCard({
+  label,
+  value,
+  delta,
+  deltaInversed,
+  countMode,
+  periodLabel,
+}: KpiCardProps) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardDescription>{label}</CardDescription>
+        <CardTitle className="text-3xl tabular-nums">{value}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <div className="text-muted-foreground text-xs">
+          vs previous {periodLabel}
+        </div>
+        <DeltaBadge
+          delta={delta}
+          deltaInversed={deltaInversed}
+          countMode={countMode}
+        />
+      </CardContent>
+    </Card>
+  )
+}
+
+function DeltaBadge({
+  delta,
+  deltaInversed,
+  countMode,
+}: {
+  delta: CycleTimeDelta
+  deltaInversed?: boolean
+  countMode?: boolean
+}) {
+  if (delta.diff === null) {
+    return <div className="text-muted-foreground text-sm">—</div>
+  }
+  const sign = delta.diff > 0 ? 'up' : delta.diff < 0 ? 'down' : 'flat'
+
+  let tone: 'good' | 'bad' | 'neutral' = 'neutral'
+  if (!countMode && sign !== 'flat') {
+    if (deltaInversed) {
+      tone = sign === 'down' ? 'good' : 'bad'
+    } else {
+      tone = sign === 'up' ? 'good' : 'bad'
+    }
+  }
+
+  const Icon =
+    sign === 'up' ? ArrowUpIcon : sign === 'down' ? ArrowDownIcon : MinusIcon
+
+  const diffText = countMode
+    ? `${delta.diff > 0 ? '+' : ''}${delta.diff.toFixed(0)}`
+    : formatSignedDays(delta.diff)
+  const pctText = formatSignedPct(delta.pct)
+
+  return (
+    <div
+      className={cn(
+        'mt-1 flex items-center gap-1 text-sm font-medium tabular-nums',
+        tone === 'good' && 'text-emerald-600 dark:text-emerald-400',
+        tone === 'bad' && 'text-rose-600 dark:text-rose-400',
+        tone === 'neutral' && 'text-muted-foreground',
+      )}
+    >
+      <Icon className="size-4" />
+      <span>{diffText}</span>
+      {pctText && <span className="text-muted-foreground">({pctText})</span>}
+    </div>
+  )
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -1,5 +1,6 @@
 import { ChevronRightIcon } from 'lucide-react'
 import { AuthorBadge } from '~/app/components/author-badge'
+import { ExternalLink } from '~/app/components/external-link'
 import { Badge } from '~/app/components/ui/badge'
 import {
   Card,
@@ -65,10 +66,9 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                     className="hover:bg-muted/50"
                   >
                     <TableCell className="max-w-[320px]">
-                      <a
+                      <ExternalLink
                         href={row.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                        aria-label={`Open ${formatPrIdentifier(row.repo, row.number)}: ${row.title}`}
                         className="hover:underline focus-visible:underline focus-visible:outline-none"
                       >
                         <div className="text-muted-foreground text-xs tabular-nums">
@@ -77,7 +77,7 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                         <div className="text-primary line-clamp-1">
                           {row.title}
                         </div>
-                      </a>
+                      </ExternalLink>
                     </TableCell>
                     <TableCell>
                       <AuthorBadge

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -32,7 +32,7 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
         <CardTitle>Longest Cycle Time PRs</CardTitle>
         <CardDescription>
           Released PRs ranked by total time. Click a row to open the pull
-          request.
+          request in a new tab.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -57,19 +57,29 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
               </TableHeader>
               <TableBody>
                 {rows.map((row) => (
-                  <TableRow key={`${row.repositoryId}:${row.number}`}>
+                  <TableRow
+                    key={`${row.repositoryId}:${row.number}`}
+                    onClick={() =>
+                      window.open(row.url, '_blank', 'noopener,noreferrer')
+                    }
+                    onKeyDown={(e) => {
+                      if (e.key === 'Enter' || e.key === ' ') {
+                        e.preventDefault()
+                        window.open(row.url, '_blank', 'noopener,noreferrer')
+                      }
+                    }}
+                    role="link"
+                    tabIndex={0}
+                    aria-label={`Open pull request #${row.number}: ${row.title}`}
+                    className="hover:bg-muted/50 focus-visible:bg-muted/50 cursor-pointer focus-visible:outline-none"
+                  >
                     <TableCell className="max-w-[320px]">
-                      <a
-                        href={row.url}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="text-primary hover:underline"
-                      >
+                      <span className="text-primary group-hover:underline">
                         <span className="text-muted-foreground mr-1">
                           #{row.number}
                         </span>
                         <span className="line-clamp-1">{row.title}</span>
-                      </a>
+                      </span>
                     </TableCell>
                     <TableCell className="text-muted-foreground tabular-nums">
                       {row.repo}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -18,6 +18,7 @@ import {
 } from '~/app/components/ui/table'
 import { useTimezone } from '~/app/hooks/use-timezone'
 import dayjs from '~/app/libs/dayjs'
+import { formatPrIdentifier } from '~/app/libs/format-pr'
 import type { LongestPrRow } from '../+functions/aggregate'
 import { CompositionBar, compositionFromStageTimes } from './composition-bar'
 import { STAGE_COLOR_VAR, STAGE_LABEL, formatDays } from './stage-config'
@@ -49,7 +50,7 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                 <TableRow>
                   <TableHead>PR</TableHead>
                   <TableHead>Author</TableHead>
-                  <TableHead className="min-w-[140px]">Composition</TableHead>
+                  <TableHead className="min-w-[160px]">Composition</TableHead>
                   <TableHead>Bottleneck</TableHead>
                   <TableHead>State</TableHead>
                   <TableHead className="text-right">Total</TableHead>
@@ -78,11 +79,11 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                     >
                       <TableCell className="max-w-[320px]">
                         <div className="text-muted-foreground text-xs tabular-nums">
-                          {row.repo}#{row.number}
+                          {formatPrIdentifier(row.repo, row.number)}
                         </div>
-                        <span className="text-primary line-clamp-1">
+                        <div className="text-primary line-clamp-1">
                           {row.title}
-                        </span>
+                        </div>
                       </TableCell>
                       <TableCell>
                         <AuthorBadge

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -1,4 +1,5 @@
 import { ChevronRightIcon } from 'lucide-react'
+import { AuthorBadge } from '~/app/components/author-badge'
 import { Badge } from '~/app/components/ui/badge'
 import {
   Card,
@@ -18,7 +19,6 @@ import {
 import { useTimezone } from '~/app/hooks/use-timezone'
 import dayjs from '~/app/libs/dayjs'
 import type { LongestPrRow } from '../+functions/aggregate'
-import { AuthorBadge } from './author-badge'
 import { STAGE_COLOR_VAR, STAGE_LABEL, formatDays } from './stage-config'
 
 interface LongestPrsTableProps {
@@ -57,72 +57,76 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {rows.map((row) => (
-                  <TableRow
-                    key={`${row.repositoryId}:${row.number}`}
-                    onClick={() =>
-                      window.open(row.url, '_blank', 'noopener,noreferrer')
-                    }
-                    onKeyDown={(e) => {
-                      if (e.key === 'Enter' || e.key === ' ') {
-                        e.preventDefault()
-                        window.open(row.url, '_blank', 'noopener,noreferrer')
-                      }
-                    }}
-                    role="link"
-                    tabIndex={0}
-                    aria-label={`Open pull request #${row.number}: ${row.title}`}
-                    className="hover:bg-muted/50 focus-visible:bg-muted/50 cursor-pointer focus-visible:outline-none"
-                  >
-                    <TableCell className="max-w-[320px]">
-                      <span className="text-primary group-hover:underline">
-                        <span className="text-muted-foreground mr-1">
-                          #{row.number}
+                {rows.map((row) => {
+                  const open = () =>
+                    window.open(row.url, '_blank', 'noopener,noreferrer')
+                  return (
+                    <TableRow
+                      key={`${row.repositoryId}:${row.number}`}
+                      onClick={open}
+                      onKeyDown={(e) => {
+                        if (e.key === 'Enter' || e.key === ' ') {
+                          e.preventDefault()
+                          open()
+                        }
+                      }}
+                      role="link"
+                      tabIndex={0}
+                      aria-label={`Open pull request #${row.number}: ${row.title}`}
+                      className="hover:bg-muted/50 focus-visible:bg-muted/50 cursor-pointer focus-visible:outline-none"
+                    >
+                      <TableCell className="max-w-[320px]">
+                        <span className="text-primary">
+                          <span className="text-muted-foreground mr-1">
+                            #{row.number}
+                          </span>
+                          <span className="line-clamp-1">{row.title}</span>
                         </span>
-                        <span className="line-clamp-1">{row.title}</span>
-                      </span>
-                    </TableCell>
-                    <TableCell className="text-muted-foreground tabular-nums">
-                      {row.repo}
-                    </TableCell>
-                    <TableCell>
-                      <AuthorBadge
-                        login={row.author}
-                        displayName={row.authorDisplayName}
-                      />
-                    </TableCell>
-                    <TableCell>
-                      {row.bottleneck ? (
-                        <Badge
-                          variant="outline"
-                          className="font-normal"
-                          style={{
-                            borderColor: STAGE_COLOR_VAR[row.bottleneck],
-                            color: STAGE_COLOR_VAR[row.bottleneck],
-                          }}
-                        >
-                          {STAGE_LABEL[row.bottleneck]}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground tabular-nums">
+                        {row.repo}
+                      </TableCell>
+                      <TableCell>
+                        <AuthorBadge
+                          login={row.author}
+                          displayName={row.authorDisplayName}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        {row.bottleneck ? (
+                          <Badge
+                            variant="outline"
+                            className="font-normal"
+                            style={{
+                              borderColor: STAGE_COLOR_VAR[row.bottleneck],
+                              color: STAGE_COLOR_VAR[row.bottleneck],
+                            }}
+                          >
+                            {STAGE_LABEL[row.bottleneck]}
+                          </Badge>
+                        ) : (
+                          <span className="text-muted-foreground text-sm">
+                            —
+                          </span>
+                        )}
+                      </TableCell>
+                      <TableCell>
+                        <Badge variant="secondary" className="capitalize">
+                          {row.state}
                         </Badge>
-                      ) : (
-                        <span className="text-muted-foreground text-sm">—</span>
-                      )}
-                    </TableCell>
-                    <TableCell>
-                      <Badge variant="secondary" className="capitalize">
-                        {row.state}
-                      </Badge>
-                    </TableCell>
-                    <TableCell className="text-right font-semibold tabular-nums">
-                      {formatDays(row.totalTime)}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground text-sm tabular-nums">
-                      {dayjs.utc(row.updatedAt).tz(timezone).format('MMM D')}
-                    </TableCell>
-                    <TableCell className="text-muted-foreground">
-                      <ChevronRightIcon className="size-4" />
-                    </TableCell>
-                  </TableRow>
-                ))}
+                      </TableCell>
+                      <TableCell className="text-right font-semibold tabular-nums">
+                        {formatDays(row.totalTime)}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground text-sm tabular-nums">
+                        {dayjs.utc(row.updatedAt).tz(timezone).format('MMM D')}
+                      </TableCell>
+                      <TableCell className="text-muted-foreground">
+                        <ChevronRightIcon className="size-4" />
+                      </TableCell>
+                    </TableRow>
+                  )
+                })}
               </TableBody>
             </Table>
           </div>

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -34,7 +34,7 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
       <CardHeader>
         <CardTitle>Longest Cycle Time PRs</CardTitle>
         <CardDescription>
-          Released PRs ranked by total time. Click a row to open the pull
+          Released PRs ranked by total time. Click the PR title to open the pull
           request in a new tab.
         </CardDescription>
       </CardHeader>
@@ -59,78 +59,69 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {rows.map((row) => {
-                  const open = () =>
-                    window.open(row.url, '_blank', 'noopener,noreferrer')
-                  return (
-                    <TableRow
-                      key={`${row.repositoryId}:${row.number}`}
-                      onClick={open}
-                      onKeyDown={(e) => {
-                        if (e.key === 'Enter' || e.key === ' ') {
-                          e.preventDefault()
-                          open()
-                        }
-                      }}
-                      role="link"
-                      tabIndex={0}
-                      aria-label={`Open pull request #${row.number}: ${row.title}`}
-                      className="hover:bg-muted/50 focus-visible:bg-muted/50 cursor-pointer focus-visible:outline-none"
-                    >
-                      <TableCell className="max-w-[320px]">
+                {rows.map((row) => (
+                  <TableRow
+                    key={`${row.repositoryId}:${row.number}`}
+                    className="hover:bg-muted/50"
+                  >
+                    <TableCell className="max-w-[320px]">
+                      <a
+                        href={row.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="hover:underline focus-visible:underline focus-visible:outline-none"
+                      >
                         <div className="text-muted-foreground text-xs tabular-nums">
                           {formatPrIdentifier(row.repo, row.number)}
                         </div>
                         <div className="text-primary line-clamp-1">
                           {row.title}
                         </div>
-                      </TableCell>
-                      <TableCell>
-                        <AuthorBadge
-                          login={row.author}
-                          displayName={row.authorDisplayName}
-                        />
-                      </TableCell>
-                      <TableCell>
-                        <CompositionBar
-                          composition={compositionFromStageTimes(row)}
-                        />
-                      </TableCell>
-                      <TableCell>
-                        {row.bottleneck ? (
-                          <Badge
-                            variant="outline"
-                            className="font-normal"
-                            style={{
-                              borderColor: STAGE_COLOR_VAR[row.bottleneck],
-                              color: STAGE_COLOR_VAR[row.bottleneck],
-                            }}
-                          >
-                            {STAGE_LABEL[row.bottleneck]}
-                          </Badge>
-                        ) : (
-                          <span className="text-muted-foreground text-sm">
-                            —
-                          </span>
-                        )}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="secondary" className="capitalize">
-                          {row.state}
+                      </a>
+                    </TableCell>
+                    <TableCell>
+                      <AuthorBadge
+                        login={row.author}
+                        displayName={row.authorDisplayName}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      <CompositionBar
+                        composition={compositionFromStageTimes(row)}
+                      />
+                    </TableCell>
+                    <TableCell>
+                      {row.bottleneck ? (
+                        <Badge
+                          variant="outline"
+                          className="font-normal"
+                          style={{
+                            borderColor: STAGE_COLOR_VAR[row.bottleneck],
+                            color: STAGE_COLOR_VAR[row.bottleneck],
+                          }}
+                        >
+                          {STAGE_LABEL[row.bottleneck]}
                         </Badge>
-                      </TableCell>
-                      <TableCell className="text-right font-semibold tabular-nums">
-                        {formatDays(row.totalTime)}
-                      </TableCell>
-                      <TableCell className="text-muted-foreground text-sm tabular-nums">
-                        {dayjs.utc(row.updatedAt).tz(timezone).format('MMM D')}
-                      </TableCell>
-                      <TableCell className="text-muted-foreground">
-                        <ChevronRightIcon className="size-4" />
-                      </TableCell>
-                    </TableRow>
-                  )
-                })}
+                      ) : (
+                        <span className="text-muted-foreground text-sm">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="secondary" className="capitalize">
+                        {row.state}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right font-semibold tabular-nums">
+                      {formatDays(row.totalTime)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm tabular-nums">
+                      {dayjs.utc(row.updatedAt).tz(timezone).format('MMM D')}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      <ChevronRightIcon className="size-4" />
+                    </TableCell>
+                  </TableRow>
+                ))}
               </TableBody>
             </Table>
           </div>

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -1,0 +1,119 @@
+import { ChevronRightIcon } from 'lucide-react'
+import { Badge } from '~/app/components/ui/badge'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/app/components/ui/card'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '~/app/components/ui/table'
+import { useTimezone } from '~/app/hooks/use-timezone'
+import dayjs from '~/app/libs/dayjs'
+import type { LongestPrRow } from '../+functions/aggregate'
+import { STAGE_COLOR_VAR, STAGE_LABEL, formatDays } from './stage-config'
+
+interface LongestPrsTableProps {
+  rows: LongestPrRow[]
+}
+
+export function LongestPrsTable({ rows }: LongestPrsTableProps) {
+  const timezone = useTimezone()
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Longest Cycle Time PRs</CardTitle>
+        <CardDescription>
+          Released PRs ranked by total time. Click a row to open the pull
+          request.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        {rows.length === 0 ? (
+          <p className="text-muted-foreground text-sm">
+            No released pull requests in this period.
+          </p>
+        ) : (
+          <div className="overflow-x-auto">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>PR</TableHead>
+                  <TableHead>Repo</TableHead>
+                  <TableHead>Author</TableHead>
+                  <TableHead>Bottleneck</TableHead>
+                  <TableHead>State</TableHead>
+                  <TableHead className="text-right">Total</TableHead>
+                  <TableHead>Released</TableHead>
+                  <TableHead className="w-8" aria-hidden />
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {rows.map((row) => (
+                  <TableRow key={`${row.repositoryId}:${row.number}`}>
+                    <TableCell className="max-w-[320px]">
+                      <a
+                        href={row.url}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="text-primary hover:underline"
+                      >
+                        <span className="text-muted-foreground mr-1">
+                          #{row.number}
+                        </span>
+                        <span className="line-clamp-1">{row.title}</span>
+                      </a>
+                    </TableCell>
+                    <TableCell className="text-muted-foreground tabular-nums">
+                      {row.repo}
+                    </TableCell>
+                    <TableCell>
+                      {row.authorDisplayName?.trim() || row.author}
+                    </TableCell>
+                    <TableCell>
+                      {row.bottleneck ? (
+                        <Badge
+                          variant="outline"
+                          className="font-normal"
+                          style={{
+                            borderColor: STAGE_COLOR_VAR[row.bottleneck],
+                            color: STAGE_COLOR_VAR[row.bottleneck],
+                          }}
+                        >
+                          {STAGE_LABEL[row.bottleneck]}
+                        </Badge>
+                      ) : (
+                        <span className="text-muted-foreground text-sm">—</span>
+                      )}
+                    </TableCell>
+                    <TableCell>
+                      <Badge variant="secondary" className="capitalize">
+                        {row.state}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="text-right font-semibold tabular-nums">
+                      {formatDays(row.totalTime)}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground text-sm tabular-nums">
+                      {dayjs.utc(row.updatedAt).tz(timezone).format('MMM D')}
+                    </TableCell>
+                    <TableCell className="text-muted-foreground">
+                      <ChevronRightIcon className="size-4" />
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -19,6 +19,7 @@ import {
 import { useTimezone } from '~/app/hooks/use-timezone'
 import dayjs from '~/app/libs/dayjs'
 import type { LongestPrRow } from '../+functions/aggregate'
+import { CompositionBar, compositionFromStageTimes } from './composition-bar'
 import { STAGE_COLOR_VAR, STAGE_LABEL, formatDays } from './stage-config'
 
 interface LongestPrsTableProps {
@@ -47,8 +48,8 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
               <TableHeader>
                 <TableRow>
                   <TableHead>PR</TableHead>
-                  <TableHead>Repo</TableHead>
                   <TableHead>Author</TableHead>
+                  <TableHead className="min-w-[140px]">Composition</TableHead>
                   <TableHead>Bottleneck</TableHead>
                   <TableHead>State</TableHead>
                   <TableHead className="text-right">Total</TableHead>
@@ -76,20 +77,22 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                       className="hover:bg-muted/50 focus-visible:bg-muted/50 cursor-pointer focus-visible:outline-none"
                     >
                       <TableCell className="max-w-[320px]">
-                        <span className="text-primary">
-                          <span className="text-muted-foreground mr-1">
-                            #{row.number}
-                          </span>
-                          <span className="line-clamp-1">{row.title}</span>
+                        <div className="text-muted-foreground text-xs tabular-nums">
+                          {row.repo}#{row.number}
+                        </div>
+                        <span className="text-primary line-clamp-1">
+                          {row.title}
                         </span>
-                      </TableCell>
-                      <TableCell className="text-muted-foreground tabular-nums">
-                        {row.repo}
                       </TableCell>
                       <TableCell>
                         <AuthorBadge
                           login={row.author}
                           displayName={row.authorDisplayName}
+                        />
+                      </TableCell>
+                      <TableCell>
+                        <CompositionBar
+                          composition={compositionFromStageTimes(row)}
                         />
                       </TableCell>
                       <TableCell>

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -18,6 +18,7 @@ import {
 import { useTimezone } from '~/app/hooks/use-timezone'
 import dayjs from '~/app/libs/dayjs'
 import type { LongestPrRow } from '../+functions/aggregate'
+import { AuthorBadge } from './author-badge'
 import { STAGE_COLOR_VAR, STAGE_LABEL, formatDays } from './stage-config'
 
 interface LongestPrsTableProps {
@@ -85,7 +86,10 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                       {row.repo}
                     </TableCell>
                     <TableCell>
-                      {row.authorDisplayName?.trim() || row.author}
+                      <AuthorBadge
+                        login={row.author}
+                        displayName={row.authorDisplayName}
+                      />
                     </TableCell>
                     <TableCell>
                       {row.bottleneck ? (

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/stage-config.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/stage-config.ts
@@ -1,0 +1,50 @@
+import type { CycleStage } from '../+functions/aggregate'
+
+export const STAGE_LABEL: Record<CycleStage, string> = {
+  coding: 'Coding',
+  pickup: 'Pickup',
+  review: 'Review',
+  deploy: 'Deploy',
+}
+
+/**
+ * Stage colors aligned with the existing chart palette. Values reference
+ * `--color-chart-*` tokens defined in the Tailwind config.
+ */
+export const STAGE_COLOR_VAR: Record<CycleStage, string> = {
+  coding: 'var(--color-chart-2)',
+  pickup: 'var(--color-chart-4)',
+  review: 'var(--color-chart-1)',
+  deploy: 'var(--color-chart-3)',
+}
+
+/**
+ * Format a duration expressed in days. Sub-day values are reported in hours
+ * (or minutes when below 1h) so a 0.16-day median reads as "3.8h" instead of
+ * the imprecise "0.2d", and stage cells stay comparable in one breath.
+ */
+export function formatDuration(value: number): string {
+  if (value === 0) return '0d'
+  const abs = Math.abs(value)
+  if (abs >= 1) return `${value.toFixed(1)}d`
+  const hours = value * 24
+  if (Math.abs(hours) >= 1) return `${hours.toFixed(1)}h`
+  return `${Math.round(value * 24 * 60)}m`
+}
+
+export function formatDays(value: number | null): string {
+  if (value === null) return '—'
+  return formatDuration(value)
+}
+
+export function formatSignedDays(value: number | null): string {
+  if (value === null) return '—'
+  const sign = value > 0 ? '+' : ''
+  return `${sign}${formatDuration(value)}`
+}
+
+export function formatSignedPct(value: number | null): string {
+  if (value === null) return ''
+  const sign = value >= 0 ? '+' : ''
+  return `${sign}${(value * 100).toFixed(1)}%`
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/weekly-trend-chart.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/weekly-trend-chart.tsx
@@ -1,0 +1,177 @@
+import {
+  Bar,
+  CartesianGrid,
+  Cell,
+  ComposedChart,
+  Line,
+  XAxis,
+  YAxis,
+} from 'recharts'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '~/app/components/ui/card'
+import {
+  type ChartConfig,
+  ChartContainer,
+  ChartLegend,
+  ChartLegendContent,
+  ChartTooltip,
+  ChartTooltipContent,
+} from '~/app/components/ui/chart'
+import type { MetricMode, WeeklyTrendPoint } from '../+functions/aggregate'
+import { STAGE_COLOR_VAR, STAGE_LABEL, formatDays } from './stage-config'
+
+const chartConfig = {
+  coding: { label: STAGE_LABEL.coding, color: STAGE_COLOR_VAR.coding },
+  pickup: { label: STAGE_LABEL.pickup, color: STAGE_COLOR_VAR.pickup },
+  review: { label: STAGE_LABEL.review, color: STAGE_COLOR_VAR.review },
+  deploy: { label: STAGE_LABEL.deploy, color: STAGE_COLOR_VAR.deploy },
+  total: { label: 'Total (stages sum)', color: 'var(--color-foreground)' },
+} satisfies ChartConfig
+
+const STAGES = ['coding', 'pickup', 'review', 'deploy'] as const
+
+interface WeeklyTrendChartProps {
+  weeks: WeeklyTrendPoint[]
+  mode: MetricMode
+  selectedWeek: string | null
+  onSelectWeek: (weekStart: string | null) => void
+}
+
+export function WeeklyTrendChart({
+  weeks,
+  mode,
+  selectedWeek,
+  onSelectWeek,
+}: WeeklyTrendChartProps) {
+  const titleSuffix = mode === 'median' ? 'median' : 'average'
+
+  if (weeks.length === 0 || weeks.every((w) => w.prCount === 0)) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Weekly Cycle Time Trend</CardTitle>
+          <CardDescription>
+            No released pull requests in this period.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    )
+  }
+
+  const handleChartClick = (state: {
+    activePayload?: { payload?: unknown }[]
+  }) => {
+    const payload = state?.activePayload?.[0]?.payload as
+      | WeeklyTrendPoint
+      | undefined
+    if (!payload) return
+    onSelectWeek(payload.weekStart === selectedWeek ? null : payload.weekStart)
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Weekly Cycle Time Trend</CardTitle>
+        <CardDescription>
+          Stacked stage breakdown ({titleSuffix} days). The total line is the
+          sum of stage {titleSuffix}s — see the KPI card for the {titleSuffix}{' '}
+          of total cycle time. Click a week to drill down.
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <ChartContainer
+          config={chartConfig}
+          style={{ height: 320, width: '100%' }}
+        >
+          <ComposedChart
+            data={weeks}
+            onClick={handleChartClick}
+            style={{ cursor: 'pointer' }}
+          >
+            <CartesianGrid vertical={false} />
+            <XAxis
+              dataKey="weekLabel"
+              tick={{ fontSize: 12 }}
+              minTickGap={16}
+            />
+            <YAxis
+              tickFormatter={(v: number) => `${v.toFixed(0)}d`}
+              width={40}
+            />
+            <ChartTooltip
+              content={
+                <ChartTooltipContent
+                  labelFormatter={(_, payload) => {
+                    if (!payload?.length) return ''
+                    const p = payload[0]?.payload as
+                      | WeeklyTrendPoint
+                      | undefined
+                    if (!p) return ''
+                    return `${p.weekLabel} · ${p.prCount} PR${p.prCount === 1 ? '' : 's'}`
+                  }}
+                  formatter={(value, name) => {
+                    const numeric =
+                      typeof value === 'number' ? value : Number(value)
+                    const label =
+                      typeof name === 'string'
+                        ? (chartConfig[name as keyof typeof chartConfig]
+                            ?.label ?? name)
+                        : name
+                    return (
+                      <div className="flex flex-1 justify-between gap-4">
+                        <span className="text-muted-foreground">{label}</span>
+                        <span className="font-mono tabular-nums">
+                          {Number.isFinite(numeric) ? formatDays(numeric) : '—'}
+                        </span>
+                      </div>
+                    )
+                  }}
+                />
+              }
+            />
+            <ChartLegend
+              content={<ChartLegendContent className="flex-wrap" />}
+            />
+            {STAGES.map((stage, i) => (
+              <Bar
+                key={stage}
+                dataKey={stage}
+                stackId="cycle"
+                fill={`var(--color-${stage})`}
+                radius={
+                  i === STAGES.length - 1
+                    ? ([4, 4, 0, 0] as [number, number, number, number])
+                    : undefined
+                }
+              >
+                {weeks.map((w) => (
+                  <Cell
+                    key={w.weekStart}
+                    fillOpacity={
+                      selectedWeek === null || selectedWeek === w.weekStart
+                        ? 1
+                        : 0.3
+                    }
+                  />
+                ))}
+              </Bar>
+            ))}
+            <Line
+              type="monotone"
+              dataKey="total"
+              stroke="var(--color-total)"
+              strokeWidth={2}
+              dot={{ r: 3 }}
+              connectNulls
+            />
+          </ComposedChart>
+        </ChartContainer>
+      </CardContent>
+    </Card>
+  )
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
@@ -1,0 +1,581 @@
+import { describe, expect, test } from 'vitest'
+import {
+  computeAuthorRows,
+  computeBottleneckMix,
+  computeInsights,
+  computeKpi,
+  computeLongestPrs,
+  computeWeeklyTrend,
+  filterRowsByWeek,
+  type CycleTimeRawRow,
+} from './aggregate'
+
+const baseRow = (overrides: Partial<CycleTimeRawRow>): CycleTimeRawRow => ({
+  repositoryId: 'repo-1',
+  repo: 'service-a',
+  number: 1,
+  title: 'sample pr',
+  url: 'https://example.invalid/pulls/1',
+  author: 'alpha',
+  authorDisplayName: 'Alpha User',
+  state: 'merged',
+  pullRequestCreatedAt: '2026-03-01T00:00:00.000Z',
+  mergedAt: '2026-03-02T00:00:00.000Z',
+  releasedAt: '2026-03-03T00:00:00.000Z',
+  codingTime: 1,
+  pickupTime: 1,
+  reviewTime: 1,
+  deployTime: 1,
+  totalTime: 4,
+  ...overrides,
+})
+
+describe('computeKpi', () => {
+  test('median mode picks median per stage and counts PRs', () => {
+    const rows = [
+      baseRow({ number: 1, totalTime: 2, reviewTime: 1, deployTime: 1 }),
+      baseRow({ number: 2, totalTime: 6, reviewTime: 3, deployTime: 2 }),
+      baseRow({ number: 3, totalTime: 4, reviewTime: 2, deployTime: 4 }),
+    ]
+    const prevRows = [
+      baseRow({ number: 99, totalTime: 5, reviewTime: 2, deployTime: 2 }),
+    ]
+    const kpi = computeKpi(rows, prevRows, 'median')
+    expect(kpi.total).toBe(4)
+    expect(kpi.review).toBe(2)
+    expect(kpi.deploy).toBe(2)
+    expect(kpi.prCount).toBe(3)
+    expect(kpi.totalDelta.diff).toBe(-1)
+  })
+
+  test('average mode differs from median', () => {
+    const rows = [
+      baseRow({ number: 1, totalTime: 1 }),
+      baseRow({ number: 2, totalTime: 1 }),
+      baseRow({ number: 3, totalTime: 10 }),
+    ]
+    const med = computeKpi(rows, [], 'median')
+    const avg = computeKpi(rows, [], 'average')
+    expect(med.total).toBe(1)
+    expect(avg.total).toBeCloseTo(4)
+  })
+
+  test('null stage values are excluded, not zeroed', () => {
+    const rows = [
+      baseRow({ number: 1, reviewTime: null, totalTime: 5 }),
+      baseRow({ number: 2, reviewTime: 3, totalTime: 5 }),
+    ]
+    expect(computeKpi(rows, [], 'median').review).toBe(3)
+  })
+
+  test('empty current rows yields null metrics and zero count', () => {
+    const kpi = computeKpi([], [], 'median')
+    expect(kpi.total).toBeNull()
+    expect(kpi.prCount).toBe(0)
+    expect(kpi.totalDelta.diff).toBeNull()
+  })
+})
+
+describe('computeWeeklyTrend', () => {
+  test('buckets PRs by Monday-start week in given timezone', () => {
+    const since = '2026-03-02T00:00:00.000Z' // Mon
+    const until = '2026-03-23T00:00:00.000Z' // Mon (exclusive end)
+    const rows = [
+      // Week 1: 2026-03-02 - 2026-03-08 — baseRow has all stages = 1
+      baseRow({
+        number: 1,
+        releasedAt: '2026-03-04T05:00:00.000Z',
+        totalTime: 4,
+      }),
+      baseRow({
+        number: 2,
+        releasedAt: '2026-03-08T22:00:00.000Z',
+        totalTime: 6,
+      }),
+      // Week 2: 2026-03-09 - 2026-03-15
+      baseRow({
+        number: 3,
+        releasedAt: '2026-03-12T01:00:00.000Z',
+        totalTime: 8,
+      }),
+      // Week 3: 2026-03-16 - 2026-03-22 (no PRs)
+    ]
+    const trend = computeWeeklyTrend(rows, since, until, 'UTC', 'median')
+    expect(trend).toHaveLength(3)
+    expect(trend[0].prCount).toBe(2)
+    // Sum of stage medians (1+1+1+1) — matches the stacked bar height
+    expect(trend[0].total).toBe(4)
+    expect(trend[1].prCount).toBe(1)
+    expect(trend[1].total).toBe(4)
+    expect(trend[2].prCount).toBe(0)
+    expect(trend[2].total).toBeNull()
+  })
+
+  test('total equals sum of stage medians, not median of totalTime', () => {
+    // Three PRs whose stage medians sum to 7 but median(totalTime) = 9.
+    const rows = [
+      baseRow({
+        number: 1,
+        releasedAt: '2026-03-03T00:00:00.000Z',
+        codingTime: 1,
+        pickupTime: 1,
+        reviewTime: 1,
+        deployTime: 1,
+        totalTime: 4,
+      }),
+      baseRow({
+        number: 2,
+        releasedAt: '2026-03-04T00:00:00.000Z',
+        codingTime: 2,
+        pickupTime: 2,
+        reviewTime: 2,
+        deployTime: 2,
+        totalTime: 9,
+      }),
+      baseRow({
+        number: 3,
+        releasedAt: '2026-03-05T00:00:00.000Z',
+        codingTime: 5,
+        pickupTime: 5,
+        reviewTime: 5,
+        deployTime: 5,
+        totalTime: 30,
+      }),
+    ]
+    const trend = computeWeeklyTrend(
+      rows,
+      '2026-03-02T00:00:00.000Z',
+      '2026-03-09T00:00:00.000Z',
+      'UTC',
+      'median',
+    )
+    expect(trend).toHaveLength(1)
+    expect(trend[0].coding).toBe(2)
+    expect(trend[0].pickup).toBe(2)
+    expect(trend[0].review).toBe(2)
+    expect(trend[0].deploy).toBe(2)
+    // sum of stage medians = 8, NOT median(totalTime) = 9
+    expect(trend[0].total).toBe(8)
+  })
+
+  test('week start follows Asia/Tokyo when timezone shifts the day', () => {
+    // 2026-03-01 23:00 UTC = 2026-03-02 08:00 Asia/Tokyo (Mon)
+    const since = '2026-03-02T00:00:00.000Z'
+    const until = '2026-03-09T00:00:00.000Z'
+    const rows = [
+      baseRow({
+        number: 1,
+        releasedAt: '2026-03-01T23:00:00.000Z',
+        totalTime: 5,
+      }),
+    ]
+    const trend = computeWeeklyTrend(rows, since, until, 'Asia/Tokyo', 'median')
+    expect(trend.length).toBeGreaterThan(0)
+    expect(trend[0].prCount).toBe(1)
+    // baseRow stages all = 1 → sum = 4
+    expect(trend[0].total).toBe(4)
+  })
+
+  test('returns [] when since is not before until', () => {
+    expect(
+      computeWeeklyTrend(
+        [],
+        '2026-03-10T00:00:00.000Z',
+        '2026-03-01T00:00:00.000Z',
+        'UTC',
+        'median',
+      ),
+    ).toEqual([])
+  })
+})
+
+describe('filterRowsByWeek', () => {
+  test('keeps only rows whose release week (Monday-start) matches', () => {
+    const rows = [
+      baseRow({ number: 1, releasedAt: '2026-03-04T05:00:00.000Z' }), // wk 03-02
+      baseRow({ number: 2, releasedAt: '2026-03-08T22:00:00.000Z' }), // wk 03-02
+      baseRow({ number: 3, releasedAt: '2026-03-12T01:00:00.000Z' }), // wk 03-09
+      baseRow({ number: 4, releasedAt: null }),
+    ]
+    const out = filterRowsByWeek(rows, '2026-03-02', 'UTC')
+    expect(out.map((r) => r.number)).toEqual([1, 2])
+  })
+
+  test('uses the given timezone to determine the week boundary', () => {
+    // 2026-03-01 23:00 UTC = 2026-03-02 08:00 Asia/Tokyo (Mon)
+    const rows = [
+      baseRow({ number: 1, releasedAt: '2026-03-01T23:00:00.000Z' }),
+    ]
+    expect(
+      filterRowsByWeek(rows, '2026-03-02', 'Asia/Tokyo').map((r) => r.number),
+    ).toEqual([1])
+    expect(
+      filterRowsByWeek(rows, '2026-03-02', 'UTC').map((r) => r.number),
+    ).toEqual([])
+  })
+})
+
+describe('computeBottleneckMix', () => {
+  test('ratios sum to 1 when there is data', () => {
+    const rows = [
+      baseRow({
+        number: 1,
+        codingTime: 2,
+        pickupTime: 1,
+        reviewTime: 4,
+        deployTime: 3,
+      }),
+      baseRow({
+        number: 2,
+        codingTime: 2,
+        pickupTime: 1,
+        reviewTime: 4,
+        deployTime: 3,
+      }),
+    ]
+    const mix = computeBottleneckMix(rows, 'median')
+    const sum = mix.slices.reduce((s, x) => s + x.ratio, 0)
+    expect(sum).toBeCloseTo(1)
+    const review = mix.slices.find((s) => s.stage === 'review')
+    expect(review?.value).toBe(4)
+  })
+
+  test('handles empty rows with zero ratios', () => {
+    const mix = computeBottleneckMix([], 'median')
+    expect(mix.sum).toBe(0)
+    for (const s of mix.slices) {
+      expect(s.ratio).toBe(0)
+      expect(s.value).toBe(0)
+    }
+  })
+})
+
+describe('computeAuthorRows', () => {
+  test('groups by author and computes Review p75 and change vs prev', () => {
+    const rows = [
+      baseRow({
+        author: 'alpha',
+        authorDisplayName: 'Alpha',
+        number: 1,
+        reviewTime: 1,
+        totalTime: 5,
+      }),
+      baseRow({
+        author: 'alpha',
+        authorDisplayName: 'Alpha',
+        number: 2,
+        reviewTime: 3,
+        totalTime: 7,
+      }),
+      baseRow({
+        author: 'alpha',
+        authorDisplayName: 'Alpha',
+        number: 3,
+        reviewTime: 5,
+        totalTime: 9,
+      }),
+      baseRow({
+        author: 'beta',
+        authorDisplayName: 'Beta',
+        number: 4,
+        reviewTime: 2,
+        totalTime: 4,
+      }),
+    ]
+    const prev = [
+      baseRow({
+        author: 'alpha',
+        authorDisplayName: 'Alpha',
+        number: 11,
+        totalTime: 10,
+      }),
+    ]
+    const out = computeAuthorRows(rows, prev, 'median')
+    expect(out.map((a) => a.author)).toEqual(['alpha', 'beta'])
+
+    const alpha = out.find((a) => a.author === 'alpha')
+    expect(alpha?.prCount).toBe(3)
+    expect(alpha?.total).toBe(7)
+    expect(alpha?.reviewP75).toBeCloseTo(4)
+    expect(alpha?.changeVsPrev.diff).toBe(-3)
+    expect(alpha?.composition.reduce((s, c) => s + c.ratio, 0)).toBeCloseTo(1)
+
+    const beta = out.find((a) => a.author === 'beta')
+    expect(beta?.prCount).toBe(1)
+    expect(beta?.changeVsPrev.diff).toBeNull()
+  })
+
+  test('main driver is the largest non-zero stage', () => {
+    const rows = [
+      baseRow({
+        author: 'gamma',
+        authorDisplayName: 'Gamma',
+        number: 1,
+        codingTime: 1,
+        pickupTime: 0.5,
+        reviewTime: 5,
+        deployTime: 1,
+      }),
+    ]
+    const out = computeAuthorRows(rows, [], 'median')
+    expect(out[0].mainDriver).toBe('review')
+  })
+
+  test('falls back to login when display name is empty', () => {
+    const rows = [
+      baseRow({ author: 'delta', authorDisplayName: '   ', number: 1 }),
+    ]
+    const out = computeAuthorRows(rows, [], 'median')
+    expect(out[0].displayName).toBe('delta')
+  })
+})
+
+describe('computeLongestPrs', () => {
+  test('sorts by totalTime desc and keeps limit', () => {
+    const rows = [
+      baseRow({ number: 1, totalTime: 5 }),
+      baseRow({ number: 2, totalTime: 12 }),
+      baseRow({ number: 3, totalTime: 8 }),
+    ]
+    const out = computeLongestPrs(rows, 2)
+    expect(out.map((r) => r.number)).toEqual([2, 3])
+  })
+
+  test('bottleneck is the largest stage', () => {
+    const rows = [
+      baseRow({
+        number: 1,
+        codingTime: 1,
+        pickupTime: 0.5,
+        reviewTime: 7,
+        deployTime: 1,
+        totalTime: 9.5,
+      }),
+    ]
+    expect(computeLongestPrs(rows)[0].bottleneck).toBe('review')
+  })
+
+  test('PR with all-null stages has bottleneck null', () => {
+    const rows = [
+      baseRow({
+        number: 1,
+        codingTime: null,
+        pickupTime: null,
+        reviewTime: null,
+        deployTime: null,
+        totalTime: 3,
+      }),
+    ]
+    expect(computeLongestPrs(rows)[0].bottleneck).toBeNull()
+  })
+
+  test('skips rows without totalTime or releasedAt', () => {
+    const rows = [
+      baseRow({ number: 1, totalTime: null }),
+      baseRow({ number: 2, totalTime: 5, releasedAt: null }),
+      baseRow({ number: 3, totalTime: 6 }),
+    ]
+    const out = computeLongestPrs(rows)
+    expect(out.map((r) => r.number)).toEqual([3])
+  })
+})
+
+describe('computeInsights', () => {
+  const mode = 'median' as const
+
+  test('caps to 3 entries', () => {
+    const rows = [
+      baseRow({
+        number: 1,
+        codingTime: 1,
+        pickupTime: 1,
+        reviewTime: 5,
+        deployTime: 1,
+        totalTime: 8,
+      }),
+      baseRow({
+        number: 2,
+        codingTime: 1,
+        pickupTime: 1,
+        reviewTime: 5,
+        deployTime: 1,
+        totalTime: 8,
+      }),
+    ]
+    const prev = [
+      baseRow({
+        number: 11,
+        codingTime: 1,
+        pickupTime: 5,
+        reviewTime: 1,
+        deployTime: 1,
+        totalTime: 8,
+      }),
+    ]
+    const weekly = [
+      {
+        weekStart: 'a',
+        weekLabel: 'a',
+        prCount: 2,
+        coding: 1,
+        pickup: 1,
+        review: 5,
+        deploy: 1,
+        total: 8,
+      },
+      {
+        weekStart: 'b',
+        weekLabel: 'b',
+        prCount: 0,
+        coding: null,
+        pickup: null,
+        review: null,
+        deploy: 4,
+        total: null,
+      },
+      {
+        weekStart: 'c',
+        weekLabel: 'c',
+        prCount: 0,
+        coding: null,
+        pickup: null,
+        review: null,
+        deploy: 1,
+        total: null,
+      },
+    ]
+    const mix = computeBottleneckMix(rows, mode)
+    const prevMix = computeBottleneckMix(prev, mode)
+    const out = computeInsights({
+      current: rows,
+      previous: prev,
+      weekly,
+      mix,
+      prevMix,
+      mode,
+    })
+    expect(out.length).toBeLessThanOrEqual(3)
+  })
+
+  test('returns review-dominance string when review is the largest stage', () => {
+    const rows = [
+      baseRow({
+        number: 1,
+        codingTime: 1,
+        pickupTime: 1,
+        reviewTime: 6,
+        deployTime: 1,
+        totalTime: 9,
+      }),
+    ]
+    const prev = [
+      baseRow({
+        number: 11,
+        codingTime: 1,
+        pickupTime: 1,
+        reviewTime: 3,
+        deployTime: 1,
+        totalTime: 6,
+      }),
+    ]
+    const mix = computeBottleneckMix(rows, mode)
+    const prevMix = computeBottleneckMix(prev, mode)
+    const out = computeInsights({
+      current: rows,
+      previous: prev,
+      weekly: [],
+      mix,
+      prevMix,
+      mode,
+    })
+    expect(out[0]).toMatch(/^Review time is the main driver/)
+  })
+
+  test('main driver follows the actual largest stage (not hardcoded review)', () => {
+    // Pickup is dominant (61%), review is 36%. The first insight must be
+    // about Pickup, not Review.
+    const rows = [
+      baseRow({
+        number: 1,
+        codingTime: 0.05,
+        pickupTime: 0.2,
+        reviewTime: 0.12,
+        deployTime: 0,
+        totalTime: 0.37,
+      }),
+    ]
+    const prev = [
+      baseRow({
+        number: 11,
+        codingTime: 0.05,
+        pickupTime: 0.25,
+        reviewTime: 0.12,
+        deployTime: 0,
+        totalTime: 0.42,
+      }),
+    ]
+    const mix = computeBottleneckMix(rows, mode)
+    const prevMix = computeBottleneckMix(prev, mode)
+    const out = computeInsights({
+      current: rows,
+      previous: prev,
+      weekly: [],
+      mix,
+      prevMix,
+      mode,
+    })
+    expect(out[0]).toMatch(/^Pickup time is the main driver/)
+    // No insight should claim Review is the main driver in this scenario.
+    expect(out.some((s) => /Review time is the main driver/.test(s))).toBe(
+      false,
+    )
+  })
+
+  test('improvement insight only fires for non-dominant stages', () => {
+    // Pickup is dominant AND improved. Improvement message must not appear
+    // separately — the dominant insight already speaks to the change.
+    const rows = [
+      baseRow({
+        number: 1,
+        codingTime: 0.1,
+        pickupTime: 0.5,
+        reviewTime: 0.1,
+        deployTime: 0.1,
+        totalTime: 0.8,
+      }),
+    ]
+    const prev = [
+      baseRow({
+        number: 11,
+        codingTime: 0.1,
+        pickupTime: 1.0,
+        reviewTime: 0.1,
+        deployTime: 0.1,
+        totalTime: 1.3,
+      }),
+    ]
+    const mix = computeBottleneckMix(rows, mode)
+    const prevMix = computeBottleneckMix(prev, mode)
+    const out = computeInsights({
+      current: rows,
+      previous: prev,
+      weekly: [],
+      mix,
+      prevMix,
+      mode,
+    })
+    expect(out.filter((s) => /^Pickup time/.test(s))).toHaveLength(1)
+  })
+
+  test('empty current period returns []', () => {
+    const out = computeInsights({
+      current: [],
+      previous: [],
+      weekly: [],
+      mix: computeBottleneckMix([], mode),
+      prevMix: computeBottleneckMix([], mode),
+      mode,
+    })
+    expect(out).toEqual([])
+  })
+})

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
@@ -328,6 +328,40 @@ describe('computeAuthorRows', () => {
     const out = computeAuthorRows(rows, [], 'median')
     expect(out[0].displayName).toBe('delta')
   })
+
+  test('groups authors case-insensitively (login casing varies across PRs)', () => {
+    const rows = [
+      baseRow({
+        author: 'Alpha',
+        authorDisplayName: 'Alpha',
+        number: 1,
+        totalTime: 5,
+      }),
+      baseRow({
+        author: 'alpha',
+        authorDisplayName: 'Alpha',
+        number: 2,
+        totalTime: 7,
+      }),
+      baseRow({
+        author: 'ALPHA',
+        authorDisplayName: 'Alpha',
+        number: 3,
+        totalTime: 9,
+      }),
+    ]
+    const prev = [
+      baseRow({ author: 'Alpha', number: 11, totalTime: 10 }),
+      baseRow({ author: 'alpha', number: 12, totalTime: 12 }),
+    ]
+    const out = computeAuthorRows(rows, prev, 'median')
+    expect(out).toHaveLength(1)
+    expect(out[0].prCount).toBe(3)
+    expect(out[0].total).toBe(7)
+    // Previous-period rows with the same login (different casing) must be
+    // matched and produce a non-null delta.
+    expect(out[0].changeVsPrev.diff).not.toBeNull()
+  })
 })
 
 describe('computeLongestPrs', () => {

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
@@ -358,6 +358,10 @@ describe('computeAuthorRows', () => {
     expect(out).toHaveLength(1)
     expect(out[0].prCount).toBe(3)
     expect(out[0].total).toBe(7)
+    // Output `author` keeps the casing of the first row in the group so the
+    // canonical login is preserved.
+    expect(out[0].author.toLowerCase()).toBe('alpha')
+    expect(out[0].author).toBe('Alpha')
     // Previous-period rows with the same login (different casing) must be
     // matched and produce a non-null delta.
     expect(out[0].changeVsPrev.diff).not.toBeNull()

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
@@ -1,5 +1,6 @@
+import { startOfWeekMonday } from '~/app/libs/date-utils'
 import dayjs from '~/app/libs/dayjs'
-import { median } from '~/app/libs/stats'
+import { average, median, percentile } from '~/app/libs/stats'
 
 export type MetricMode = 'median' | 'average'
 
@@ -33,12 +34,6 @@ export interface CycleTimeRawRow {
 
 // --- helpers ---
 
-function startOfWeekMonday(d: dayjs.Dayjs): dayjs.Dayjs {
-  const day = d.day()
-  const diffToMonday = day === 0 ? -6 : 1 - day
-  return d.startOf('day').add(diffToMonday, 'day')
-}
-
 /**
  * Filter raw rows to those released within the week starting at `weekStart`
  * (Monday) in the given timezone. `weekStart` is the `YYYY-MM-DD` key produced
@@ -56,62 +51,60 @@ export function filterRowsByWeek(
   })
 }
 
-function average(values: number[]): number | null {
-  if (values.length === 0) return null
-  let sum = 0
-  for (const v of values) sum += v
-  return sum / values.length
-}
-
 function aggregateValue(values: number[], mode: MetricMode): number | null {
-  if (mode === 'median') return median(values)
-  return average(values)
+  return mode === 'median' ? median(values) : average(values)
 }
 
-function percentile(values: number[], p: number): number | null {
-  if (values.length === 0) return null
-  const sorted = [...values].sort((a, b) => a - b)
-  const rank = (sorted.length - 1) * p
-  const lower = Math.floor(rank)
-  const upper = Math.ceil(rank)
-  if (lower === upper) return sorted[lower]
-  const weight = rank - lower
-  return sorted[lower] * (1 - weight) + sorted[upper] * weight
+type StageValues = Record<CycleStage, number[]>
+
+const STAGE_KEY: Record<
+  CycleStage,
+  'codingTime' | 'pickupTime' | 'reviewTime' | 'deployTime'
+> = {
+  coding: 'codingTime',
+  pickup: 'pickupTime',
+  review: 'reviewTime',
+  deploy: 'deployTime',
 }
 
-function nonNullStageValues(
-  rows: CycleTimeRawRow[],
-  stage: CycleStage,
-): number[] {
-  const key = stageKey(stage)
-  const out: number[] = []
+/**
+ * Single O(n) pass that splits rows into the four stage value arrays. Used
+ * by every aggregator so we don't scan rows once per stage.
+ */
+function partitionStageValues(rows: CycleTimeRawRow[]): StageValues {
+  const out: StageValues = { coding: [], pickup: [], review: [], deploy: [] }
   for (const r of rows) {
-    const v = r[key]
-    if (v !== null) out.push(v)
+    if (r.codingTime !== null) out.coding.push(r.codingTime)
+    if (r.pickupTime !== null) out.pickup.push(r.pickupTime)
+    if (r.reviewTime !== null) out.review.push(r.reviewTime)
+    if (r.deployTime !== null) out.deploy.push(r.deployTime)
   }
   return out
 }
 
-function stageKey(
-  stage: CycleStage,
-): 'codingTime' | 'pickupTime' | 'reviewTime' | 'deployTime' {
-  switch (stage) {
-    case 'coding':
-      return 'codingTime'
-    case 'pickup':
-      return 'pickupTime'
-    case 'review':
-      return 'reviewTime'
-    case 'deploy':
-      return 'deployTime'
+function aggregateStages(
+  buckets: StageValues,
+  mode: MetricMode,
+): Record<CycleStage, number | null> {
+  return {
+    coding: aggregateValue(buckets.coding, mode),
+    pickup: aggregateValue(buckets.pickup, mode),
+    review: aggregateValue(buckets.review, mode),
+    deploy: aggregateValue(buckets.deploy, mode),
   }
+}
+
+function nonNullTotalValues(rows: CycleTimeRawRow[]): number[] {
+  const out: number[] = []
+  for (const r of rows) if (r.totalTime !== null) out.push(r.totalTime)
+  return out
 }
 
 function bottleneckStage(row: CycleTimeRawRow): CycleStage | null {
   let best: CycleStage | null = null
   let bestVal = -Infinity
   for (const s of STAGES) {
-    const v = row[stageKey(s)]
+    const v = row[STAGE_KEY[s]]
     if (v === null) continue
     if (v > bestVal) {
       bestVal = v
@@ -160,38 +153,24 @@ export function computeKpi(
   prevRows: CycleTimeRawRow[],
   mode: MetricMode,
 ): CycleTimeKpi {
-  const total = aggregateValue(
-    rows.map((r) => r.totalTime).filter((v): v is number => v !== null),
-    mode,
-  )
-  const prevTotal = aggregateValue(
-    prevRows.map((r) => r.totalTime).filter((v): v is number => v !== null),
-    mode,
-  )
-  const review = aggregateValue(nonNullStageValues(rows, 'review'), mode)
-  const prevReview = aggregateValue(
-    nonNullStageValues(prevRows, 'review'),
-    mode,
-  )
-  const deploy = aggregateValue(nonNullStageValues(rows, 'deploy'), mode)
-  const prevDeploy = aggregateValue(
-    nonNullStageValues(prevRows, 'deploy'),
-    mode,
-  )
+  const cur = aggregateStages(partitionStageValues(rows), mode)
+  const prev = aggregateStages(partitionStageValues(prevRows), mode)
+  const total = aggregateValue(nonNullTotalValues(rows), mode)
+  const prevTotal = aggregateValue(nonNullTotalValues(prevRows), mode)
 
   return {
     total,
     prCount: rows.length,
-    review,
-    deploy,
+    review: cur.review,
+    deploy: cur.deploy,
     prevTotal,
     prevPrCount: prevRows.length,
-    prevReview,
-    prevDeploy,
+    prevReview: prev.review,
+    prevDeploy: prev.deploy,
     totalDelta: makeDelta(total, prevTotal),
     prCountDelta: makeDelta(rows.length, prevRows.length),
-    reviewDelta: makeDelta(review, prevReview),
-    deployDelta: makeDelta(deploy, prevDeploy),
+    reviewDelta: makeDelta(cur.review, prev.review),
+    deployDelta: makeDelta(cur.deploy, prev.deploy),
   }
 }
 
@@ -243,26 +222,25 @@ export function computeWeeklyTrend(
 
   return weekKeys.map((key) => {
     const bucket = buckets.get(key) ?? []
-    const coding = aggregateValue(nonNullStageValues(bucket, 'coding'), mode)
-    const pickup = aggregateValue(nonNullStageValues(bucket, 'pickup'), mode)
-    const review = aggregateValue(nonNullStageValues(bucket, 'review'), mode)
-    const deploy = aggregateValue(nonNullStageValues(bucket, 'deploy'), mode)
-    const stageValues = [coding, pickup, review, deploy]
+    const stages = aggregateStages(partitionStageValues(bucket), mode)
+    const stageVals = [
+      stages.coding,
+      stages.pickup,
+      stages.review,
+      stages.deploy,
+    ]
     // Total = sum of stage aggregates so the line matches the stacked bar
     // height and tooltip components in both median and average modes. (Median
     // of totalTime ≠ sum of stage medians, which previously caused the line
     // to disagree with the breakdown.)
-    const total = stageValues.every((v) => v === null)
+    const total = stageVals.every((v) => v === null)
       ? null
-      : stageValues.reduce<number>((s, v) => s + (v ?? 0), 0)
+      : stageVals.reduce<number>((s, v) => s + (v ?? 0), 0)
     return {
       weekStart: key,
       weekLabel: dayjs(key).format('MMM D'),
       prCount: bucket.length,
-      coding,
-      pickup,
-      review,
-      deploy,
+      ...stages,
       total,
     }
   })
@@ -287,9 +265,10 @@ export function computeBottleneckMix(
   rows: CycleTimeRawRow[],
   mode: MetricMode,
 ): BottleneckMix {
+  const stages = aggregateStages(partitionStageValues(rows), mode)
   const values = STAGES.map((stage) => ({
     stage,
-    value: aggregateValue(nonNullStageValues(rows, stage), mode) ?? 0,
+    value: stages[stage] ?? 0,
   }))
   const sum = values.reduce((s, v) => s + v.value, 0)
   return {
@@ -334,6 +313,16 @@ function formatPct(p: number): string {
   return `${sign}${(p * 100).toFixed(0)}%`
 }
 
+function directionVsPrev(
+  current: number,
+  prev: number | null,
+): 'up' | 'down' | 'steady' {
+  if (prev === null) return 'steady'
+  if (current < prev) return 'down'
+  if (current > prev) return 'up'
+  return 'steady'
+}
+
 export function computeInsights(args: {
   current: CycleTimeRawRow[]
   previous: CycleTimeRawRow[]
@@ -347,6 +336,9 @@ export function computeInsights(args: {
 
   if (current.length === 0) return insights
 
+  const curStages = aggregateStages(partitionStageValues(current), mode)
+  const prevStages = aggregateStages(partitionStageValues(previous), mode)
+
   const ranked = [...mix.slices].sort((a, b) => b.ratio - a.ratio)
   const dominant = ranked[0]
 
@@ -354,14 +346,8 @@ export function computeInsights(args: {
   if (dominant && dominant.ratio >= DOMINANT_THRESHOLD) {
     const stageLabel = STAGE_LABEL_NICE[dominant.stage]
     const pctText = `${(dominant.ratio * 100).toFixed(0)}%`
-    const cur = aggregateValue(
-      nonNullStageValues(current, dominant.stage),
-      mode,
-    )
-    const prv = aggregateValue(
-      nonNullStageValues(previous, dominant.stage),
-      mode,
-    )
+    const cur = curStages[dominant.stage]
+    const prv = prevStages[dominant.stage]
     if (cur !== null && prv !== null && prv > 0) {
       const diff = cur - prv
       const pctDelta = cur / prv - 1
@@ -388,8 +374,8 @@ export function computeInsights(args: {
   // 2. Notable improvement on a non-dominant stage (>=15% drop vs prev).
   for (const stage of STAGES) {
     if (dominant && stage === dominant.stage) continue
-    const cur = aggregateValue(nonNullStageValues(current, stage), mode)
-    const prv = aggregateValue(nonNullStageValues(previous, stage), mode)
+    const cur = curStages[stage]
+    const prv = prevStages[stage]
     if (cur === null || prv === null || prv <= 0) continue
     if (cur < prv * STAGE_IMPROVEMENT_THRESHOLD) {
       const pctDelta = cur / prv - 1
@@ -424,12 +410,7 @@ export function computeInsights(args: {
   // isn't empty.
   if (insights.length === 0 && dominant && dominant.ratio > 0) {
     const prevSlice = prevMix.slices.find((s) => s.stage === dominant.stage)
-    const direction =
-      prevSlice && dominant.value < prevSlice.value
-        ? 'down'
-        : prevSlice && dominant.value > prevSlice.value
-          ? 'up'
-          : 'steady'
+    const direction = directionVsPrev(dominant.value, prevSlice?.value ?? null)
     insights.push(
       `${STAGE_LABEL_NICE[dominant.stage]} accounts for ${(dominant.ratio * 100).toFixed(0)}% of cycle time and is ${direction} vs previous period.`,
     )
@@ -478,37 +459,32 @@ export function computeAuthorRows(
 
   const out: AuthorRow[] = []
   for (const [author, authorRows] of groupCurrent) {
+    const buckets = partitionStageValues(authorRows)
     const stageValues = STAGES.map((stage) => ({
       stage,
-      value: aggregateValue(nonNullStageValues(authorRows, stage), mode) ?? 0,
+      value: aggregateValue(buckets[stage], mode) ?? 0,
     }))
     const sum = stageValues.reduce((s, v) => s + v.value, 0)
-    const composition = stageValues.map(({ stage, value }) => ({
-      stage,
-      ratio: sum > 0 ? value / sum : 0,
-    }))
-
-    const total = aggregateValue(
-      authorRows.map((r) => r.totalTime).filter((v): v is number => v !== null),
-      mode,
-    )
 
     let mainDriver: CycleStage | null = null
     let mainDriverValue = -Infinity
+    const composition: AuthorRow['composition'] = []
     for (const sv of stageValues) {
+      composition.push({
+        stage: sv.stage,
+        ratio: sum > 0 ? sv.value / sum : 0,
+      })
       if (sv.value > 0 && sv.value > mainDriverValue) {
         mainDriverValue = sv.value
         mainDriver = sv.stage
       }
     }
 
-    const reviewP75 = percentile(nonNullStageValues(authorRows, 'review'), 0.75)
+    const total = aggregateValue(nonNullTotalValues(authorRows), mode)
+    const reviewP75 = percentile(buckets.review, 0.75)
 
     const prevList = groupPrev.get(author) ?? []
-    const prevTotal = aggregateValue(
-      prevList.map((r) => r.totalTime).filter((v): v is number => v !== null),
-      mode,
-    )
+    const prevTotal = aggregateValue(nonNullTotalValues(prevList), mode)
 
     out.push({
       author,

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
@@ -1,0 +1,579 @@
+import dayjs from '~/app/libs/dayjs'
+import { median } from '~/app/libs/stats'
+
+export type MetricMode = 'median' | 'average'
+
+export type CycleStage = 'coding' | 'pickup' | 'review' | 'deploy'
+
+export const STAGES: readonly CycleStage[] = [
+  'coding',
+  'pickup',
+  'review',
+  'deploy',
+] as const
+
+export interface CycleTimeRawRow {
+  repositoryId: string
+  repo: string
+  number: number
+  title: string
+  url: string
+  author: string
+  authorDisplayName: string | null
+  state: 'open' | 'closed' | 'merged'
+  pullRequestCreatedAt: string
+  mergedAt: string | null
+  releasedAt: string | null
+  codingTime: number | null
+  pickupTime: number | null
+  reviewTime: number | null
+  deployTime: number | null
+  totalTime: number | null
+}
+
+// --- helpers ---
+
+function startOfWeekMonday(d: dayjs.Dayjs): dayjs.Dayjs {
+  const day = d.day()
+  const diffToMonday = day === 0 ? -6 : 1 - day
+  return d.startOf('day').add(diffToMonday, 'day')
+}
+
+/**
+ * Filter raw rows to those released within the week starting at `weekStart`
+ * (Monday) in the given timezone. `weekStart` is the `YYYY-MM-DD` key produced
+ * by `computeWeeklyTrend`.
+ */
+export function filterRowsByWeek(
+  rows: CycleTimeRawRow[],
+  weekStart: string,
+  timezone: string,
+): CycleTimeRawRow[] {
+  return rows.filter((row) => {
+    if (row.releasedAt === null) return false
+    const wk = startOfWeekMonday(dayjs.utc(row.releasedAt).tz(timezone))
+    return wk.format('YYYY-MM-DD') === weekStart
+  })
+}
+
+function average(values: number[]): number | null {
+  if (values.length === 0) return null
+  let sum = 0
+  for (const v of values) sum += v
+  return sum / values.length
+}
+
+function aggregateValue(values: number[], mode: MetricMode): number | null {
+  if (mode === 'median') return median(values)
+  return average(values)
+}
+
+function percentile(values: number[], p: number): number | null {
+  if (values.length === 0) return null
+  const sorted = [...values].sort((a, b) => a - b)
+  const rank = (sorted.length - 1) * p
+  const lower = Math.floor(rank)
+  const upper = Math.ceil(rank)
+  if (lower === upper) return sorted[lower]
+  const weight = rank - lower
+  return sorted[lower] * (1 - weight) + sorted[upper] * weight
+}
+
+function nonNullStageValues(
+  rows: CycleTimeRawRow[],
+  stage: CycleStage,
+): number[] {
+  const key = stageKey(stage)
+  const out: number[] = []
+  for (const r of rows) {
+    const v = r[key]
+    if (v !== null) out.push(v)
+  }
+  return out
+}
+
+function stageKey(
+  stage: CycleStage,
+): 'codingTime' | 'pickupTime' | 'reviewTime' | 'deployTime' {
+  switch (stage) {
+    case 'coding':
+      return 'codingTime'
+    case 'pickup':
+      return 'pickupTime'
+    case 'review':
+      return 'reviewTime'
+    case 'deploy':
+      return 'deployTime'
+  }
+}
+
+function bottleneckStage(row: CycleTimeRawRow): CycleStage | null {
+  let best: CycleStage | null = null
+  let bestVal = -Infinity
+  for (const s of STAGES) {
+    const v = row[stageKey(s)]
+    if (v === null) continue
+    if (v > bestVal) {
+      bestVal = v
+      best = s
+    }
+  }
+  return best
+}
+
+// --- KPI ---
+
+export interface CycleTimeDelta {
+  /** Current value - previous value. null if either side is null. */
+  diff: number | null
+  /** Relative change (current/previous - 1). null if previous is null/0. */
+  pct: number | null
+}
+
+export interface CycleTimeKpi {
+  total: number | null
+  prCount: number
+  review: number | null
+  deploy: number | null
+  prevTotal: number | null
+  prevPrCount: number
+  prevReview: number | null
+  prevDeploy: number | null
+  totalDelta: CycleTimeDelta
+  prCountDelta: CycleTimeDelta
+  reviewDelta: CycleTimeDelta
+  deployDelta: CycleTimeDelta
+}
+
+function makeDelta(
+  current: number | null,
+  prev: number | null,
+): CycleTimeDelta {
+  if (current === null || prev === null) return { diff: null, pct: null }
+  const diff = current - prev
+  const pct = prev === 0 ? null : current / prev - 1
+  return { diff, pct }
+}
+
+export function computeKpi(
+  rows: CycleTimeRawRow[],
+  prevRows: CycleTimeRawRow[],
+  mode: MetricMode,
+): CycleTimeKpi {
+  const total = aggregateValue(
+    rows.map((r) => r.totalTime).filter((v): v is number => v !== null),
+    mode,
+  )
+  const prevTotal = aggregateValue(
+    prevRows.map((r) => r.totalTime).filter((v): v is number => v !== null),
+    mode,
+  )
+  const review = aggregateValue(nonNullStageValues(rows, 'review'), mode)
+  const prevReview = aggregateValue(
+    nonNullStageValues(prevRows, 'review'),
+    mode,
+  )
+  const deploy = aggregateValue(nonNullStageValues(rows, 'deploy'), mode)
+  const prevDeploy = aggregateValue(
+    nonNullStageValues(prevRows, 'deploy'),
+    mode,
+  )
+
+  return {
+    total,
+    prCount: rows.length,
+    review,
+    deploy,
+    prevTotal,
+    prevPrCount: prevRows.length,
+    prevReview,
+    prevDeploy,
+    totalDelta: makeDelta(total, prevTotal),
+    prCountDelta: makeDelta(rows.length, prevRows.length),
+    reviewDelta: makeDelta(review, prevReview),
+    deployDelta: makeDelta(deploy, prevDeploy),
+  }
+}
+
+// --- Weekly trend ---
+
+export interface WeeklyTrendPoint {
+  weekStart: string
+  weekLabel: string
+  prCount: number
+  coding: number | null
+  pickup: number | null
+  review: number | null
+  deploy: number | null
+  total: number | null
+}
+
+export function computeWeeklyTrend(
+  rows: CycleTimeRawRow[],
+  sinceDate: string,
+  untilDate: string,
+  timezone: string,
+  mode: MetricMode,
+): WeeklyTrendPoint[] {
+  const since = dayjs.utc(sinceDate).tz(timezone)
+  const until = dayjs.utc(untilDate).tz(timezone)
+  if (!since.isBefore(until)) return []
+
+  const firstMonday = startOfWeekMonday(since)
+  // until is exclusive — the last full day in range is until - 1ms
+  const lastMonday = startOfWeekMonday(until.subtract(1, 'millisecond'))
+
+  const weekKeys: string[] = []
+  const buckets = new Map<string, CycleTimeRawRow[]>()
+  let cursor = firstMonday
+  while (cursor.isBefore(lastMonday) || cursor.isSame(lastMonday, 'day')) {
+    const key = cursor.format('YYYY-MM-DD')
+    weekKeys.push(key)
+    buckets.set(key, [])
+    cursor = cursor.add(7, 'day')
+  }
+
+  for (const row of rows) {
+    if (row.releasedAt === null) continue
+    const wk = startOfWeekMonday(dayjs.utc(row.releasedAt).tz(timezone))
+    const key = wk.format('YYYY-MM-DD')
+    const bucket = buckets.get(key)
+    if (bucket) bucket.push(row)
+  }
+
+  return weekKeys.map((key) => {
+    const bucket = buckets.get(key) ?? []
+    const coding = aggregateValue(nonNullStageValues(bucket, 'coding'), mode)
+    const pickup = aggregateValue(nonNullStageValues(bucket, 'pickup'), mode)
+    const review = aggregateValue(nonNullStageValues(bucket, 'review'), mode)
+    const deploy = aggregateValue(nonNullStageValues(bucket, 'deploy'), mode)
+    const stageValues = [coding, pickup, review, deploy]
+    // Total = sum of stage aggregates so the line matches the stacked bar
+    // height and tooltip components in both median and average modes. (Median
+    // of totalTime ≠ sum of stage medians, which previously caused the line
+    // to disagree with the breakdown.)
+    const total = stageValues.every((v) => v === null)
+      ? null
+      : stageValues.reduce<number>((s, v) => s + (v ?? 0), 0)
+    return {
+      weekStart: key,
+      weekLabel: dayjs(key).format('MMM D'),
+      prCount: bucket.length,
+      coding,
+      pickup,
+      review,
+      deploy,
+      total,
+    }
+  })
+}
+
+// --- Bottleneck mix ---
+
+export interface BottleneckMixSlice {
+  stage: CycleStage
+  value: number
+  ratio: number
+}
+
+export interface BottleneckMix {
+  /** Stage value (median/avg days) and share of the sum across stages. */
+  slices: BottleneckMixSlice[]
+  /** Sum of stage values. 0 when no data. */
+  sum: number
+}
+
+export function computeBottleneckMix(
+  rows: CycleTimeRawRow[],
+  mode: MetricMode,
+): BottleneckMix {
+  const values = STAGES.map((stage) => ({
+    stage,
+    value: aggregateValue(nonNullStageValues(rows, stage), mode) ?? 0,
+  }))
+  const sum = values.reduce((s, v) => s + v.value, 0)
+  return {
+    slices: values.map(({ stage, value }) => ({
+      stage,
+      value,
+      ratio: sum > 0 ? value / sum : 0,
+    })),
+    sum,
+  }
+}
+
+// --- Insights ---
+
+const DOMINANT_THRESHOLD = 0.3
+const STAGE_IMPROVEMENT_THRESHOLD = 0.85
+const DEPLOY_VARIANCE_RATIO = 2
+
+const STAGE_LABEL_NICE: Record<CycleStage, string> = {
+  coding: 'Coding',
+  pickup: 'Pickup',
+  review: 'Review',
+  deploy: 'Deploy',
+}
+
+/**
+ * Insight-friendly duration formatter. Sub-day values fall back to hours or
+ * minutes so a 0.05-day delta reads as "1.2h" instead of the misleading
+ * "0.0d", and stage values stay comparable across coding / pickup / review.
+ */
+function formatDays(d: number): string {
+  if (d === 0) return '0d'
+  const abs = Math.abs(d)
+  if (abs >= 1) return `${d.toFixed(1)}d`
+  const hours = d * 24
+  if (Math.abs(hours) >= 1) return `${hours.toFixed(1)}h`
+  return `${Math.round(d * 24 * 60)}m`
+}
+
+function formatPct(p: number): string {
+  const sign = p >= 0 ? '+' : ''
+  return `${sign}${(p * 100).toFixed(0)}%`
+}
+
+export function computeInsights(args: {
+  current: CycleTimeRawRow[]
+  previous: CycleTimeRawRow[]
+  weekly: WeeklyTrendPoint[]
+  mix: BottleneckMix
+  prevMix: BottleneckMix
+  mode: MetricMode
+}): string[] {
+  const { current, previous, weekly, mix, prevMix, mode } = args
+  const insights: string[] = []
+
+  if (current.length === 0) return insights
+
+  const ranked = [...mix.slices].sort((a, b) => b.ratio - a.ratio)
+  const dominant = ranked[0]
+
+  // 1. Main driver — whichever stage actually has the largest share.
+  if (dominant && dominant.ratio >= DOMINANT_THRESHOLD) {
+    const stageLabel = STAGE_LABEL_NICE[dominant.stage]
+    const pctText = `${(dominant.ratio * 100).toFixed(0)}%`
+    const cur = aggregateValue(
+      nonNullStageValues(current, dominant.stage),
+      mode,
+    )
+    const prv = aggregateValue(
+      nonNullStageValues(previous, dominant.stage),
+      mode,
+    )
+    if (cur !== null && prv !== null && prv > 0) {
+      const diff = cur - prv
+      const pctDelta = cur / prv - 1
+      if (diff > 0) {
+        insights.push(
+          `${stageLabel} time is the main driver (${pctText}). It increased ${formatDays(diff)} (${formatPct(pctDelta)}) vs previous period.`,
+        )
+      } else if (diff < 0) {
+        insights.push(
+          `${stageLabel} time is the main driver (${pctText}). It decreased ${formatDays(Math.abs(diff))} (${formatPct(pctDelta)}) but still leads cycle time.`,
+        )
+      } else {
+        insights.push(
+          `${stageLabel} time is the main driver (${pctText}) of cycle time in this period.`,
+        )
+      }
+    } else {
+      insights.push(
+        `${stageLabel} time is the main driver (${pctText}) of cycle time in this period.`,
+      )
+    }
+  }
+
+  // 2. Notable improvement on a non-dominant stage (>=15% drop vs prev).
+  for (const stage of STAGES) {
+    if (dominant && stage === dominant.stage) continue
+    const cur = aggregateValue(nonNullStageValues(current, stage), mode)
+    const prv = aggregateValue(nonNullStageValues(previous, stage), mode)
+    if (cur === null || prv === null || prv <= 0) continue
+    if (cur < prv * STAGE_IMPROVEMENT_THRESHOLD) {
+      const pctDelta = cur / prv - 1
+      const stageLabel = STAGE_LABEL_NICE[stage]
+      insights.push(
+        `${stageLabel} time improved to ${formatDays(cur)} (${formatPct(pctDelta)}) vs previous period.`,
+      )
+      break
+    }
+  }
+
+  // 3. Deploy variance across the period (skip when deploy is dominant —
+  // the level message above already covers it).
+  if (!dominant || dominant.stage !== 'deploy') {
+    const deployValues = weekly
+      .map((w) => w.deploy)
+      .filter((v): v is number => v !== null && v > 0)
+    if (deployValues.length >= 3) {
+      const sortedDeploy = [...deployValues].sort((a, b) => a - b)
+      const med = sortedDeploy[Math.floor(sortedDeploy.length / 2)]
+      const max = sortedDeploy[sortedDeploy.length - 1]
+      if (med > 0 && max >= med * DEPLOY_VARIANCE_RATIO) {
+        insights.push(
+          `Deploy time variance is high. Some weeks exceed ${formatDays(max)}.`,
+        )
+      }
+    }
+  }
+
+  // 4. Fallback: dominant stage exists but didn't reach the threshold (no
+  // previous data, or below 30%). Report direction vs prev so the panel
+  // isn't empty.
+  if (insights.length === 0 && dominant && dominant.ratio > 0) {
+    const prevSlice = prevMix.slices.find((s) => s.stage === dominant.stage)
+    const direction =
+      prevSlice && dominant.value < prevSlice.value
+        ? 'down'
+        : prevSlice && dominant.value > prevSlice.value
+          ? 'up'
+          : 'steady'
+    insights.push(
+      `${STAGE_LABEL_NICE[dominant.stage]} accounts for ${(dominant.ratio * 100).toFixed(0)}% of cycle time and is ${direction} vs previous period.`,
+    )
+  }
+
+  return insights.slice(0, 3)
+}
+
+// --- By Author ---
+
+export interface AuthorRow {
+  author: string
+  displayName: string
+  prCount: number
+  composition: { stage: CycleStage; ratio: number }[]
+  total: number | null
+  mainDriver: CycleStage | null
+  reviewP75: number | null
+  changeVsPrev: CycleTimeDelta
+}
+
+function authorDisplay(row: CycleTimeRawRow): string {
+  return row.authorDisplayName?.trim() || row.author
+}
+
+export function computeAuthorRows(
+  rows: CycleTimeRawRow[],
+  prevRows: CycleTimeRawRow[],
+  mode: MetricMode,
+): AuthorRow[] {
+  const groupCurrent = new Map<string, CycleTimeRawRow[]>()
+  for (const r of rows) {
+    const key = r.author
+    const list = groupCurrent.get(key)
+    if (list) list.push(r)
+    else groupCurrent.set(key, [r])
+  }
+
+  const groupPrev = new Map<string, CycleTimeRawRow[]>()
+  for (const r of prevRows) {
+    const key = r.author
+    const list = groupPrev.get(key)
+    if (list) list.push(r)
+    else groupPrev.set(key, [r])
+  }
+
+  const out: AuthorRow[] = []
+  for (const [author, authorRows] of groupCurrent) {
+    const stageValues = STAGES.map((stage) => ({
+      stage,
+      value: aggregateValue(nonNullStageValues(authorRows, stage), mode) ?? 0,
+    }))
+    const sum = stageValues.reduce((s, v) => s + v.value, 0)
+    const composition = stageValues.map(({ stage, value }) => ({
+      stage,
+      ratio: sum > 0 ? value / sum : 0,
+    }))
+
+    const total = aggregateValue(
+      authorRows.map((r) => r.totalTime).filter((v): v is number => v !== null),
+      mode,
+    )
+
+    let mainDriver: CycleStage | null = null
+    let mainDriverValue = -Infinity
+    for (const sv of stageValues) {
+      if (sv.value > 0 && sv.value > mainDriverValue) {
+        mainDriverValue = sv.value
+        mainDriver = sv.stage
+      }
+    }
+
+    const reviewP75 = percentile(nonNullStageValues(authorRows, 'review'), 0.75)
+
+    const prevList = groupPrev.get(author) ?? []
+    const prevTotal = aggregateValue(
+      prevList.map((r) => r.totalTime).filter((v): v is number => v !== null),
+      mode,
+    )
+
+    out.push({
+      author,
+      displayName: authorDisplay(authorRows[0]),
+      prCount: authorRows.length,
+      composition,
+      total,
+      mainDriver,
+      reviewP75,
+      changeVsPrev: makeDelta(total, prevTotal),
+    })
+  }
+
+  out.sort((a, b) => {
+    if (b.prCount !== a.prCount) return b.prCount - a.prCount
+    return a.displayName.localeCompare(b.displayName)
+  })
+
+  return out
+}
+
+// --- Longest PRs ---
+
+export interface LongestPrRow {
+  repositoryId: string
+  repo: string
+  number: number
+  title: string
+  url: string
+  author: string
+  authorDisplayName: string | null
+  state: 'open' | 'closed' | 'merged'
+  totalTime: number
+  codingTime: number | null
+  pickupTime: number | null
+  reviewTime: number | null
+  deployTime: number | null
+  bottleneck: CycleStage | null
+  updatedAt: string
+}
+
+export function computeLongestPrs(
+  rows: CycleTimeRawRow[],
+  limit = 10,
+): LongestPrRow[] {
+  const filtered = rows.filter(
+    (r): r is CycleTimeRawRow & { totalTime: number; releasedAt: string } =>
+      r.totalTime !== null && r.releasedAt !== null,
+  )
+  filtered.sort((a, b) => b.totalTime - a.totalTime)
+  return filtered.slice(0, limit).map((r) => ({
+    repositoryId: r.repositoryId,
+    repo: r.repo,
+    number: r.number,
+    title: r.title,
+    url: r.url,
+    author: r.author,
+    authorDisplayName: r.authorDisplayName,
+    state: r.state,
+    totalTime: r.totalTime,
+    codingTime: r.codingTime,
+    pickupTime: r.pickupTime,
+    reviewTime: r.reviewTime,
+    deployTime: r.deployTime,
+    bottleneck: bottleneckStage(r),
+    updatedAt: r.releasedAt,
+  }))
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
@@ -446,9 +446,13 @@ export function computeAuthorRows(
   prevRows: CycleTimeRawRow[],
   mode: MetricMode,
 ): AuthorRow[] {
+  // Group by lower-cased login: GitHub treats logins case-insensitively and
+  // the tenant DB joins on `lower(author) = lower(login)`. Without this,
+  // PRs whose author column happens to differ in casing across rows split
+  // the same person into multiple table rows.
   const groupCurrent = new Map<string, CycleTimeRawRow[]>()
   for (const r of rows) {
-    const key = r.author
+    const key = r.author.toLowerCase()
     const list = groupCurrent.get(key)
     if (list) list.push(r)
     else groupCurrent.set(key, [r])
@@ -456,14 +460,14 @@ export function computeAuthorRows(
 
   const groupPrev = new Map<string, CycleTimeRawRow[]>()
   for (const r of prevRows) {
-    const key = r.author
+    const key = r.author.toLowerCase()
     const list = groupPrev.get(key)
     if (list) list.push(r)
     else groupPrev.set(key, [r])
   }
 
   const out: AuthorRow[] = []
-  for (const [author, authorRows] of groupCurrent) {
+  for (const [authorKey, authorRows] of groupCurrent) {
     const buckets = partitionStageValues(authorRows)
     const stageValues = STAGES.map((stage) => ({
       stage,
@@ -488,11 +492,11 @@ export function computeAuthorRows(
     const total = aggregateValue(nonNullTotalValues(authorRows), mode)
     const reviewP75 = percentile(buckets.review, 0.75)
 
-    const prevList = groupPrev.get(author) ?? []
+    const prevList = groupPrev.get(authorKey) ?? []
     const prevTotal = aggregateValue(nonNullTotalValues(prevList), mode)
 
     out.push({
-      author,
+      author: authorRows[0].author,
       displayName: authorDisplay(authorRows[0]),
       prCount: authorRows.length,
       composition,

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
@@ -421,11 +421,16 @@ export function computeInsights(args: {
 
 // --- By Author ---
 
+export interface StageRatio {
+  stage: CycleStage
+  ratio: number
+}
+
 export interface AuthorRow {
   author: string
   displayName: string
   prCount: number
-  composition: { stage: CycleStage; ratio: number }[]
+  composition: StageRatio[]
   total: number | null
   mainDriver: CycleStage | null
   reviewP75: number | null
@@ -468,7 +473,7 @@ export function computeAuthorRows(
 
     let mainDriver: CycleStage | null = null
     let mainDriverValue = -Infinity
-    const composition: AuthorRow['composition'] = []
+    const composition: StageRatio[] = []
     for (const sv of stageValues) {
       composition.push({
         stage: sv.stage,

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/queries.server.ts
@@ -1,0 +1,131 @@
+import type { FilterCountStats } from '~/app/libs/pr-title-filter.server'
+import {
+  excludeBots,
+  excludePrTitleFilters,
+  filteredPullRequestCount,
+} from '~/app/libs/tenant-query.server'
+import { getTenantDb } from '~/app/services/tenant-db.server'
+import type { OrganizationId } from '~/app/types/organization'
+
+/**
+ * Cycle time raw rows for released PRs in [sinceDate, untilDate).
+ * `untilDate` を null にすると上限なしで取得する（current period 用）。
+ */
+export const getCycleTimeRawData = async (
+  organizationId: OrganizationId,
+  sinceDate: string,
+  untilDate: string | null,
+  teamId?: string | null,
+  repositoryId?: string | null,
+  normalizedPatterns: readonly string[] = [],
+) => {
+  const tenantDb = getTenantDb(organizationId)
+  return await tenantDb
+    .selectFrom('pullRequests')
+    .innerJoin('repositories', 'pullRequests.repositoryId', 'repositories.id')
+    .leftJoin('companyGithubUsers', (join) =>
+      join.onRef(
+        (eb) => eb.fn('lower', ['pullRequests.author']),
+        '=',
+        (eb) => eb.fn('lower', ['companyGithubUsers.login']),
+      ),
+    )
+    .where('pullRequests.releasedAt', 'is not', null)
+    .where('pullRequests.totalTime', 'is not', null)
+    .where('pullRequests.releasedAt', '>=', sinceDate)
+    .$if(untilDate !== null, (qb) =>
+      qb.where('pullRequests.releasedAt', '<', untilDate as string),
+    )
+    .$if(teamId != null, (qb) =>
+      qb.where('repositories.teamId', '=', teamId as string),
+    )
+    .$if(repositoryId != null, (qb) =>
+      qb.where('pullRequests.repositoryId', '=', repositoryId as string),
+    )
+    .where(excludeBots)
+    .where(excludePrTitleFilters(normalizedPatterns))
+    .select([
+      'pullRequests.repositoryId',
+      'pullRequests.repo',
+      'pullRequests.number',
+      'pullRequests.title',
+      'pullRequests.url',
+      'pullRequests.author',
+      'companyGithubUsers.displayName as authorDisplayName',
+      'pullRequests.state',
+      'pullRequests.pullRequestCreatedAt',
+      'pullRequests.mergedAt',
+      'pullRequests.releasedAt',
+      'pullRequests.codingTime',
+      'pullRequests.pickupTime',
+      'pullRequests.reviewTime',
+      'pullRequests.deployTime',
+      'pullRequests.totalTime',
+    ])
+    .execute()
+}
+
+/**
+ * バナー用 excludedCount 算出のため、cycle time 母集団の distinct PR 件数を 1 クエリで返す。
+ */
+export const countCycleTimePullRequests = async (
+  organizationId: OrganizationId,
+  sinceDate: string,
+  teamId?: string | null,
+  repositoryId?: string | null,
+  normalizedPatterns: readonly string[] = [],
+): Promise<FilterCountStats> => {
+  const tenantDb = getTenantDb(organizationId)
+  const row = await tenantDb
+    .selectFrom('pullRequests')
+    .innerJoin('repositories', 'pullRequests.repositoryId', 'repositories.id')
+    .leftJoin('companyGithubUsers', (join) =>
+      join.onRef(
+        (eb) => eb.fn('lower', ['pullRequests.author']),
+        '=',
+        (eb) => eb.fn('lower', ['companyGithubUsers.login']),
+      ),
+    )
+    .where('pullRequests.releasedAt', 'is not', null)
+    .where('pullRequests.totalTime', 'is not', null)
+    .where('pullRequests.releasedAt', '>=', sinceDate)
+    .$if(teamId != null, (qb) =>
+      qb.where('repositories.teamId', '=', teamId as string),
+    )
+    .$if(repositoryId != null, (qb) =>
+      qb.where('pullRequests.repositoryId', '=', repositoryId as string),
+    )
+    .where(excludeBots)
+    .select((eb) => [
+      eb.fn.countAll<number>().as('unfiltered'),
+      filteredPullRequestCount(normalizedPatterns)(eb).as('filtered'),
+    ])
+    .executeTakeFirstOrThrow()
+  return {
+    unfiltered: Number(row.unfiltered),
+    filtered: Number(row.filtered),
+  }
+}
+
+export interface CycleTimeRepositoryOption {
+  id: string
+  owner: string
+  repo: string
+}
+
+/**
+ * Repository filter dropdown 用の repository 一覧。team filter があればそれで絞り込む。
+ */
+export const listCycleTimeRepositories = async (
+  organizationId: OrganizationId,
+  teamId?: string | null,
+): Promise<CycleTimeRepositoryOption[]> => {
+  const tenantDb = getTenantDb(organizationId)
+  return await tenantDb
+    .selectFrom('repositories')
+    .$if(teamId != null, (qb) => qb.where('teamId', '=', teamId as string))
+    .select(['id', 'owner', 'repo'])
+    .orderBy('owner')
+    .orderBy('repo')
+    .execute()
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/index.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/index.tsx
@@ -121,12 +121,10 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
     : null
 
   const sf = filter.showFiltered ? 't' : 'f'
-  // Pattern signature must invalidate the cache when patterns change so users
-  // don't see stale rows for ~5 min after editing the filter list.
-  const patternSignature =
-    filter.normalizedPatterns.length === 0
-      ? 'none'
-      : [...filter.normalizedPatterns].sort().join('|')
+  // Pattern signature must invalidate the cache when patterns change. Use
+  // JSON.stringify so a pattern that legitimately contains the separator
+  // character can't collide with a different list.
+  const patternSignature = JSON.stringify([...filter.normalizedPatterns].sort())
   // metricMode is intentionally NOT in the cache key — raw rows are mode-
   // agnostic, the median/average choice is applied in clientLoader.
   const cacheKey = `cycle-time:${teamParam ?? 'all'}:${repositoryId ?? 'all'}:${periodMonths}:sf=${sf}:patterns=${patternSignature}`

--- a/app/routes/$orgSlug/analysis/cycle-time/index.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/index.tsx
@@ -1,0 +1,462 @@
+import { XIcon } from 'lucide-react'
+import { useMemo, useState } from 'react'
+import { useSearchParams } from 'react-router'
+import {
+  PageHeader,
+  PageHeaderActions,
+  PageHeaderDescription,
+  PageHeaderHeading,
+  PageHeaderTitle,
+} from '~/app/components/layout/page-header'
+import { Button } from '~/app/components/ui/button'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '~/app/components/ui/select'
+import { Stack } from '~/app/components/ui/stack'
+import { ToggleGroup, ToggleGroupItem } from '~/app/components/ui/toggle-group'
+import { calcSinceDate } from '~/app/libs/date-utils'
+import dayjs from '~/app/libs/dayjs'
+import { isOrgAdmin } from '~/app/libs/member-role'
+import {
+  computeExcludedCount,
+  loadPrFilterState,
+} from '~/app/libs/pr-title-filter.server'
+import {
+  orgContext,
+  teamContext,
+  timezoneContext,
+} from '~/app/middleware/context'
+import { PrTitleFilterStatus } from '~/app/routes/$orgSlug/+components/pr-title-filter-status'
+import { getOrgCachedData } from '~/app/services/cache.server'
+import { BottleneckMixCard } from './+components/bottleneck-mix-card'
+import { ByAuthorTable } from './+components/by-author-table'
+import { InsightsCard } from './+components/insights-card'
+import { KpiCards } from './+components/kpi-cards'
+import { LongestPrsTable } from './+components/longest-prs-table'
+import { WeeklyTrendChart } from './+components/weekly-trend-chart'
+import {
+  computeAuthorRows,
+  computeBottleneckMix,
+  computeInsights,
+  computeKpi,
+  computeLongestPrs,
+  computeWeeklyTrend,
+  filterRowsByWeek,
+  type MetricMode,
+} from './+functions/aggregate'
+import {
+  countCycleTimePullRequests,
+  getCycleTimeRawData,
+  listCycleTimeRepositories,
+} from './+functions/queries.server'
+import type { Route } from './+types/index'
+
+export const handle = {
+  breadcrumb: () => ({ label: 'Cycle Time' }),
+}
+
+const PERIOD_OPTIONS = [
+  { value: '1', label: '1 month' },
+  { value: '3', label: '3 months' },
+  { value: '6', label: '6 months' },
+  { value: '12', label: '1 year' },
+] as const
+
+const PERIOD_LABEL: Record<number, string> = {
+  1: '1 month',
+  3: '3 months',
+  6: '6 months',
+  12: '1 year',
+}
+
+const VALID_PERIODS = [1, 3, 6, 12] as const
+
+const VALID_METRICS: readonly MetricMode[] = ['median', 'average'] as const
+
+export const loader = async ({ request, context }: Route.LoaderArgs) => {
+  const { organization, membership } = context.get(orgContext)
+  const timezone = context.get(timezoneContext)
+  const teamParam = context.get(teamContext)
+
+  const url = new URL(request.url)
+
+  const periodParam = url.searchParams.get('period')
+  const periodMonths = VALID_PERIODS.includes(
+    Number(periodParam) as (typeof VALID_PERIODS)[number],
+  )
+    ? Number(periodParam)
+    : 3
+
+  const metricParam = url.searchParams.get('metric')
+  const metricMode: MetricMode = VALID_METRICS.includes(
+    metricParam as MetricMode,
+  )
+    ? (metricParam as MetricMode)
+    : 'median'
+
+  const repositoryParamRaw = url.searchParams.get('repository')
+  const repositoryParam =
+    repositoryParamRaw && repositoryParamRaw.length > 0
+      ? repositoryParamRaw
+      : null
+
+  const sinceDate = calcSinceDate(periodMonths, timezone)
+  const prevSinceDate = calcSinceDate(periodMonths * 2, timezone)
+  const now = dayjs.utc().toISOString()
+
+  const filter = await loadPrFilterState(request, organization.id)
+
+  const sf = filter.showFiltered ? 't' : 'f'
+  const cacheKey = `cycle-time:${teamParam ?? 'all'}:${repositoryParam ?? 'all'}:${periodMonths}:${metricMode}:sf=${sf}`
+  const FIVE_MINUTES = 5 * 60 * 1000
+
+  const repositories = await listCycleTimeRepositories(
+    organization.id,
+    teamParam,
+  )
+
+  // Validate repository param against the team-scoped list
+  const repositoryId = repositories.some((r) => r.id === repositoryParam)
+    ? repositoryParam
+    : null
+
+  const [[currentRows, previousRows], excludedCount] = await Promise.all([
+    getOrgCachedData(
+      organization.id,
+      cacheKey,
+      () =>
+        Promise.all([
+          getCycleTimeRawData(
+            organization.id,
+            sinceDate,
+            null,
+            teamParam,
+            repositoryId,
+            filter.normalizedPatterns,
+          ),
+          getCycleTimeRawData(
+            organization.id,
+            prevSinceDate,
+            sinceDate,
+            teamParam,
+            repositoryId,
+            filter.normalizedPatterns,
+          ),
+        ]),
+      FIVE_MINUTES,
+    ),
+    computeExcludedCount(filter, (patterns) =>
+      countCycleTimePullRequests(
+        organization.id,
+        sinceDate,
+        teamParam,
+        repositoryId,
+        patterns,
+      ),
+    ),
+  ])
+
+  return {
+    currentRows,
+    previousRows,
+    sinceDate,
+    untilDate: now,
+    timezone,
+    periodMonths,
+    metricMode,
+    repositoryId,
+    repositories,
+    excludedCount,
+    filterActive: filter.filterActive,
+    showFiltered: filter.showFiltered,
+    hasAnyEnabledPattern: filter.hasAnyEnabledPattern,
+    isAdmin: isOrgAdmin(membership.role),
+  }
+}
+
+export const clientLoader = async ({
+  serverLoader,
+}: Route.ClientLoaderArgs) => {
+  const data = await serverLoader()
+
+  const weekly = computeWeeklyTrend(
+    data.currentRows,
+    data.sinceDate,
+    data.untilDate,
+    data.timezone,
+    data.metricMode,
+  )
+
+  const kpi = computeKpi(data.currentRows, data.previousRows, data.metricMode)
+  const mix = computeBottleneckMix(data.currentRows, data.metricMode)
+  const prevMix = computeBottleneckMix(data.previousRows, data.metricMode)
+  const insights = computeInsights({
+    current: data.currentRows,
+    previous: data.previousRows,
+    weekly,
+    mix,
+    prevMix,
+    mode: data.metricMode,
+  })
+  const authors = computeAuthorRows(
+    data.currentRows,
+    data.previousRows,
+    data.metricMode,
+  )
+  const longest = computeLongestPrs(data.currentRows, 10)
+
+  return {
+    currentRows: data.currentRows,
+    previousRows: data.previousRows,
+    timezone: data.timezone,
+    kpi,
+    weekly,
+    mix,
+    insights,
+    authors,
+    longest,
+    periodMonths: data.periodMonths,
+    metricMode: data.metricMode,
+    repositoryId: data.repositoryId,
+    repositories: data.repositories,
+    excludedCount: data.excludedCount,
+    filterActive: data.filterActive,
+    showFiltered: data.showFiltered,
+    hasAnyEnabledPattern: data.hasAnyEnabledPattern,
+    isAdmin: data.isAdmin,
+  }
+}
+clientLoader.hydrate = true as const
+
+export function HydrateFallback() {
+  return (
+    <Stack>
+      <PageHeader>
+        <PageHeaderHeading>
+          <PageHeaderTitle>Cycle Time</PageHeaderTitle>
+          <PageHeaderDescription>Loading…</PageHeaderDescription>
+        </PageHeaderHeading>
+      </PageHeader>
+    </Stack>
+  )
+}
+
+export default function CycleTimePage({
+  loaderData: {
+    currentRows,
+    previousRows,
+    timezone,
+    kpi,
+    weekly,
+    mix,
+    insights,
+    authors,
+    longest,
+    periodMonths,
+    metricMode,
+    repositoryId,
+    repositories,
+    excludedCount,
+    filterActive,
+    showFiltered,
+    hasAnyEnabledPattern,
+    isAdmin,
+  },
+}: Route.ComponentProps) {
+  const [, setSearchParams] = useSearchParams()
+  const [selectedWeek, setSelectedWeek] = useState<string | null>(null)
+
+  const periodLabel = PERIOD_LABEL[periodMonths] ?? `${periodMonths} months`
+
+  // Reset selection if the underlying period no longer contains it (e.g. user
+  // changed period / filters and the selected week disappeared).
+  const selectedWeekValid =
+    selectedWeek !== null && weekly.some((w) => w.weekStart === selectedWeek)
+  const effectiveSelectedWeek = selectedWeekValid ? selectedWeek : null
+
+  const drilldown = useMemo(() => {
+    if (effectiveSelectedWeek === null) {
+      return { mix, authors, longest, prCount: kpi.prCount }
+    }
+    const weekRows = filterRowsByWeek(
+      currentRows,
+      effectiveSelectedWeek,
+      timezone,
+    )
+    const prevWeekRows = filterRowsByWeek(
+      previousRows,
+      effectiveSelectedWeek,
+      timezone,
+    )
+    return {
+      mix: computeBottleneckMix(weekRows, metricMode),
+      authors: computeAuthorRows(weekRows, prevWeekRows, metricMode),
+      longest: computeLongestPrs(weekRows, 10),
+      prCount: weekRows.length,
+    }
+  }, [
+    effectiveSelectedWeek,
+    currentRows,
+    previousRows,
+    timezone,
+    metricMode,
+    mix,
+    authors,
+    longest,
+    kpi.prCount,
+  ])
+
+  const selectedWeekPoint = effectiveSelectedWeek
+    ? weekly.find((w) => w.weekStart === effectiveSelectedWeek)
+    : null
+
+  return (
+    <Stack gap="6">
+      <PageHeader>
+        <PageHeaderHeading>
+          <PageHeaderTitle>Cycle Time</PageHeaderTitle>
+          <PageHeaderDescription>
+            {periodLabel} trend of PR delivery speed and bottlenecks.
+          </PageHeaderDescription>
+        </PageHeaderHeading>
+        <PageHeaderActions className="flex flex-wrap">
+          <PrTitleFilterStatus
+            excludedCount={excludedCount}
+            filterActive={filterActive}
+            showFiltered={showFiltered}
+            hasAnyEnabledPattern={hasAnyEnabledPattern}
+            isAdmin={isAdmin}
+          />
+          <Select
+            value={repositoryId ?? 'all'}
+            onValueChange={(value) => {
+              setSearchParams((prev) => {
+                if (value === 'all') {
+                  prev.delete('repository')
+                } else {
+                  prev.set('repository', value)
+                }
+                return prev
+              })
+            }}
+          >
+            <SelectTrigger className="w-[200px]">
+              <SelectValue placeholder="All repositories" />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value="all">All repositories</SelectItem>
+              {repositories.map((r) => (
+                <SelectItem key={r.id} value={r.id}>
+                  {r.owner}/{r.repo}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <Select
+            value={String(periodMonths)}
+            onValueChange={(value) => {
+              setSearchParams((prev) => {
+                if (value === '3') {
+                  prev.delete('period')
+                } else {
+                  prev.set('period', value)
+                }
+                return prev
+              })
+            }}
+          >
+            <SelectTrigger className="w-[130px]">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {PERIOD_OPTIONS.map((opt) => (
+                <SelectItem key={opt.value} value={opt.value}>
+                  {opt.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <ToggleGroup
+            type="single"
+            variant="outline"
+            size="sm"
+            value={metricMode}
+            onValueChange={(value) => {
+              if (!value) return
+              setSearchParams((prev) => {
+                if (value === 'median') {
+                  prev.delete('metric')
+                } else {
+                  prev.set('metric', value)
+                }
+                return prev
+              })
+            }}
+          >
+            <ToggleGroupItem value="median">Median</ToggleGroupItem>
+            <ToggleGroupItem value="average">Average</ToggleGroupItem>
+          </ToggleGroup>
+        </PageHeaderActions>
+      </PageHeader>
+
+      <KpiCards kpi={kpi} mode={metricMode} periodLabel={periodLabel} />
+
+      <div className="grid grid-cols-1 gap-4 lg:grid-cols-3">
+        <div className="lg:col-span-2">
+          <WeeklyTrendChart
+            weeks={weekly}
+            mode={metricMode}
+            selectedWeek={effectiveSelectedWeek}
+            onSelectWeek={setSelectedWeek}
+          />
+        </div>
+        <div className="space-y-4">
+          <BottleneckMixCard mix={drilldown.mix} mode={metricMode} />
+          <InsightsCard insights={insights} />
+        </div>
+      </div>
+
+      {selectedWeekPoint !== null && selectedWeekPoint !== undefined && (
+        <DrilldownBanner
+          weekLabel={selectedWeekPoint.weekLabel}
+          prCount={drilldown.prCount}
+          onClear={() => setSelectedWeek(null)}
+        />
+      )}
+
+      <ByAuthorTable rows={drilldown.authors} mode={metricMode} />
+      <LongestPrsTable rows={drilldown.longest} />
+    </Stack>
+  )
+}
+
+function DrilldownBanner({
+  weekLabel,
+  prCount,
+  onClear,
+}: {
+  weekLabel: string
+  prCount: number
+  onClear: () => void
+}) {
+  return (
+    <div className="bg-muted/50 flex flex-wrap items-center justify-between gap-2 rounded-md border px-3 py-2 text-sm">
+      <span>
+        Drilled down to week of <span className="font-medium">{weekLabel}</span>{' '}
+        ·{' '}
+        <span className="tabular-nums">
+          {prCount} PR{prCount === 1 ? '' : 's'}
+        </span>
+        . Bottleneck Mix and tables below reflect this week only.
+      </span>
+      <Button variant="ghost" size="sm" onClick={onClear} className="h-7">
+        <XIcon className="size-4" />
+        Clear
+      </Button>
+    </div>
+  )
+}

--- a/app/routes/$orgSlug/analysis/cycle-time/index.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/index.tsx
@@ -110,12 +110,6 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
 
   const filter = await loadPrFilterState(request, organization.id)
 
-  const sf = filter.showFiltered ? 't' : 'f'
-  // metricMode is intentionally NOT in the cache key — raw rows are mode-
-  // agnostic, the median/average choice is applied in clientLoader.
-  const cacheKey = `cycle-time:${teamParam ?? 'all'}:${repositoryParam ?? 'all'}:${periodMonths}:sf=${sf}`
-  const FIVE_MINUTES = 5 * 60 * 1000
-
   const repositories = await listCycleTimeRepositories(
     organization.id,
     teamParam,
@@ -125,6 +119,18 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
   const repositoryId = repositories.some((r) => r.id === repositoryParam)
     ? repositoryParam
     : null
+
+  const sf = filter.showFiltered ? 't' : 'f'
+  // Pattern signature must invalidate the cache when patterns change so users
+  // don't see stale rows for ~5 min after editing the filter list.
+  const patternSignature =
+    filter.normalizedPatterns.length === 0
+      ? 'none'
+      : [...filter.normalizedPatterns].sort().join('|')
+  // metricMode is intentionally NOT in the cache key — raw rows are mode-
+  // agnostic, the median/average choice is applied in clientLoader.
+  const cacheKey = `cycle-time:${teamParam ?? 'all'}:${repositoryId ?? 'all'}:${periodMonths}:sf=${sf}:patterns=${patternSignature}`
+  const FIVE_MINUTES = 5 * 60 * 1000
 
   const [[currentRows, previousRows], excludedCount] = await Promise.all([
     getOrgCachedData(
@@ -213,7 +219,6 @@ export const clientLoader = async ({
 
   return {
     currentRows: data.currentRows,
-    previousRows: data.previousRows,
     timezone: data.timezone,
     kpi,
     weekly,
@@ -250,7 +255,6 @@ export function HydrateFallback() {
 export default function CycleTimePage({
   loaderData: {
     currentRows,
-    previousRows,
     timezone,
     kpi,
     weekly,
@@ -287,18 +291,16 @@ export default function CycleTimePage({
       effectiveSelectedWeek,
       timezone,
     )
-    const prevWeekRows = filterRowsByWeek(
-      previousRows,
-      effectiveSelectedWeek,
-      timezone,
-    )
+    // No previous-period rows: the "same week" of the prior period isn't a
+    // meaningful comparison axis when drilling into a single week, so the
+    // vs-prev column is intentionally blank during drill-down.
     return {
       mix: computeBottleneckMix(weekRows, metricMode),
-      authors: computeAuthorRows(weekRows, prevWeekRows, metricMode),
+      authors: computeAuthorRows(weekRows, [], metricMode),
       longest: computeLongestPrs(weekRows, 10),
       prCount: weekRows.length,
     }
-  }, [effectiveSelectedWeek, currentRows, previousRows, timezone, metricMode])
+  }, [effectiveSelectedWeek, currentRows, timezone, metricMode])
 
   const drilldown = weekDrilldown ?? {
     mix,

--- a/app/routes/$orgSlug/analysis/cycle-time/index.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/index.tsx
@@ -111,7 +111,9 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
   const filter = await loadPrFilterState(request, organization.id)
 
   const sf = filter.showFiltered ? 't' : 'f'
-  const cacheKey = `cycle-time:${teamParam ?? 'all'}:${repositoryParam ?? 'all'}:${periodMonths}:${metricMode}:sf=${sf}`
+  // metricMode is intentionally NOT in the cache key — raw rows are mode-
+  // agnostic, the median/average choice is applied in clientLoader.
+  const cacheKey = `cycle-time:${teamParam ?? 'all'}:${repositoryParam ?? 'all'}:${periodMonths}:sf=${sf}`
   const FIVE_MINUTES = 5 * 60 * 1000
 
   const repositories = await listCycleTimeRepositories(
@@ -278,10 +280,8 @@ export default function CycleTimePage({
     selectedWeek !== null && weekly.some((w) => w.weekStart === selectedWeek)
   const effectiveSelectedWeek = selectedWeekValid ? selectedWeek : null
 
-  const drilldown = useMemo(() => {
-    if (effectiveSelectedWeek === null) {
-      return { mix, authors, longest, prCount: kpi.prCount }
-    }
+  const weekDrilldown = useMemo(() => {
+    if (effectiveSelectedWeek === null) return null
     const weekRows = filterRowsByWeek(
       currentRows,
       effectiveSelectedWeek,
@@ -298,17 +298,14 @@ export default function CycleTimePage({
       longest: computeLongestPrs(weekRows, 10),
       prCount: weekRows.length,
     }
-  }, [
-    effectiveSelectedWeek,
-    currentRows,
-    previousRows,
-    timezone,
-    metricMode,
+  }, [effectiveSelectedWeek, currentRows, previousRows, timezone, metricMode])
+
+  const drilldown = weekDrilldown ?? {
     mix,
     authors,
     longest,
-    kpi.prCount,
-  ])
+    prCount: kpi.prCount,
+  }
 
   const selectedWeekPoint = effectiveSelectedWeek
     ? weekly.find((w) => w.weekStart === effectiveSelectedWeek)
@@ -420,7 +417,7 @@ export default function CycleTimePage({
         </div>
       </div>
 
-      {selectedWeekPoint !== null && selectedWeekPoint !== undefined && (
+      {selectedWeekPoint && (
         <DrilldownBanner
           weekLabel={selectedWeekPoint.weekLabel}
           prCount={drilldown.prCount}

--- a/app/routes/$orgSlug/analysis/feedbacks/_index/+components/feedback-columns.tsx
+++ b/app/routes/$orgSlug/analysis/feedbacks/_index/+components/feedback-columns.tsx
@@ -1,5 +1,6 @@
 import { type ColumnDef, createColumnHelper } from '@tanstack/react-table'
 import { ArrowDownIcon, ArrowUpIcon, MinusIcon } from 'lucide-react'
+import { ExternalLink } from '~/app/components/external-link'
 import { Badge } from '~/app/components/ui/badge'
 import {
   Tooltip,
@@ -62,17 +63,15 @@ export function createFeedbackColumns(
     columnHelper.accessor('prTitle', {
       header: 'PR',
       cell: (info) => (
-        <a
+        <ExternalLink
           href={info.row.original.prUrl}
-          target="_blank"
-          rel="noopener noreferrer"
           className="hover:underline"
         >
           <span className="text-muted-foreground mr-1">
             #{info.row.original.pullRequestNumber}
           </span>
           <span className="line-clamp-1">{info.getValue()}</span>
-        </a>
+        </ExternalLink>
       ),
       enableSorting: false,
     }),

--- a/app/routes/$orgSlug/analysis/inventory/+functions/aggregate.ts
+++ b/app/routes/$orgSlug/analysis/inventory/+functions/aggregate.ts
@@ -1,3 +1,4 @@
+import { startOfWeekMonday } from '~/app/libs/date-utils'
 import dayjs from '~/app/libs/dayjs'
 
 export interface OpenPRInventoryRawRow {
@@ -23,12 +24,6 @@ export interface InventoryWeekPoint {
 
 export interface OpenPRInventoryAggregation {
   weeks: InventoryWeekPoint[]
-}
-
-function startOfWeekMonday(d: dayjs.Dayjs): dayjs.Dayjs {
-  const day = d.day()
-  const diffToMonday = day === 0 ? -6 : 1 - day
-  return d.startOf('day').add(diffToMonday, 'day')
 }
 
 export function isOpenAtSnapshot(

--- a/app/routes/$orgSlug/analysis/reviews/+components/pr-drill-down-sheet.tsx
+++ b/app/routes/$orgSlug/analysis/reviews/+components/pr-drill-down-sheet.tsx
@@ -9,6 +9,7 @@ import {
   SheetHeader,
   SheetTitle,
 } from '~/app/components/ui/sheet'
+import { formatPrIdentifier } from '~/app/libs/format-pr'
 import { parseRiskAreas } from '~/app/libs/pr-classify'
 import { HidePRsByTitleMenu } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
 
@@ -59,7 +60,7 @@ export function PRDrillDownSheet({
           <div className="divide-y">
             {prs.map((pr) => (
               <div
-                key={`${pr.repo}#${pr.number}`}
+                key={formatPrIdentifier(pr.repo, pr.number)}
                 className="flex flex-col gap-1 py-3"
               >
                 <div className="flex items-center gap-2">
@@ -69,7 +70,7 @@ export function PRDrillDownSheet({
                     target="_blank"
                     rel="noreferrer noopener"
                   >
-                    {pr.repo}#{pr.number}
+                    {formatPrIdentifier(pr.repo, pr.number)}
                     <ExternalLinkIcon className="ml-0.5 inline-block h-3 w-3" />
                   </a>
                   <SizeBadge complexity={pr.size ?? null} />

--- a/app/routes/$orgSlug/analysis/reviews/+components/pr-drill-down-sheet.tsx
+++ b/app/routes/$orgSlug/analysis/reviews/+components/pr-drill-down-sheet.tsx
@@ -1,4 +1,5 @@
 import { ExternalLinkIcon } from 'lucide-react'
+import { ExternalLink } from '~/app/components/external-link'
 import { SizeBadge } from '~/app/components/size-badge'
 import { Badge } from '~/app/components/ui'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
@@ -64,15 +65,13 @@ export function PRDrillDownSheet({
                 className="flex flex-col gap-1 py-3"
               >
                 <div className="flex items-center gap-2">
-                  <a
+                  <ExternalLink
                     href={pr.url}
                     className="text-muted-foreground shrink-0 text-xs hover:underline"
-                    target="_blank"
-                    rel="noreferrer noopener"
                   >
                     {formatPrIdentifier(pr.repo, pr.number)}
                     <ExternalLinkIcon className="ml-0.5 inline-block h-3 w-3" />
-                  </a>
+                  </ExternalLink>
                   <SizeBadge complexity={pr.size ?? null} />
                   <span className="text-muted-foreground flex items-center gap-1 text-xs">
                     <Avatar className="size-4">
@@ -95,14 +94,12 @@ export function PRDrillDownSheet({
                     <HidePRsByTitleMenu title={pr.title} />
                   </div>
                 </div>
-                <a
+                <ExternalLink
                   href={pr.url}
                   className="truncate text-sm hover:underline"
-                  target="_blank"
-                  rel="noreferrer noopener"
                 >
                   {pr.title}
-                </a>
+                </ExternalLink>
                 {(pr.complexityReason || pr.riskAreas) && (
                   <div className="space-y-0.5 text-xs">
                     {pr.complexityReason && (

--- a/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
+++ b/app/routes/$orgSlug/settings/_index/+forms/integration-settings.tsx
@@ -13,6 +13,7 @@ import { toast } from 'sonner'
 import type { z } from 'zod'
 import type { ConfirmDialogData } from '~/app/components/confirm-dialog'
 import { ConfirmDialog } from '~/app/components/confirm-dialog'
+import { ExternalLink } from '~/app/components/external-link'
 import Github from '~/app/components/icons/Github'
 import {
   Alert,
@@ -105,10 +106,10 @@ function InstallationCard({ link }: { link: GithubAppLinkSummary }) {
       <HStack className="flex-wrap">
         {settingsUrl && (
           <Button variant="outline" size="sm" asChild>
-            <a href={settingsUrl} target="_blank" rel="noreferrer">
+            <ExternalLink href={settingsUrl}>
               <ExternalLinkIcon className="mr-1 h-4 w-4" />
               GitHub App settings
-            </a>
+            </ExternalLink>
           </Button>
         )}
         <Button

--- a/app/routes/$orgSlug/settings/github-users._index/+components/data-table-toolbar.tsx
+++ b/app/routes/$orgSlug/settings/github-users._index/+components/data-table-toolbar.tsx
@@ -2,6 +2,7 @@ import type { Table } from '@tanstack/react-table'
 import { ExternalLinkIcon, LoaderIcon, PlusIcon, XIcon } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { useFetcher, useSearchParams } from 'react-router'
+import { ExternalLink } from '~/app/components/external-link'
 import { SearchInput } from '~/app/components/search-input'
 import {
   Select,
@@ -209,15 +210,13 @@ export function DataTableToolbar<TData>({
                             </span>
                           )}
                         </div>
-                        <a
+                        <ExternalLink
                           href={`https://github.com/${user.login}`}
-                          target="_blank"
-                          rel="noopener noreferrer"
                           className="text-muted-foreground hover:text-foreground ml-2 shrink-0"
                           onClick={(e) => e.stopPropagation()}
                         >
                           <ExternalLinkIcon className="h-3.5 w-3.5" />
-                        </a>
+                        </ExternalLink>
                       </ComboboxItem>
                     )}
                   </ComboboxCollection>

--- a/app/routes/$orgSlug/settings/github-users._index/+components/github-users-columns.tsx
+++ b/app/routes/$orgSlug/settings/github-users._index/+components/github-users-columns.tsx
@@ -1,9 +1,10 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { ExternalLinkIcon } from 'lucide-react'
 import { useState } from 'react'
-import { Link, useFetcher } from 'react-router'
+import { useFetcher } from 'react-router'
 import { ConfirmDialog } from '~/app/components/confirm-dialog'
 import { EditableCell } from '~/app/components/editable-cell'
+import { ExternalLink } from '~/app/components/external-link'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import { Badge } from '~/app/components/ui/badge'
 import {
@@ -142,15 +143,13 @@ export function createColumns(timezone: string): ColumnDef<GithubUserRow>[] {
                 {login.slice(0, 2).toUpperCase()}
               </AvatarFallback>
             </Avatar>
-            <Link
-              to={`https://github.com/${login}`}
-              target="_blank"
-              rel="noopener noreferrer"
+            <ExternalLink
+              href={`https://github.com/${login}`}
               className="inline-flex items-center gap-1 font-medium hover:underline"
             >
               {login}
               <ExternalLinkIcon className="h-3 w-3" />
-            </Link>
+            </ExternalLink>
           </div>
         )
       },

--- a/app/routes/$orgSlug/settings/repositories._index/+components/repo-columns.tsx
+++ b/app/routes/$orgSlug/settings/repositories._index/+components/repo-columns.tsx
@@ -1,7 +1,8 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { AlertTriangleIcon, ExternalLinkIcon } from 'lucide-react'
-import { Link, useFetcher } from 'react-router'
+import { useFetcher } from 'react-router'
 import { match } from 'ts-pattern'
+import { ExternalLink } from '~/app/components/external-link'
 import {
   Select,
   SelectContent,
@@ -133,15 +134,13 @@ export const createColumns = (
       const isBroken = isRepositoryBroken(row.original, integrationMethod)
       return (
         <span className="inline-flex items-center gap-1">
-          <Link
-            to={repoUrl}
-            target="_blank"
-            rel="noopener noreferrer"
+          <ExternalLink
+            href={repoUrl}
             className="inline-flex items-center gap-1 font-medium hover:underline"
           >
             {owner}/{repo}
             <ExternalLinkIcon className="h-3 w-3" />
-          </Link>
+          </ExternalLink>
           {isBroken && <NeedsReconnectionBadge repositoryId={id} />}
         </span>
       )

--- a/app/routes/$orgSlug/throughput/deployed/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/deployed/+columns.tsx
@@ -1,8 +1,8 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { AppSortableHeader } from '~/app/components'
+import { AuthorBadge } from '~/app/components/author-badge'
 import { SizeBadgePopover } from '~/app/components/size-badge-popover'
 import { Badge, HStack } from '~/app/components/ui'
-import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
 import { hidePrActionsColumn } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
@@ -19,23 +19,12 @@ export function createColumns(
       header: ({ column }) => (
         <AppSortableHeader column={column} title="author" />
       ),
-      cell: ({ row }) => {
-        const login = row.original.author
-        return (
-          <div className="flex items-center gap-2">
-            <Avatar className="size-6">
-              <AvatarImage
-                src={`https://github.com/${login}.png?size=48`}
-                alt={login}
-              />
-              <AvatarFallback className="text-xs">
-                {login.slice(0, 2).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-            <span>{row.original.authorDisplayName || login}</span>
-          </div>
-        )
-      },
+      cell: ({ row }) => (
+        <AuthorBadge
+          login={row.original.author}
+          displayName={row.original.authorDisplayName}
+        />
+      ),
       enableHiding: false,
     },
     {

--- a/app/routes/$orgSlug/throughput/deployed/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/deployed/+columns.tsx
@@ -1,6 +1,7 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { AppSortableHeader } from '~/app/components'
 import { AuthorBadge } from '~/app/components/author-badge'
+import { ExternalLink } from '~/app/components/external-link'
 import { SizeBadgePopover } from '~/app/components/size-badge-popover'
 import { Badge, HStack } from '~/app/components/ui'
 import dayjs from '~/app/libs/dayjs'
@@ -47,14 +48,12 @@ export function createColumns(
         <AppSortableHeader column={column} title="title" />
       ),
       cell: ({ row }) => (
-        <a
+        <ExternalLink
           href={row.original.url}
           className="block w-96 truncate text-blue-500 hover:underline"
-          target="_blank"
-          rel="noreferrer noopener"
         >
           <span>{row.original.title}</span>
-        </a>
+        </ExternalLink>
       ),
       enableHiding: false,
     },

--- a/app/routes/$orgSlug/throughput/merged/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/merged/+columns.tsx
@@ -1,8 +1,8 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { AppSortableHeader } from '~/app/components'
+import { AuthorBadge } from '~/app/components/author-badge'
 import { SizeBadgePopover } from '~/app/components/size-badge-popover'
 import { Badge, HStack } from '~/app/components/ui'
-import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
 import { hidePrActionsColumn } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
@@ -19,23 +19,12 @@ export function createColumns(
       header: ({ column }) => (
         <AppSortableHeader column={column} title="author" />
       ),
-      cell: ({ row }) => {
-        const login = row.original.author
-        return (
-          <div className="flex items-center gap-2">
-            <Avatar className="size-6">
-              <AvatarImage
-                src={`https://github.com/${login}.png?size=48`}
-                alt={login}
-              />
-              <AvatarFallback className="text-xs">
-                {login.slice(0, 2).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-            <span>{row.original.authorDisplayName || login}</span>
-          </div>
-        )
-      },
+      cell: ({ row }) => (
+        <AuthorBadge
+          login={row.original.author}
+          displayName={row.original.authorDisplayName}
+        />
+      ),
       enableHiding: false,
     },
     {

--- a/app/routes/$orgSlug/throughput/merged/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/merged/+columns.tsx
@@ -1,6 +1,7 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { AppSortableHeader } from '~/app/components'
 import { AuthorBadge } from '~/app/components/author-badge'
+import { ExternalLink } from '~/app/components/external-link'
 import { SizeBadgePopover } from '~/app/components/size-badge-popover'
 import { Badge, HStack } from '~/app/components/ui'
 import dayjs from '~/app/libs/dayjs'
@@ -47,14 +48,12 @@ export function createColumns(
         <AppSortableHeader column={column} title="title" />
       ),
       cell: ({ row }) => (
-        <a
+        <ExternalLink
           href={row.original.url}
           className="block w-96 truncate text-blue-500 hover:underline"
-          target="_blank"
-          rel="noreferrer noopener"
         >
           <span>{row.original.title}</span>
-        </a>
+        </ExternalLink>
       ),
       enableHiding: false,
     },

--- a/app/routes/$orgSlug/throughput/ongoing/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/ongoing/+columns.tsx
@@ -1,6 +1,7 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { AppSortableHeader } from '~/app/components'
 import { AuthorBadge } from '~/app/components/author-badge'
+import { ExternalLink } from '~/app/components/external-link'
 import { SizeBadgePopover } from '~/app/components/size-badge-popover'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
@@ -46,14 +47,12 @@ export function createColumns(
         <AppSortableHeader column={column} title="title" />
       ),
       cell: ({ row }) => (
-        <a
+        <ExternalLink
           href={row.original.url}
           className="block w-96 truncate text-blue-500 hover:underline"
-          target="_blank"
-          rel="noreferrer noopener"
         >
           <span>{row.original.title}</span>
-        </a>
+        </ExternalLink>
       ),
       enableHiding: false,
     },

--- a/app/routes/$orgSlug/throughput/ongoing/+columns.tsx
+++ b/app/routes/$orgSlug/throughput/ongoing/+columns.tsx
@@ -1,7 +1,7 @@
 import type { ColumnDef } from '@tanstack/react-table'
 import { AppSortableHeader } from '~/app/components'
+import { AuthorBadge } from '~/app/components/author-badge'
 import { SizeBadgePopover } from '~/app/components/size-badge-popover'
-import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import dayjs from '~/app/libs/dayjs'
 import { complexitySortingFn } from '~/app/libs/pr-classify'
 import { hidePrActionsColumn } from '~/app/routes/$orgSlug/+components/hide-prs-by-title-menu'
@@ -18,23 +18,12 @@ export function createColumns(
       header: ({ column }) => (
         <AppSortableHeader column={column} title="author" />
       ),
-      cell: ({ row }) => {
-        const login = row.original.author
-        return (
-          <div className="flex items-center gap-2">
-            <Avatar className="size-6">
-              <AvatarImage
-                src={`https://github.com/${login}.png?size=48`}
-                alt={login}
-              />
-              <AvatarFallback className="text-xs">
-                {login.slice(0, 2).toUpperCase()}
-              </AvatarFallback>
-            </Avatar>
-            <span>{row.original.authorDisplayName || login}</span>
-          </div>
-        )
-      },
+      cell: ({ row }) => (
+        <AuthorBadge
+          login={row.original.author}
+          displayName={row.original.authorDisplayName}
+        />
+      ),
       enableHiding: false,
     },
     {

--- a/app/routes/$orgSlug/workload/$login/index.tsx
+++ b/app/routes/$orgSlug/workload/$login/index.tsx
@@ -1,6 +1,7 @@
 import holiday_jp from '@holiday-jp/holiday_jp'
 import { useMemo } from 'react'
 import { href, Link, useSearchParams } from 'react-router'
+import { ExternalLink } from '~/app/components/external-link'
 import { SizeBadge } from '~/app/components/size-badge'
 import { Avatar, AvatarFallback, AvatarImage } from '~/app/components/ui/avatar'
 import { HStack, Stack } from '~/app/components/ui/stack'
@@ -827,14 +828,12 @@ function PRRow({
   return (
     <div className="flex flex-col gap-1 py-1 text-sm lg:grid lg:grid-cols-[max-content_max-content_minmax(0,1fr)_auto] lg:items-center lg:gap-x-4 lg:gap-y-0">
       <div className="flex min-w-0 items-start justify-between gap-2 lg:contents">
-        <a
+        <ExternalLink
           href={url}
           className="min-w-0 truncate text-blue-500 hover:underline lg:block"
-          target="_blank"
-          rel="noreferrer noopener"
         >
           {formatPrIdentifier(repo, number)}
-        </a>
+        </ExternalLink>
         <div className="flex shrink-0 items-center gap-2 lg:min-w-0">
           <SizeBadge complexity={complexity} />
           {stateStyle && (

--- a/app/routes/$orgSlug/workload/$login/index.tsx
+++ b/app/routes/$orgSlug/workload/$login/index.tsx
@@ -9,6 +9,7 @@ import WeeklyCalendar from '~/app/components/week-calendar'
 import { useTimezone } from '~/app/hooks/use-timezone'
 import { getEndOfWeek, getStartOfWeek } from '~/app/libs/date-utils'
 import dayjs from '~/app/libs/dayjs'
+import { formatPrIdentifier } from '~/app/libs/format-pr'
 import { isOrgAdmin } from '~/app/libs/member-role'
 import { PR_SIZE_RANK } from '~/app/libs/pr-classify'
 import {
@@ -832,7 +833,7 @@ function PRRow({
           target="_blank"
           rel="noreferrer noopener"
         >
-          {repo}#{number}
+          {formatPrIdentifier(repo, number)}
         </a>
         <div className="flex shrink-0 items-center gap-2 lg:min-w-0">
           <SizeBadge complexity={complexity} />

--- a/biome.json
+++ b/biome.json
@@ -1,5 +1,5 @@
 {
-  "$schema": "https://biomejs.dev/schemas/2.4.11/schema.json",
+  "$schema": "https://biomejs.dev/schemas/2.4.12/schema.json",
   "assist": { "actions": { "source": { "organizeImports": "off" } } },
   "files": {
     "includes": [

--- a/docs/rdd/README.md
+++ b/docs/rdd/README.md
@@ -48,3 +48,4 @@ Implemented in #301, #305, #309, #312, #316
 - [issue-283: 1 org に複数の GitHub App installation を紐づける](./issue-283-multiple-github-accounts.md)
 - [issue-307: PR タイトルパターンによる表示フィルター](./issue-307-pr-title-filter.md)
 - [issue-314: PR ポップオーバーを resource route 化して drop-in に使う](./issue-314-pr-popover-resource-route.md)
+- [issue-327: テナント内 Cycle Time ダッシュボード](./issue-327-cycle-time-dashboard.md)

--- a/docs/rdd/issue-327-cycle-time-dashboard.md
+++ b/docs/rdd/issue-327-cycle-time-dashboard.md
@@ -1,0 +1,491 @@
+# Issue #327 RDD: テナント内 Cycle Time ダッシュボード
+
+## 背景・課題
+
+現在、直近数か月の PR サイクルタイム推移は Upflow からデータをエクスポートし、外部 BI ツールで可視化して共有している。この運用だと、以下の問題がある。
+
+- Upflow を見ているメンバーが同じ場所で傾向を確認できない
+- フィルタ、timezone、PR title filter など Upflow 側の表示文脈と外部 BI 側の文脈がずれやすい
+- 外部 BI では「次に誰・どの PR を見るべきか」まで Upflow の導線に接続しにくい
+- ダッシュボードのサンプルやテストに実データ由来の固有名詞が混ざるリスクがある
+
+本 issue では、テナント内メンバー全員が見られる Analysis 配下の Cycle Time 画面を追加し、直近 3 か月のサイクルタイム推移・ボトルネック・調査対象 author / PR を Upflow 内で確認できるようにする。
+
+## 現状実装の確認
+
+### サイクルタイムの保存先
+
+tenant DB の [`pull_requests`](../../db/tenant.sql) には、サイクルタイム分析に必要な列がすでに存在する。
+
+- `first_committed_at`
+- `pull_request_created_at`
+- `first_reviewed_at`
+- `merged_at`
+- `released_at`
+- `coding_time`
+- `pickup_time`
+- `review_time`
+- `deploy_time`
+- `total_time`
+- `repository_id`
+- `author`
+- `repo`
+- `title`
+- `url`
+
+`coding_time` / `pickup_time` / `review_time` / `deploy_time` / `total_time` は batch 側で計算済みの値として保存されている。定義は export の data dictionary にも記載されている。
+
+- [`app/routes/$orgSlug/settings/data-management/+data/DATA_DICTIONARY.md`](../../app/routes/$orgSlug/settings/data-management/+data/DATA_DICTIONARY.md)
+- [`batch/bizlogic/cycletime.ts`](../../batch/bizlogic/cycletime.ts)
+
+### 既存の analysis 画面
+
+Analysis 配下には以下の先行実装がある。
+
+- [`app/routes/$orgSlug/analysis/reviews/index.tsx`](../../app/routes/$orgSlug/analysis/reviews/index.tsx) — Review Bottleneck
+- [`app/routes/$orgSlug/analysis/inventory/index.tsx`](../../app/routes/$orgSlug/analysis/inventory/index.tsx) — Open PR Inventory
+
+どちらも以下のパターンを持つ。
+
+- `loader` で org / timezone / team / PR title filter を取得する
+- 重い raw query は [`getOrgCachedData`](../../app/services/cache.server.ts) で 5 分キャッシュする
+- `clientLoader` で raw data を集計済み chart data に変換する
+- `PageHeader` + `PageHeaderActions` に period selector や filter status を置く
+- chart は shadcn/ui `Card` + Recharts + [`ChartContainer`](../../app/components/ui/chart.tsx) を使う
+
+### Throughput 画面のサイクルタイム表示
+
+Throughput 配下の deployed 画面は、単週の deployed PR に対して cycle time metrics を表示している。
+
+- [`app/routes/$orgSlug/throughput/deployed/index.tsx`](../../app/routes/$orgSlug/throughput/deployed/index.tsx)
+- [`app/routes/$orgSlug/throughput/deployed/+functions/queries.server.ts`](../../app/routes/$orgSlug/throughput/deployed/+functions/queries.server.ts)
+- [`app/routes/$orgSlug/throughput/+components/stat-card.tsx`](../../app/routes/$orgSlug/throughput/+components/stat-card.tsx)
+
+`getDeployedPullRequestReport` は `releasedAt` を基準に期間指定し、`businessDaysOnly` に応じて `diffInDays` で deploy time / total 相当を再計算している。一方、tenant DB 上の `coding_time` 等は batch 計算済みの calendar-day metrics として保存されている。
+
+### PR title filter
+
+PR title filter はすでに tenant DB と query helper に存在する。
+
+- [`db/tenant.sql`](../../db/tenant.sql) — `pr_title_filters`
+- [`app/libs/tenant-query.server.ts`](../../app/libs/tenant-query.server.ts) — `excludePrTitleFilters` / `filteredPullRequestCount`
+- [`app/libs/pr-title-filter.server.ts`](../../app/libs/pr-title-filter.server.ts)
+- [`app/routes/$orgSlug/+components/pr-title-filter-status.tsx`](../../app/routes/$orgSlug/+components/pr-title-filter-status.tsx)
+
+新画面も他の Analysis 画面と同じく、デフォルトでは PR title filter を反映し、`showFiltered` で一時的に除外 PR を表示できるようにする。
+
+### org layout とナビゲーション
+
+org 配下の route は [`app/routes/$orgSlug/_layout.tsx`](../../app/routes/$orgSlug/_layout.tsx) で `orgMemberMiddleware` に保護されている。つまり Analysis 配下に追加する画面は、テナントの member 以上が閲覧できる。
+
+サイドバーのナビゲーションは [`app/components/layout/nav-config.ts`](../../app/components/layout/nav-config.ts) で定義されている。Cycle Time は Analysis group に追加する。
+
+## 設計判断
+
+### 1. route は `/:orgSlug/analysis/cycle-time` とする
+
+結論: 新画面は `app/routes/$orgSlug/analysis/cycle-time/index.tsx` に追加する。breadcrumb label は `Cycle Time`。
+
+理由:
+
+- 画面の主目的は個別 PR の throughput 一覧ではなく、期間傾向とボトルネック分析である
+- 既存の Review Bottleneck / Inventory と同じ Analysis 配下に置くと情報設計が自然
+- テナント内全員が見られる画面なので settings や admin 配下には置かない
+
+### 2. 初期スコープは released PR を基準にした 3 か月の週次集計にする
+
+結論: デフォルトでは `released_at IS NOT NULL` の PR を、組織 timezone 基準の直近 3 か月で集計する。期間判定は `released_at >= sinceDate` を基準にする。
+
+理由:
+
+- `total_time` は first commit から release までの値であり、release 済み PR を母集団にするのが最も整合する
+- `deploy_time` を含めた end-to-end のサイクルタイムを見たい画面なので、merged 基準にすると deploy が未確定の PR が混ざる
+- 既存 `throughput/deployed` も deployed/released PR をサイクルタイム表示の中心にしている
+
+補足:
+
+- open / merged but not released の滞留はこの画面では主対象にしない。Open PR Inventory / Review Bottleneck 側で扱う
+- 将来 `merged` 基準の toggle を追加する余地はあるが、初期実装には含めない
+
+### 3. 週次 bucket は組織 timezone の週始まりで作り、ラベルだけ client 側で整形する
+
+結論: raw query は `released_at` と metrics を返し、週 bucket は `clientLoader` の aggregate 関数で組織 timezone に変換して作る。週の開始は既存の `getStartOfWeek` と同じ Monday-start に寄せる。
+
+理由:
+
+- CLAUDE.md の日時原則どおり、DB の日時は UTC ISO として扱い、表示・期間境界は組織 timezone を使う必要がある
+- SQLite の date function で timezone 変換を行うと実装が読みづらく、SSR / browser の境界でも扱いがぶれやすい
+- 既存 `analysis/reviews` / `inventory` も raw data を取り、aggregate 関数で chart 用構造に変換している
+
+### 4. business days toggle は Phase 1 では表示しない。DB 保存値を正として使う
+
+結論: 初期実装では `coding_time` / `pickup_time` / `review_time` / `deploy_time` / `total_time` の DB 保存値をそのまま使い、business days toggle は実装しない。
+
+理由:
+
+- DB 保存済みの各工程時間は batch 側のサイクルタイム定義と export の正本に揃っている
+- `businessDaysOnly` を正しく実装するには、各工程の start/end timestamp をすべて raw query で取得し、`diffInDays` で再計算する必要がある
+- `coding_time` / `pickup_time` は fallback 境界を含む batch ロジックに依存するため、UI 側で再計算すると定義ずれのリスクがある
+- まず外部 BI 相当の可視化を Upflow に統合することを優先する
+
+非採用案:
+
+- DB 保存値と別に UI 側で business day metrics を再計算する。定義が二重化し、Data Dictionary / export / dashboard の値が一致しなくなる可能性があるため初期実装では採らない。
+
+### 5. Median / Average は切り替え可能にする。初期値は Median
+
+結論: `metric=median|average` の URL query param を持ち、デフォルトは `median` とする。KPI、週次 trend、By Author、Bottleneck Mix は同じ metric mode で計算する。
+
+理由:
+
+- サイクルタイムは長い PR の外れ値に引っ張られやすく、傾向把握には median が安定している
+- 外部 BI の運用では average を見たいケースもあるため切り替えは残す
+- URL に出すことで共有・再現できる
+
+### 6. repository filter は Phase 1 で実装するが、既存 TeamSwitcher とは独立した URL query にする
+
+結論: `repository=<repositoryId>` query param を追加する。`teamContext` は既存 layout の TeamSwitcher から取得し、repository filter はページ内 `Select` として扱う。
+
+理由:
+
+- Team は org 全体で共有される横断文脈としてすでに layout が扱っている
+- Repository はこの画面固有の絞り込みとして、period / metric mode と同じ page-level query に置く方が自然
+- `repositories.teamId` と `pullRequests.repositoryId` の両方で where 条件を組める
+
+### 7. cache key には集計条件と `showFiltered` を含める
+
+結論: `getOrgCachedData` の key には少なくとも以下を含める。
+
+- `cycle-time`
+- `teamId` or `all`
+- `repositoryId` or `all`
+- `periodMonths`
+- `metricMode`
+- `showFiltered` (`sf=t|f`)
+
+`normalizedPatterns` 自体は key に含めない。PR title filter の mutation で `clearOrgCache` される既存方針に従う。
+
+理由:
+
+- `showFiltered` を含めないと、除外あり/なしの結果が cache で混ざる
+- pattern 文字列を key に入れると cache key が肥大化する
+- 既存 RDD #307 と実装済み helper の方針に合わせる
+
+### 8. 表は「調査対象を選ぶ」ための静かな UI にする
+
+結論: 下部の表は BI 的な全面ヒートマップにはしない。強調は以下に限定する。
+
+- `Main driver` / `Bottleneck` の pill
+- `Total` の太字
+- `Change` の小さな delta badge
+- author ごとの薄い composition bar
+- 選択行または drawer 内の mini timeline
+
+理由:
+
+- 画面の主役は週次 trend と Bottleneck Mix。表まで全面的に色付けすると、どこを見るべきか分散する
+- Author / PR 表の目的は「次に誰・どの PR を見るべきか」を決めること
+- 色は工程カテゴリと状態差分に限定した方が、既存 Upflow の落ち着いた UI に合う
+
+### 9. Insights は初期実装ではルールベースにする
+
+結論: LLM 生成ではなく、集計結果から deterministic な短文を最大 3 件返す。
+
+例:
+
+- `Review dominates cycle time: 45%, +0.6d vs previous period.`
+- `Pickup improved to 1.1d, down 15% vs previous period.`
+- `Deploy variance is concentrated in one team.`
+
+理由:
+
+- 数値の根拠が明確で、テストしやすい
+- 表示のたびに LLM を呼ぶ必要がなく、レスポンス・コスト・再現性の問題がない
+- Upflow の分析画面ではまず stable な示唆が重要
+
+### 10. PR 詳細は一覧に詰め込まず、行クリック drawer へ逃がす
+
+結論: `Longest Cycle Time PRs` の一覧列は `PR / Repo / Author / Bottleneck / State / Total / Updated` に絞る。Coding / Pickup / Review / Deploy の細かい内訳は、選択行の mini timeline または drawer 側に表示する。
+
+理由:
+
+- 一覧に工程別日数をすべて並べると、PR タイトルや Bottleneck が読みにくくなる
+- 行クリックで既存 PR popover / 将来の PR detail drawer へ接続しやすい
+- 画面下部の役割は「上位の問題 PR を見つける」ことであり、詳細分析は drill-down に分ける方が見やすい
+
+## 要件
+
+### 機能要件
+
+1. Analysis ナビゲーションに `Cycle Time` を追加し、`/:orgSlug/analysis/cycle-time` へ遷移できる。
+2. org member 以上が画面を閲覧できる。admin-only にはしない。
+3. デフォルトで組織 timezone 基準の直近 3 か月、released PR の週次サイクルタイム推移を表示する。
+4. Team filter は既存 `teamContext` を反映する。
+5. Repository filter で特定 repository に絞り込める。
+6. Period は `1 month` / `3 months` / `6 months` / `12 months` を選択でき、デフォルトは `3 months`。
+7. Median / Average を切り替えられ、デフォルトは Median。
+8. PR title filter が有効な場合は既存画面と同じく除外を反映し、filter status と `showFiltered` を扱える。
+9. KPI として `Median/Avg Total`、`PRs`、`Review`、`Deploy` を表示する。
+10. KPI には直前同期間との差分を small delta badge で表示する。
+11. 週次 chart では Coding / Pickup / Review / Deploy の内訳と Total の推移を確認できる。
+12. chart tooltip では week、PR count、Total、Coding、Pickup、Review、Deploy を表示する。
+13. Bottleneck Mix では選択期間の Coding / Pickup / Review / Deploy の構成比を表示する。
+14. Insights は最大 3 件の deterministic な短文を表示する。
+15. By Author では `Author / PRs / Median or Avg Total / Main driver / Review p75 / Change vs previous period` を表示する。
+16. By Author には工程構成を薄い composition bar で表示する。全面ヒートマップにはしない。
+17. Longest Cycle Time PRs では `PR / Repo / Author / Bottleneck / State / Total / Updated` を表示する。
+18. PR row は clickable にし、詳細 drawer または PR popover への導線を持つ。
+19. サンプルデータ、テスト名、ドキュメントには実テナント名・社名・実データ由来の固有名詞を含めない。
+
+### 非機能要件
+
+1. 日付境界と週 bucket は組織 timezone を使う。DB から読んだ日時は UTC ISO として扱う。
+2. tenant DB の scoping は `getTenantDb(organizationId)` と org middleware に従う。
+3. 重い raw query は `getOrgCachedData` で 5 分程度 cache する。
+4. cache key には `teamId` / `repositoryId` / `period` / `metricMode` / `showFiltered` を含める。
+5. UI は既存 shadcn/ui + Recharts の画面と揃える。カードの多用・ネスト・過度な色面は避ける。
+6. 表の色は chart と同じ工程色を薄く使い、alert 的な赤を多用しない。
+7. 集計関数は unit test 可能な pure function に分ける。
+8. raw query は必要列だけ select し、アプリ側で全期間・全 PR を無制限に持たない。
+
+## スキーマ変更
+
+なし。
+
+既存 `pull_requests` の cycle time columns と `repositories.team_id` を使用する。新しい正規化テーブルや snapshot table は作らない。
+
+将来、サイクルタイムの pre-aggregation が必要になるほど PR 件数が増えた場合は、週次 aggregate table を別 issue で検討する。
+
+## アプリケーション変更
+
+### 想定する実装単位
+
+route は `app/routes/$orgSlug/analysis/cycle-time/` 配下に追加する想定。具体的なファイル分割は実装時に調整してよいが、少なくとも以下の責務は分ける。
+
+- route loader / clientLoader
+- tenant DB query
+- raw rows から chart / table data へ変換する aggregate 関数
+- chart / table / insight の表示 component
+- aggregate 関数の unit test
+
+### 更新する既存箇所
+
+- [`app/components/layout/nav-config.ts`](../../app/components/layout/nav-config.ts) — Analysis group に Cycle Time を追加する
+- 必要なら [`app/routes/$orgSlug/analysis/_layout.tsx`](../../app/routes/$orgSlug/analysis/_layout.tsx) — breadcrumb の親 link は既存のままでよい
+
+### Query 方針
+
+サイクルタイム画面用の raw query は、chart / author table / PR table を組み立てるのに必要な最小限の列だけを返す。
+
+- `repositoryId`
+- `repo`
+- `number`
+- `title`
+- `url`
+- `author`
+- `authorDisplayName`
+- `state`
+- `pullRequestCreatedAt`
+- `mergedAt`
+- `releasedAt`
+- `codingTime`
+- `pickupTime`
+- `reviewTime`
+- `deployTime`
+- `totalTime`
+
+主な where 条件:
+
+- `pullRequests.releasedAt is not null`
+- `pullRequests.totalTime is not null`
+- `pullRequests.releasedAt >= sinceDate`
+- previous period 用には `prevSinceDate <= releasedAt < sinceDate`
+- team filter がある場合は `repositories.teamId = teamId`
+- repository filter がある場合は `pullRequests.repositoryId = repositoryId`
+- `excludeBots`
+- `excludePrTitleFilters(normalizedPatterns)`
+
+PR title filter status 用の count は、画面と同じ母集団で算出する。
+
+### Aggregate 方針
+
+aggregate 関数は raw rows から画面表示用の派生データを作る。
+
+- KPI
+- previous period diff
+- weekly trend points
+- bottleneck mix
+- insights
+- author rows
+- longest PR rows
+
+`Main driver` / `Bottleneck` は `codingTime` / `pickupTime` / `reviewTime` / `deployTime` のうち最大の工程とする。`null` は 0 として扱うのではなく、その工程を対象外にする。全工程が `null` の場合は `Unknown`。
+
+構成比は、選択 metric mode に応じて工程ごとの median / average を計算し、その合計に対する割合を出す。`totalTime` と工程合計は完全一致しない可能性があるため、Bottleneck Mix は「工程内訳の構成比」として扱う。
+
+## UI 変更
+
+### Page Header
+
+- Title: `Cycle Time`
+- Description: `3-month trend of PR delivery speed and bottlenecks.`
+- Actions: PR title filter status、repository select、period select、Median / Average segmented control
+
+Business days toggle は Phase 1 では置かない。
+
+### KPI
+
+4 card を横並びにする。
+
+- `Median Total` or `Avg Total`
+- `PRs`
+- `Review`
+- `Deploy`
+
+差分 badge は以下の意味にする。
+
+- time metric は減少が good、増加が bad
+- PRs は増減だけ表示し、good/bad 判定を強く出さない
+
+### Weekly Cycle Time Trend
+
+`Card` 内に chart を置く。
+
+- stacked bar: Coding / Pickup / Review / Deploy
+- line: Total
+- tooltip: week + PR count + each metric
+
+annotation は任意。入れる場合は deterministic に 1 件までにし、例として previous 4 weeks 比で Review が最も増えた週を示す。
+
+### Bottleneck Mix / Insights
+
+右 column または chart 下に配置する。画面幅が狭い場合は縦積みにする。
+
+Insights は短文 3 件まで。長文説明や in-app manual にはしない。
+
+### By Author
+
+列:
+
+- Author
+- PRs
+- Composition
+- Median/Avg Total
+- Main driver
+- Review p75
+- Change vs prev period
+
+UI:
+
+- composition は薄い 4-segment bar
+- Main driver は small pill
+- Total は bold
+- Change は compact delta badge
+- row 全体や metric cell を heatmap で塗らない
+
+### Longest Cycle Time PRs
+
+列:
+
+- PR
+- Repo
+- Author
+- Bottleneck
+- State
+- Total
+- Updated
+
+UI:
+
+- PR title は link style
+- State は neutral badge
+- Bottleneck は small pill
+- Total は bold
+- 行末に chevron を置き、詳細導線を示す
+
+詳細 drawer を実装する場合は、一覧の列を増やすのではなく、工程別内訳と PR への導線を drawer 側に置く。
+
+## テスト方針
+
+### Unit tests
+
+aggregate 関数の unit test で以下を確認する。
+
+- timezone を考慮した週 bucket が期待どおりになる
+- median / average mode で KPI と weekly trend が変わる
+- previous period diff が正しく計算される
+- Bottleneck は最大工程を選ぶ
+- null metrics がある PR でも集計が壊れない
+- By Author の Review p75 と Change が正しく出る
+- Longest PRs が total time desc で並ぶ
+- Insights が最大 3 件に制限される
+
+### Route/query tests
+
+必要に応じて server query のテストを追加する。
+
+- team filter
+- repository filter
+- PR title filter
+- showFiltered
+- previous period
+
+既存 test setup の負荷が大きい場合、Phase 1 では aggregate unit test を優先する。
+
+### Visual / manual QA
+
+- seed data または匿名の fixture で画面を確認する
+- テーブルが過度なヒートマップになっていないこと
+- 実テナント名・社名が fixture / screenshot / docs に含まれないこと
+- 画面幅を狭めても header actions と tables が破綻しないこと
+
+## 移行方針
+
+スキーマ変更はないため migration は不要。
+
+外部 BI 運用はすぐに削除しない。Upflow 画面の数値と外部 BI の数値を比較し、定義差分がないことを確認してから段階的に置き換える。
+
+## リスク・補足
+
+### business day 指標の期待差分
+
+外部 BI 側で営業日ベースの計算をしている場合、DB 保存済み metrics と値が一致しない可能性がある。現時点でこの RDD は DB 保存値を正として扱う。business day 対応が必要なら、batch 側の正本定義から拡張する別 issue にする。
+
+### release 検出の遅れ
+
+`released_at` が後から補完される PR は、補完後に過去週の数字へ反映される。これは既存 throughput/deployed と同じ性質であり、5 分 cache の範囲で許容する。
+
+### author 表の個人評価化リスク
+
+By Author は人を責めるためではなく、ボトルネック調査対象を探すための表である。UI コピーは個人評価に見えすぎないようにし、Main driver / PR count / trend の文脈を添える。
+
+### PR 件数が多い tenant
+
+直近 12 か月でも released PR が多い tenant では raw rows が増える。初期実装では必要列のみ select + org cache で対応する。遅い場合は SQL 側 pre-aggregation または materialized weekly aggregate を検討する。
+
+## 受け入れ条件
+
+1. `/:orgSlug/analysis/cycle-time` にアクセスすると Cycle Time 画面が表示される。
+2. Sidebar の Analysis group から Cycle Time へ遷移できる。
+3. デフォルトで直近 3 か月の released PR の週次サイクルタイム trend が表示される。
+4. Team / Repository / Period / Median-Average / PR title filter の条件変更が chart と tables に反映される。
+5. KPI に Total / PRs / Review / Deploy と前期間差分が表示される。
+6. Weekly chart の tooltip で週ごとの PR count と工程別 metrics を確認できる。
+7. Bottleneck Mix と Insights から主要なボトルネックを把握できる。
+8. By Author は全面ヒートマップではなく、composition bar / driver pill / delta badge で静かに表示される。
+9. Longest Cycle Time PRs は長期化 PR と主因を scan でき、詳細導線を持つ。
+10. 実テナント名・社名・実データ由来の固有名詞が追加コード、テスト、ドキュメントに含まれていない。
+
+## Status
+
+Phase 1 implemented.
+
+- route: `app/routes/$orgSlug/analysis/cycle-time/index.tsx`
+- nav: `app/components/layout/nav-config.ts` の Analysis group に `Cycle Time` を追加
+- raw query: `+functions/queries.server.ts`
+- aggregate: `+functions/aggregate.ts` (unit test 同居)
+- UI: `+components/` (KPI, Weekly Trend, Bottleneck Mix, Insights, By Author, Longest PRs)
+- 週 bucket: `releasedAt` を組織 timezone で Monday-start に変換し、`untilDate` は exclusive として扱う
+- previous period: 同じ長さの直前期間 (`prevSinceDate = calcSinceDate(periodMonths * 2, timezone)`, `prevUntilDate = sinceDate`)
+- repository filter: team filter で絞り込んだ repositories list を `Select` で表示し、URL `?repository=<id>` に保存
+- business days toggle / drawer / 詳細 mini timeline は Phase 1 では未実装。GitHub の PR ページへのリンクと chevron で代用

--- a/package.json
+++ b/package.json
@@ -139,10 +139,14 @@
   "pnpm": {
     "onlyBuiltDependencies": [
       "@biomejs/biome",
+      "@sentry/cli",
       "@tailwindcss/oxide",
       "better-sqlite3",
       "esbuild",
-      "msw"
+      "msw",
+      "protobufjs",
+      "sharp",
+      "workerd"
     ]
   }
 }


### PR DESCRIPTION
## Summary

Closes #327. Adds `/:orgSlug/analysis/cycle-time` so tenants can read PR delivery speed trends, stage breakdowns, by-author detail, and the longest-running PRs without leaving Upflow. Phase 1 of the RDD at `docs/rdd/issue-327-cycle-time-dashboard.md`.

What started as a Phase 1 dashboard grew, by user direction, into a more thorough refactor — sharing helpers across the codebase rather than leaving inline duplicates. The follow-ups discovered along the way are tracked separately as #328 (monorepo release streams) and #330 (chart keyboard a11y).

## Cycle Time dashboard

- **KPI cards**: Median (or Average) Total, PR count, Review, Deploy. Each shows the delta vs the previous period of equal length, tone-inverted so down=good for time metrics. Sub-day values render as hours/minutes (`3.7h`, `12m`) instead of `0.0d`.
- **Weekly Cycle Time Trend**: stacked stage bars (Coding/Pickup/Review/Deploy) plus a Total line. Total = sum of stage aggregates so the line matches the bar height (KPI Total still uses median/avg of `total_time`). Click a week bar to drill the tables and Bottleneck Mix down to that week; selected bar stays opaque, others dim. A banner shows the selection with a Clear button.
- **Bottleneck Mix**: stage share by median/avg in the current period.
- **Insights**: up to 3 deterministic short strings — main driver follows the actual dominant stage (not hardcoded), non-dominant stage improvements highlighted, deploy variance flagged when weeks exceed 2× median.
- **By Author**: GitHub avatar + display name, PR count, composition bar (no full-row heatmap), Median/Avg Total, Main driver pill, Review p75, vs prev delta. Authors are grouped case-insensitively so PRs with mixed login casing don't split into multiple rows.
- **Longest Cycle Time PRs**: each row's PR cell is a real `<a target="_blank" rel="noopener noreferrer">` (Cmd/Ctrl-click, "Copy link address", and screen reader announcements work). PR identifier on row 1, title on row 2, then Author / Composition bar / Bottleneck pill / State / Total / Released.

## Filters

- Team (existing layout-level), Repository, Period (1/3/6/12 months, default 3), Median/Average toggle (default Median), PR title filter status with show-all toggle.

## Architecture

- `app/routes/$orgSlug/analysis/cycle-time/index.tsx` — loader fetches current + previous period rows in one cached call (`cycle-time:<team>:<repo>:<period>:sf=<show>:patterns=<JSON>`, 5 min TTL); pattern signature uses `JSON.stringify(sorted)` so a pattern containing `'|'` can't collide with a different list. `clientLoader` runs the aggregate functions; the page uses `useMemo` to recompute Bottleneck Mix / By Author / Longest PRs when a week is selected (vs-prev intentionally blank during drill-down because "same week of prior period" isn't a meaningful axis).
- `+functions/queries.server.ts` — `getCycleTimeRawData`, `countCycleTimePullRequests`, `listCycleTimeRepositories`. Honors `excludeBots`, `excludePrTitleFilters`, team/repository scopes.
- `+functions/aggregate.ts` — pure functions covered by unit tests: `computeKpi`, `computeWeeklyTrend`, `computeBottleneckMix`, `computeInsights`, `computeAuthorRows`, `computeLongestPrs`, `filterRowsByWeek`. `partitionStageValues` splits rows into the four stage arrays in a single O(n) pass and is reused everywhere so each call site doesn't scan rows once per stage.
- `+components/` — `kpi-cards`, `weekly-trend-chart` (Recharts ComposedChart), `bottleneck-mix-card`, `insights-card`, `by-author-table`, `longest-prs-table`, `composition-bar` (shared between By Author and Longest PRs), `stage-config` (shared label/color/format helpers).

## Refactors that came along (scope creep, on purpose)

Driven by `/simplify` and CodeRabbit reviews:

- **`startOfWeekMonday`** promoted to `app/libs/date-utils.ts`. Was duplicated in inventory aggregate; now both routes share one impl.
- **`average()` / `percentile()`** added to `app/libs/stats.ts` next to `median()`.
- **`AuthorBadge`** promoted to `app/components/`. Replaced the hand-rolled avatar+name blocks in `throughput/deployed`, `throughput/merged`, `throughput/ongoing` with it. Added `min-w-0` + `shrink-0` so `line-clamp-1` actually clamps inside flex parents.
- **`formatPrIdentifier(repo, number)`** added to `app/libs/format-pr.ts`. Replaced 7 inline `${repo}#${number}` sites across `pr-block`, `pr-drill-down-sheet`, `workload`, and `longest-prs-table`.
- **`StageRatio`** exported from `aggregate.ts`. `composition-bar.tsx` and `AuthorRow.composition` use the shared type instead of redefining.
- **`<ExternalLink>`** added to `app/components/external-link.tsx`. Replaced 16 inline `<a target="_blank" rel="...">` occurrences across 12 files (cycle-time, throughput, reviews, feedbacks, workload, settings/github-users, settings/repositories, settings/_index, pr-block) so the secure rel pair can't drift; an existing `rel="noreferrer"` (single attr) typo was fixed in passing.

## Tests

- 25 unit tests on the cycle-time aggregate functions, including regression tests for: timezone-aware week bucketing, sum-of-stage-medians vs median-of-totals, prev-period delta, bottleneck selection with null metrics, Review p75, longest sort, insights cap of 3 (with a regression for the original "Review hardcoded" bug), week filter for drill-down, and the case-insensitive author grouping (`Alpha` / `alpha` / `ALPHA` mixed).
- Inventory's existing tests still pass (the shared `startOfWeekMonday` swap didn't break anything).
- Full suite: 467/467 pass.

## Out of scope (deferred)

- **Business days toggle** (Phase 2 per RDD).
- **PR detail drawer with mini timeline** (Phase 2).
- **Chart keyboard accessibility** for week selection — Recharts SVG Cells aren't simply tabIndex-able; deciding between an in-chart focusable-Cell approach and an external week selector buttons row needs UX work. Tracked as #330.
- **Monorepo multi-release-stream support** — the dashboard inherits whatever release detection each repo has. monorepo tenants with multiple independent components currently produce noisy `deploy_time` because all components are detected as one stream. Tracked as #328.

## Test plan

- [ ] Sidebar Analysis → Cycle Time loads without errors
- [ ] Default view shows last 3 months, weekly trend renders
- [ ] Switching Period (1/6/12 months) updates chart + KPIs + tables
- [ ] Repository filter narrows to a single repo
- [ ] Median/Average toggle changes KPI values and chart
- [ ] PR title filter status badge appears when patterns are enabled and toggling "Show all" works; editing patterns does NOT show stale rows for 5 min (cache key now includes a pattern signature)
- [ ] Clicking a week bar drills Bottleneck Mix / By Author / Longest PRs to that week, highlights the bar, shows the banner; Clear restores the period view; By Author's "vs prev" is em-dash during drill-down
- [ ] Clicking a PR title in Longest PRs opens the PR in a new tab; Cmd/Ctrl-click and "Copy link address" also work; row hover highlight visible
- [ ] By Author shows GitHub avatars; mixed-case login PRs (e.g. `Alpha` vs `alpha`) appear as one row, not two

🤖 Generated with [Claude Code](https://claude.com/claude-code)
