### PR TITLE
Switch Cycle Time dashboard to merged_at basis (#333)

### DIFF
--- a/app/routes/$orgSlug/analysis/cycle-time/+components/bottleneck-mix-card.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/bottleneck-mix-card.tsx
@@ -20,7 +20,7 @@ export function BottleneckMixCard({ mix, mode }: BottleneckMixCardProps) {
       <CardHeader>
         <CardTitle>Bottleneck Mix</CardTitle>
         <CardDescription>
-          Stage share by {mode} time across released PRs in this period.
+          Stage share by {mode} time across merged PRs in this period.
         </CardDescription>
       </CardHeader>
       <CardContent>

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/by-author-table.tsx
@@ -50,7 +50,7 @@ export function ByAuthorTable({ rows, mode }: ByAuthorTableProps) {
       <CardContent>
         {rows.length === 0 ? (
           <p className="text-muted-foreground text-sm">
-            No released pull requests in this period.
+            No merged pull requests in this period.
           </p>
         ) : (
           <div className="overflow-x-auto">

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/composition-bar.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/composition-bar.tsx
@@ -41,14 +41,12 @@ interface StageTimes {
   codingTime: number | null
   pickupTime: number | null
   reviewTime: number | null
-  deployTime: number | null
 }
 
 const STAGE_TIME_KEY = {
   coding: 'codingTime',
   pickup: 'pickupTime',
   review: 'reviewTime',
-  deploy: 'deployTime',
 } as const satisfies Record<StageRatio['stage'], keyof StageTimes>
 
 /**

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/kpi-cards.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/kpi-cards.tsx
@@ -23,7 +23,7 @@ interface KpiCardsProps {
 export function KpiCards({ kpi, mode, periodLabel }: KpiCardsProps) {
   const totalLabel = mode === 'median' ? 'Median Total' : 'Avg Total'
   return (
-    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-3">
       <KpiCard
         label={totalLabel}
         value={formatDays(kpi.total)}
@@ -42,13 +42,6 @@ export function KpiCards({ kpi, mode, periodLabel }: KpiCardsProps) {
         label={mode === 'median' ? 'Review (median)' : 'Review (avg)'}
         value={formatDays(kpi.review)}
         delta={kpi.reviewDelta}
-        deltaInversed
-        periodLabel={periodLabel}
-      />
-      <KpiCard
-        label={mode === 'median' ? 'Deploy (median)' : 'Deploy (avg)'}
-        value={formatDays(kpi.deploy)}
-        delta={kpi.deployDelta}
         deltaInversed
         periodLabel={periodLabel}
       />

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -55,7 +55,7 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                   <TableHead>Bottleneck</TableHead>
                   <TableHead>State</TableHead>
                   <TableHead className="text-right">Total</TableHead>
-                  <TableHead>Released</TableHead>
+                  <TableHead>Merged</TableHead>
                   <TableHead className="w-8" aria-hidden />
                 </TableRow>
               </TableHeader>
@@ -115,7 +115,7 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
                       {formatDays(row.totalTime)}
                     </TableCell>
                     <TableCell className="text-muted-foreground text-sm tabular-nums">
-                      {dayjs.utc(row.updatedAt).tz(timezone).format('MMM D')}
+                      {dayjs.utc(row.mergedAt).tz(timezone).format('MMM D')}
                     </TableCell>
                     <TableCell className="text-muted-foreground">
                       <ChevronRightIcon className="size-4" />

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/longest-prs-table.tsx
@@ -35,14 +35,14 @@ export function LongestPrsTable({ rows }: LongestPrsTableProps) {
       <CardHeader>
         <CardTitle>Longest Cycle Time PRs</CardTitle>
         <CardDescription>
-          Released PRs ranked by total time. Click the PR title to open the pull
+          Merged PRs ranked by total time. Click the PR title to open the pull
           request in a new tab.
         </CardDescription>
       </CardHeader>
       <CardContent>
         {rows.length === 0 ? (
           <p className="text-muted-foreground text-sm">
-            No released pull requests in this period.
+            No merged pull requests in this period.
           </p>
         ) : (
           <div className="overflow-x-auto">

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/stage-config.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/stage-config.ts
@@ -4,7 +4,6 @@ export const STAGE_LABEL: Record<CycleStage, string> = {
   coding: 'Coding',
   pickup: 'Pickup',
   review: 'Review',
-  deploy: 'Deploy',
 }
 
 /**
@@ -15,7 +14,6 @@ export const STAGE_COLOR_VAR: Record<CycleStage, string> = {
   coding: 'var(--color-chart-2)',
   pickup: 'var(--color-chart-4)',
   review: 'var(--color-chart-1)',
-  deploy: 'var(--color-chart-3)',
 }
 
 /**

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/weekly-trend-chart.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/weekly-trend-chart.tsx
@@ -29,11 +29,10 @@ const chartConfig = {
   coding: { label: STAGE_LABEL.coding, color: STAGE_COLOR_VAR.coding },
   pickup: { label: STAGE_LABEL.pickup, color: STAGE_COLOR_VAR.pickup },
   review: { label: STAGE_LABEL.review, color: STAGE_COLOR_VAR.review },
-  deploy: { label: STAGE_LABEL.deploy, color: STAGE_COLOR_VAR.deploy },
   total: { label: 'Total (stages sum)', color: 'var(--color-foreground)' },
 } satisfies ChartConfig
 
-const STAGES = ['coding', 'pickup', 'review', 'deploy'] as const
+const STAGES = ['coding', 'pickup', 'review'] as const
 
 interface WeeklyTrendChartProps {
   weeks: WeeklyTrendPoint[]

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/weekly-trend-chart.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/weekly-trend-chart.tsx
@@ -29,7 +29,7 @@ const chartConfig = {
   coding: { label: STAGE_LABEL.coding, color: STAGE_COLOR_VAR.coding },
   pickup: { label: STAGE_LABEL.pickup, color: STAGE_COLOR_VAR.pickup },
   review: { label: STAGE_LABEL.review, color: STAGE_COLOR_VAR.review },
-  total: { label: 'Total (stages sum)', color: 'var(--color-foreground)' },
+  prCount: { label: 'PRs merged', color: 'var(--color-foreground)' },
 } satisfies ChartConfig
 
 const STAGES = ['coding', 'pickup', 'review'] as const
@@ -77,9 +77,8 @@ export function WeeklyTrendChart({
       <CardHeader>
         <CardTitle>Weekly Cycle Time Trend</CardTitle>
         <CardDescription>
-          Stacked stage breakdown ({titleSuffix} days). The total line is the
-          sum of stage {titleSuffix}s — see the KPI card for the {titleSuffix}{' '}
-          of total cycle time. Click a week to drill down.
+          Stacked stage breakdown ({titleSuffix} days). The line shows weekly
+          merged PR count (right axis). Click a week to drill down.
         </CardDescription>
       </CardHeader>
       <CardContent>
@@ -99,8 +98,16 @@ export function WeeklyTrendChart({
               minTickGap={16}
             />
             <YAxis
+              yAxisId="left"
               tickFormatter={(v: number) => `${v.toFixed(0)}d`}
               width={40}
+            />
+            <YAxis
+              yAxisId="right"
+              orientation="right"
+              allowDecimals={false}
+              tickFormatter={(v: number) => `${v}`}
+              width={32}
             />
             <ChartTooltip
               content={
@@ -121,11 +128,16 @@ export function WeeklyTrendChart({
                         ? (chartConfig[name as keyof typeof chartConfig]
                             ?.label ?? name)
                         : name
+                    const formatted = !Number.isFinite(numeric)
+                      ? '—'
+                      : name === 'prCount'
+                        ? `${numeric}`
+                        : formatDays(numeric)
                     return (
                       <div className="flex flex-1 justify-between gap-4">
                         <span className="text-muted-foreground">{label}</span>
                         <span className="font-mono tabular-nums">
-                          {Number.isFinite(numeric) ? formatDays(numeric) : '—'}
+                          {formatted}
                         </span>
                       </div>
                     )
@@ -139,6 +151,7 @@ export function WeeklyTrendChart({
             {STAGES.map((stage, i) => (
               <Bar
                 key={stage}
+                yAxisId="left"
                 dataKey={stage}
                 stackId="cycle"
                 fill={`var(--color-${stage})`}
@@ -161,12 +174,12 @@ export function WeeklyTrendChart({
               </Bar>
             ))}
             <Line
+              yAxisId="right"
               type="monotone"
-              dataKey="total"
-              stroke="var(--color-total)"
+              dataKey="prCount"
+              stroke="var(--color-prCount)"
               strokeWidth={2}
               dot={{ r: 3 }}
-              connectNulls
             />
           </ComposedChart>
         </ChartContainer>

--- a/app/routes/$orgSlug/analysis/cycle-time/+components/weekly-trend-chart.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/+components/weekly-trend-chart.tsx
@@ -55,7 +55,7 @@ export function WeeklyTrendChart({
         <CardHeader>
           <CardTitle>Weekly Cycle Time Trend</CardTitle>
           <CardDescription>
-            No released pull requests in this period.
+            No merged pull requests in this period.
           </CardDescription>
         </CardHeader>
       </Card>

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
@@ -21,38 +21,50 @@ const baseRow = (overrides: Partial<CycleTimeRawRow>): CycleTimeRawRow => ({
   state: 'merged',
   pullRequestCreatedAt: '2026-03-01T00:00:00.000Z',
   mergedAt: '2026-03-02T00:00:00.000Z',
-  releasedAt: '2026-03-03T00:00:00.000Z',
   codingTime: 1,
   pickupTime: 1,
   reviewTime: 1,
-  deployTime: 1,
-  totalTime: 4,
   ...overrides,
 })
 
 describe('computeKpi', () => {
   test('median mode picks median per stage and counts PRs', () => {
+    // Per-PR merge total = coding + pickup + review.
     const rows = [
-      baseRow({ number: 1, totalTime: 2, reviewTime: 1, deployTime: 1 }),
-      baseRow({ number: 2, totalTime: 6, reviewTime: 3, deployTime: 2 }),
-      baseRow({ number: 3, totalTime: 4, reviewTime: 2, deployTime: 4 }),
+      baseRow({
+        number: 1,
+        codingTime: 1,
+        pickupTime: 0,
+        reviewTime: 1, // total = 2
+      }),
+      baseRow({
+        number: 2,
+        codingTime: 1,
+        pickupTime: 2,
+        reviewTime: 3, // total = 6
+      }),
+      baseRow({
+        number: 3,
+        codingTime: 1,
+        pickupTime: 1,
+        reviewTime: 2, // total = 4
+      }),
     ]
     const prevRows = [
-      baseRow({ number: 99, totalTime: 5, reviewTime: 2, deployTime: 2 }),
+      baseRow({ number: 99, codingTime: 1, pickupTime: 1, reviewTime: 3 }), // total = 5
     ]
     const kpi = computeKpi(rows, prevRows, 'median')
-    expect(kpi.total).toBe(4)
+    expect(kpi.total).toBe(4) // median([2, 6, 4])
     expect(kpi.review).toBe(2)
-    expect(kpi.deploy).toBe(2)
     expect(kpi.prCount).toBe(3)
     expect(kpi.totalDelta.diff).toBe(-1)
   })
 
   test('average mode differs from median', () => {
     const rows = [
-      baseRow({ number: 1, totalTime: 1 }),
-      baseRow({ number: 2, totalTime: 1 }),
-      baseRow({ number: 3, totalTime: 10 }),
+      baseRow({ number: 1, codingTime: 0, pickupTime: 0, reviewTime: 1 }),
+      baseRow({ number: 2, codingTime: 0, pickupTime: 0, reviewTime: 1 }),
+      baseRow({ number: 3, codingTime: 0, pickupTime: 0, reviewTime: 10 }),
     ]
     const med = computeKpi(rows, [], 'median')
     const avg = computeKpi(rows, [], 'average')
@@ -62,8 +74,8 @@ describe('computeKpi', () => {
 
   test('null stage values are excluded, not zeroed', () => {
     const rows = [
-      baseRow({ number: 1, reviewTime: null, totalTime: 5 }),
-      baseRow({ number: 2, reviewTime: 3, totalTime: 5 }),
+      baseRow({ number: 1, reviewTime: null }),
+      baseRow({ number: 2, reviewTime: 3 }),
     ]
     expect(computeKpi(rows, [], 'median').review).toBe(3)
   })
@@ -74,72 +86,68 @@ describe('computeKpi', () => {
     expect(kpi.prCount).toBe(0)
     expect(kpi.totalDelta.diff).toBeNull()
   })
+
+  test('PR with all stages null is dropped from total but counted', () => {
+    const rows = [
+      baseRow({
+        number: 1,
+        codingTime: null,
+        pickupTime: null,
+        reviewTime: null,
+      }),
+      baseRow({ number: 2, codingTime: 1, pickupTime: 1, reviewTime: 1 }),
+    ]
+    const kpi = computeKpi(rows, [], 'median')
+    expect(kpi.total).toBe(3) // only PR 2 contributes
+    expect(kpi.prCount).toBe(2)
+  })
 })
 
 describe('computeWeeklyTrend', () => {
-  test('buckets PRs by Monday-start week in given timezone', () => {
+  test('buckets PRs by mergedAt week (Monday-start) in given timezone', () => {
     const since = '2026-03-02T00:00:00.000Z' // Mon
     const until = '2026-03-23T00:00:00.000Z' // Mon (exclusive end)
     const rows = [
-      // Week 1: 2026-03-02 - 2026-03-08 — baseRow has all stages = 1
-      baseRow({
-        number: 1,
-        releasedAt: '2026-03-04T05:00:00.000Z',
-        totalTime: 4,
-      }),
-      baseRow({
-        number: 2,
-        releasedAt: '2026-03-08T22:00:00.000Z',
-        totalTime: 6,
-      }),
+      // Week 1: 2026-03-02 - 2026-03-08
+      baseRow({ number: 1, mergedAt: '2026-03-04T05:00:00.000Z' }),
+      baseRow({ number: 2, mergedAt: '2026-03-08T22:00:00.000Z' }),
       // Week 2: 2026-03-09 - 2026-03-15
-      baseRow({
-        number: 3,
-        releasedAt: '2026-03-12T01:00:00.000Z',
-        totalTime: 8,
-      }),
+      baseRow({ number: 3, mergedAt: '2026-03-12T01:00:00.000Z' }),
       // Week 3: 2026-03-16 - 2026-03-22 (no PRs)
     ]
     const trend = computeWeeklyTrend(rows, since, until, 'UTC', 'median')
     expect(trend).toHaveLength(3)
     expect(trend[0].prCount).toBe(2)
-    // Sum of stage medians (1+1+1+1) — matches the stacked bar height
-    expect(trend[0].total).toBe(4)
+    // Sum of stage medians (1+1+1) — matches the stacked bar height
+    expect(trend[0].total).toBe(3)
     expect(trend[1].prCount).toBe(1)
-    expect(trend[1].total).toBe(4)
+    expect(trend[1].total).toBe(3)
     expect(trend[2].prCount).toBe(0)
     expect(trend[2].total).toBeNull()
   })
 
-  test('total equals sum of stage medians, not median of totalTime', () => {
-    // Three PRs whose stage medians sum to 7 but median(totalTime) = 9.
+  test('total equals sum of stage medians', () => {
     const rows = [
       baseRow({
         number: 1,
-        releasedAt: '2026-03-03T00:00:00.000Z',
+        mergedAt: '2026-03-03T00:00:00.000Z',
         codingTime: 1,
         pickupTime: 1,
         reviewTime: 1,
-        deployTime: 1,
-        totalTime: 4,
       }),
       baseRow({
         number: 2,
-        releasedAt: '2026-03-04T00:00:00.000Z',
+        mergedAt: '2026-03-04T00:00:00.000Z',
         codingTime: 2,
         pickupTime: 2,
         reviewTime: 2,
-        deployTime: 2,
-        totalTime: 9,
       }),
       baseRow({
         number: 3,
-        releasedAt: '2026-03-05T00:00:00.000Z',
+        mergedAt: '2026-03-05T00:00:00.000Z',
         codingTime: 5,
         pickupTime: 5,
         reviewTime: 5,
-        deployTime: 5,
-        totalTime: 30,
       }),
     ]
     const trend = computeWeeklyTrend(
@@ -153,27 +161,18 @@ describe('computeWeeklyTrend', () => {
     expect(trend[0].coding).toBe(2)
     expect(trend[0].pickup).toBe(2)
     expect(trend[0].review).toBe(2)
-    expect(trend[0].deploy).toBe(2)
-    // sum of stage medians = 8, NOT median(totalTime) = 9
-    expect(trend[0].total).toBe(8)
+    expect(trend[0].total).toBe(6)
   })
 
   test('week start follows Asia/Tokyo when timezone shifts the day', () => {
     // 2026-03-01 23:00 UTC = 2026-03-02 08:00 Asia/Tokyo (Mon)
     const since = '2026-03-02T00:00:00.000Z'
     const until = '2026-03-09T00:00:00.000Z'
-    const rows = [
-      baseRow({
-        number: 1,
-        releasedAt: '2026-03-01T23:00:00.000Z',
-        totalTime: 5,
-      }),
-    ]
+    const rows = [baseRow({ number: 1, mergedAt: '2026-03-01T23:00:00.000Z' })]
     const trend = computeWeeklyTrend(rows, since, until, 'Asia/Tokyo', 'median')
     expect(trend.length).toBeGreaterThan(0)
     expect(trend[0].prCount).toBe(1)
-    // baseRow stages all = 1 → sum = 4
-    expect(trend[0].total).toBe(4)
+    expect(trend[0].total).toBe(3)
   })
 
   test('returns [] when since is not before until', () => {
@@ -187,15 +186,39 @@ describe('computeWeeklyTrend', () => {
       ),
     ).toEqual([])
   })
+
+  test('regression: release-branch merge bursts no longer concentrate on one week', () => {
+    // Simulate a monorepo "release branch → main" event: 5 PRs whose
+    // releasedAt would have collided on a single second under the old basis,
+    // but whose mergedAt is spread across two weeks. The chart must show
+    // the spread, not a synthetic spike.
+    const rows = [
+      baseRow({ number: 1, mergedAt: '2026-03-03T00:00:00.000Z' }),
+      baseRow({ number: 2, mergedAt: '2026-03-05T00:00:00.000Z' }),
+      baseRow({ number: 3, mergedAt: '2026-03-10T00:00:00.000Z' }),
+      baseRow({ number: 4, mergedAt: '2026-03-12T00:00:00.000Z' }),
+      baseRow({ number: 5, mergedAt: '2026-03-14T00:00:00.000Z' }),
+    ]
+    const trend = computeWeeklyTrend(
+      rows,
+      '2026-03-02T00:00:00.000Z',
+      '2026-03-16T00:00:00.000Z',
+      'UTC',
+      'median',
+    )
+    expect(trend).toHaveLength(2)
+    expect(trend[0].prCount).toBe(2)
+    expect(trend[1].prCount).toBe(3)
+  })
 })
 
 describe('filterRowsByWeek', () => {
-  test('keeps only rows whose release week (Monday-start) matches', () => {
+  test('keeps only rows whose merge week (Monday-start) matches', () => {
     const rows = [
-      baseRow({ number: 1, releasedAt: '2026-03-04T05:00:00.000Z' }), // wk 03-02
-      baseRow({ number: 2, releasedAt: '2026-03-08T22:00:00.000Z' }), // wk 03-02
-      baseRow({ number: 3, releasedAt: '2026-03-12T01:00:00.000Z' }), // wk 03-09
-      baseRow({ number: 4, releasedAt: null }),
+      baseRow({ number: 1, mergedAt: '2026-03-04T05:00:00.000Z' }), // wk 03-02
+      baseRow({ number: 2, mergedAt: '2026-03-08T22:00:00.000Z' }), // wk 03-02
+      baseRow({ number: 3, mergedAt: '2026-03-12T01:00:00.000Z' }), // wk 03-09
+      baseRow({ number: 4, mergedAt: null }),
     ]
     const out = filterRowsByWeek(rows, '2026-03-02', 'UTC')
     expect(out.map((r) => r.number)).toEqual([1, 2])
@@ -203,9 +226,7 @@ describe('filterRowsByWeek', () => {
 
   test('uses the given timezone to determine the week boundary', () => {
     // 2026-03-01 23:00 UTC = 2026-03-02 08:00 Asia/Tokyo (Mon)
-    const rows = [
-      baseRow({ number: 1, releasedAt: '2026-03-01T23:00:00.000Z' }),
-    ]
+    const rows = [baseRow({ number: 1, mergedAt: '2026-03-01T23:00:00.000Z' })]
     expect(
       filterRowsByWeek(rows, '2026-03-02', 'Asia/Tokyo').map((r) => r.number),
     ).toEqual([1])
@@ -218,26 +239,26 @@ describe('filterRowsByWeek', () => {
 describe('computeBottleneckMix', () => {
   test('ratios sum to 1 when there is data', () => {
     const rows = [
-      baseRow({
-        number: 1,
-        codingTime: 2,
-        pickupTime: 1,
-        reviewTime: 4,
-        deployTime: 3,
-      }),
-      baseRow({
-        number: 2,
-        codingTime: 2,
-        pickupTime: 1,
-        reviewTime: 4,
-        deployTime: 3,
-      }),
+      baseRow({ number: 1, codingTime: 2, pickupTime: 1, reviewTime: 4 }),
+      baseRow({ number: 2, codingTime: 2, pickupTime: 1, reviewTime: 4 }),
     ]
     const mix = computeBottleneckMix(rows, 'median')
     const sum = mix.slices.reduce((s, x) => s + x.ratio, 0)
     expect(sum).toBeCloseTo(1)
     const review = mix.slices.find((s) => s.stage === 'review')
     expect(review?.value).toBe(4)
+  })
+
+  test('exactly three stages (no deploy)', () => {
+    const mix = computeBottleneckMix(
+      [baseRow({ codingTime: 1, pickupTime: 1, reviewTime: 1 })],
+      'median',
+    )
+    expect(mix.slices.map((s) => s.stage)).toEqual([
+      'coding',
+      'pickup',
+      'review',
+    ])
   })
 
   test('handles empty rows with zero ratios', () => {
@@ -252,34 +273,39 @@ describe('computeBottleneckMix', () => {
 
 describe('computeAuthorRows', () => {
   test('groups by author and computes Review p75 and change vs prev', () => {
+    // Per-PR merge total = coding + pickup + review.
     const rows = [
       baseRow({
         author: 'alpha',
         authorDisplayName: 'Alpha',
         number: 1,
-        reviewTime: 1,
-        totalTime: 5,
+        codingTime: 1,
+        pickupTime: 0,
+        reviewTime: 1, // total = 2
       }),
       baseRow({
         author: 'alpha',
         authorDisplayName: 'Alpha',
         number: 2,
-        reviewTime: 3,
-        totalTime: 7,
+        codingTime: 1,
+        pickupTime: 2,
+        reviewTime: 3, // total = 6
       }),
       baseRow({
         author: 'alpha',
         authorDisplayName: 'Alpha',
         number: 3,
-        reviewTime: 5,
-        totalTime: 9,
+        codingTime: 1,
+        pickupTime: 3,
+        reviewTime: 5, // total = 9
       }),
       baseRow({
         author: 'beta',
         authorDisplayName: 'Beta',
         number: 4,
-        reviewTime: 2,
-        totalTime: 4,
+        codingTime: 1,
+        pickupTime: 1,
+        reviewTime: 2, // total = 4
       }),
     ]
     const prev = [
@@ -287,7 +313,9 @@ describe('computeAuthorRows', () => {
         author: 'alpha',
         authorDisplayName: 'Alpha',
         number: 11,
-        totalTime: 10,
+        codingTime: 2,
+        pickupTime: 4,
+        reviewTime: 4, // total = 10
       }),
     ]
     const out = computeAuthorRows(rows, prev, 'median')
@@ -295,9 +323,9 @@ describe('computeAuthorRows', () => {
 
     const alpha = out.find((a) => a.author === 'alpha')
     expect(alpha?.prCount).toBe(3)
-    expect(alpha?.total).toBe(7)
+    expect(alpha?.total).toBe(6) // median([2, 6, 9])
     expect(alpha?.reviewP75).toBeCloseTo(4)
-    expect(alpha?.changeVsPrev.diff).toBe(-3)
+    expect(alpha?.changeVsPrev.diff).toBe(-4)
     expect(alpha?.composition.reduce((s, c) => s + c.ratio, 0)).toBeCloseTo(1)
 
     const beta = out.find((a) => a.author === 'beta')
@@ -314,7 +342,6 @@ describe('computeAuthorRows', () => {
         codingTime: 1,
         pickupTime: 0.5,
         reviewTime: 5,
-        deployTime: 1,
       }),
     ]
     const out = computeAuthorRows(rows, [], 'median')
@@ -335,31 +362,47 @@ describe('computeAuthorRows', () => {
         author: 'Alpha',
         authorDisplayName: 'Alpha',
         number: 1,
-        totalTime: 5,
+        codingTime: 1,
+        pickupTime: 1,
+        reviewTime: 1,
       }),
       baseRow({
         author: 'alpha',
         authorDisplayName: 'Alpha',
         number: 2,
-        totalTime: 7,
+        codingTime: 1,
+        pickupTime: 2,
+        reviewTime: 1,
       }),
       baseRow({
         author: 'ALPHA',
         authorDisplayName: 'Alpha',
         number: 3,
-        totalTime: 9,
+        codingTime: 1,
+        pickupTime: 3,
+        reviewTime: 1,
       }),
     ]
     const prev = [
-      baseRow({ author: 'Alpha', number: 11, totalTime: 10 }),
-      baseRow({ author: 'alpha', number: 12, totalTime: 12 }),
+      baseRow({
+        author: 'Alpha',
+        number: 11,
+        codingTime: 2,
+        pickupTime: 4,
+        reviewTime: 2,
+      }),
+      baseRow({
+        author: 'alpha',
+        number: 12,
+        codingTime: 2,
+        pickupTime: 5,
+        reviewTime: 2,
+      }),
     ]
     const out = computeAuthorRows(rows, prev, 'median')
     expect(out).toHaveLength(1)
     expect(out[0].prCount).toBe(3)
-    expect(out[0].total).toBe(7)
-    // Output `author` keeps the casing of the first row in the group so the
-    // canonical login is preserved.
+    // First-row casing is preserved for the canonical login.
     expect(out[0].author.toLowerCase()).toBe('alpha')
     expect(out[0].author).toBe('Alpha')
     // Previous-period rows with the same login (different casing) must be
@@ -369,14 +412,16 @@ describe('computeAuthorRows', () => {
 })
 
 describe('computeLongestPrs', () => {
-  test('sorts by totalTime desc and keeps limit', () => {
+  test('sorts by merge total desc and keeps limit', () => {
     const rows = [
-      baseRow({ number: 1, totalTime: 5 }),
-      baseRow({ number: 2, totalTime: 12 }),
-      baseRow({ number: 3, totalTime: 8 }),
+      baseRow({ number: 1, codingTime: 1, pickupTime: 1, reviewTime: 3 }), // total = 5
+      baseRow({ number: 2, codingTime: 4, pickupTime: 4, reviewTime: 4 }), // total = 12
+      baseRow({ number: 3, codingTime: 2, pickupTime: 3, reviewTime: 3 }), // total = 8
     ]
     const out = computeLongestPrs(rows, 2)
     expect(out.map((r) => r.number)).toEqual([2, 3])
+    expect(out[0].totalTime).toBe(12)
+    expect(out[1].totalTime).toBe(8)
   })
 
   test('bottleneck is the largest stage', () => {
@@ -386,35 +431,45 @@ describe('computeLongestPrs', () => {
         codingTime: 1,
         pickupTime: 0.5,
         reviewTime: 7,
-        deployTime: 1,
-        totalTime: 9.5,
       }),
     ]
     expect(computeLongestPrs(rows)[0].bottleneck).toBe('review')
   })
 
-  test('PR with all-null stages has bottleneck null', () => {
+  test('PR with all-null stages is dropped (no merge total)', () => {
     const rows = [
       baseRow({
         number: 1,
         codingTime: null,
         pickupTime: null,
         reviewTime: null,
-        deployTime: null,
-        totalTime: 3,
       }),
-    ]
-    expect(computeLongestPrs(rows)[0].bottleneck).toBeNull()
-  })
-
-  test('skips rows without totalTime or releasedAt', () => {
-    const rows = [
-      baseRow({ number: 1, totalTime: null }),
-      baseRow({ number: 2, totalTime: 5, releasedAt: null }),
-      baseRow({ number: 3, totalTime: 6 }),
+      baseRow({ number: 2, codingTime: 1, pickupTime: 1, reviewTime: 1 }),
     ]
     const out = computeLongestPrs(rows)
-    expect(out.map((r) => r.number)).toEqual([3])
+    expect(out.map((r) => r.number)).toEqual([2])
+  })
+
+  test('skips rows without mergedAt', () => {
+    const rows = [
+      baseRow({ number: 1, mergedAt: null }),
+      baseRow({ number: 2, codingTime: 1, pickupTime: 1, reviewTime: 1 }),
+    ]
+    const out = computeLongestPrs(rows)
+    expect(out.map((r) => r.number)).toEqual([2])
+  })
+
+  test('mergedAt is exposed in row output', () => {
+    const rows = [
+      baseRow({
+        number: 1,
+        mergedAt: '2026-03-15T12:00:00.000Z',
+        codingTime: 1,
+        pickupTime: 1,
+        reviewTime: 1,
+      }),
+    ]
+    expect(computeLongestPrs(rows)[0].mergedAt).toBe('2026-03-15T12:00:00.000Z')
   })
 })
 
@@ -428,16 +483,12 @@ describe('computeInsights', () => {
         codingTime: 1,
         pickupTime: 1,
         reviewTime: 5,
-        deployTime: 1,
-        totalTime: 8,
       }),
       baseRow({
         number: 2,
         codingTime: 1,
         pickupTime: 1,
         reviewTime: 5,
-        deployTime: 1,
-        totalTime: 8,
       }),
     ]
     const prev = [
@@ -446,48 +497,13 @@ describe('computeInsights', () => {
         codingTime: 1,
         pickupTime: 5,
         reviewTime: 1,
-        deployTime: 1,
-        totalTime: 8,
       }),
-    ]
-    const weekly = [
-      {
-        weekStart: 'a',
-        weekLabel: 'a',
-        prCount: 2,
-        coding: 1,
-        pickup: 1,
-        review: 5,
-        deploy: 1,
-        total: 8,
-      },
-      {
-        weekStart: 'b',
-        weekLabel: 'b',
-        prCount: 0,
-        coding: null,
-        pickup: null,
-        review: null,
-        deploy: 4,
-        total: null,
-      },
-      {
-        weekStart: 'c',
-        weekLabel: 'c',
-        prCount: 0,
-        coding: null,
-        pickup: null,
-        review: null,
-        deploy: 1,
-        total: null,
-      },
     ]
     const mix = computeBottleneckMix(rows, mode)
     const prevMix = computeBottleneckMix(prev, mode)
     const out = computeInsights({
       current: rows,
       previous: prev,
-      weekly,
       mix,
       prevMix,
       mode,
@@ -502,8 +518,6 @@ describe('computeInsights', () => {
         codingTime: 1,
         pickupTime: 1,
         reviewTime: 6,
-        deployTime: 1,
-        totalTime: 9,
       }),
     ]
     const prev = [
@@ -512,8 +526,6 @@ describe('computeInsights', () => {
         codingTime: 1,
         pickupTime: 1,
         reviewTime: 3,
-        deployTime: 1,
-        totalTime: 6,
       }),
     ]
     const mix = computeBottleneckMix(rows, mode)
@@ -521,7 +533,6 @@ describe('computeInsights', () => {
     const out = computeInsights({
       current: rows,
       previous: prev,
-      weekly: [],
       mix,
       prevMix,
       mode,
@@ -530,16 +541,13 @@ describe('computeInsights', () => {
   })
 
   test('main driver follows the actual largest stage (not hardcoded review)', () => {
-    // Pickup is dominant (61%), review is 36%. The first insight must be
-    // about Pickup, not Review.
+    // Pickup is dominant. The first insight must be about Pickup, not Review.
     const rows = [
       baseRow({
         number: 1,
         codingTime: 0.05,
         pickupTime: 0.2,
         reviewTime: 0.12,
-        deployTime: 0,
-        totalTime: 0.37,
       }),
     ]
     const prev = [
@@ -548,8 +556,6 @@ describe('computeInsights', () => {
         codingTime: 0.05,
         pickupTime: 0.25,
         reviewTime: 0.12,
-        deployTime: 0,
-        totalTime: 0.42,
       }),
     ]
     const mix = computeBottleneckMix(rows, mode)
@@ -557,13 +563,11 @@ describe('computeInsights', () => {
     const out = computeInsights({
       current: rows,
       previous: prev,
-      weekly: [],
       mix,
       prevMix,
       mode,
     })
     expect(out[0]).toMatch(/^Pickup time is the main driver/)
-    // No insight should claim Review is the main driver in this scenario.
     expect(out.some((s) => /Review time is the main driver/.test(s))).toBe(
       false,
     )
@@ -578,8 +582,6 @@ describe('computeInsights', () => {
         codingTime: 0.1,
         pickupTime: 0.5,
         reviewTime: 0.1,
-        deployTime: 0.1,
-        totalTime: 0.8,
       }),
     ]
     const prev = [
@@ -588,8 +590,6 @@ describe('computeInsights', () => {
         codingTime: 0.1,
         pickupTime: 1.0,
         reviewTime: 0.1,
-        deployTime: 0.1,
-        totalTime: 1.3,
       }),
     ]
     const mix = computeBottleneckMix(rows, mode)
@@ -597,7 +597,6 @@ describe('computeInsights', () => {
     const out = computeInsights({
       current: rows,
       previous: prev,
-      weekly: [],
       mix,
       prevMix,
       mode,
@@ -609,7 +608,6 @@ describe('computeInsights', () => {
     const out = computeInsights({
       current: [],
       previous: [],
-      weekly: [],
       mix: computeBottleneckMix([], mode),
       prevMix: computeBottleneckMix([], mode),
       mode,

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.test.ts
@@ -118,50 +118,9 @@ describe('computeWeeklyTrend', () => {
     const trend = computeWeeklyTrend(rows, since, until, 'UTC', 'median')
     expect(trend).toHaveLength(3)
     expect(trend[0].prCount).toBe(2)
-    // Sum of stage medians (1+1+1) — matches the stacked bar height
-    expect(trend[0].total).toBe(3)
     expect(trend[1].prCount).toBe(1)
-    expect(trend[1].total).toBe(3)
     expect(trend[2].prCount).toBe(0)
-    expect(trend[2].total).toBeNull()
-  })
-
-  test('total equals sum of stage medians', () => {
-    const rows = [
-      baseRow({
-        number: 1,
-        mergedAt: '2026-03-03T00:00:00.000Z',
-        codingTime: 1,
-        pickupTime: 1,
-        reviewTime: 1,
-      }),
-      baseRow({
-        number: 2,
-        mergedAt: '2026-03-04T00:00:00.000Z',
-        codingTime: 2,
-        pickupTime: 2,
-        reviewTime: 2,
-      }),
-      baseRow({
-        number: 3,
-        mergedAt: '2026-03-05T00:00:00.000Z',
-        codingTime: 5,
-        pickupTime: 5,
-        reviewTime: 5,
-      }),
-    ]
-    const trend = computeWeeklyTrend(
-      rows,
-      '2026-03-02T00:00:00.000Z',
-      '2026-03-09T00:00:00.000Z',
-      'UTC',
-      'median',
-    )
-    expect(trend).toHaveLength(1)
-    expect(trend[0].coding).toBe(2)
-    expect(trend[0].pickup).toBe(2)
-    expect(trend[0].review).toBe(2)
-    expect(trend[0].total).toBe(6)
+    expect(trend[2].coding).toBeNull()
   })
 
   test('week start follows Asia/Tokyo when timezone shifts the day', () => {
@@ -172,7 +131,7 @@ describe('computeWeeklyTrend', () => {
     const trend = computeWeeklyTrend(rows, since, until, 'Asia/Tokyo', 'median')
     expect(trend.length).toBeGreaterThan(0)
     expect(trend[0].prCount).toBe(1)
-    expect(trend[0].total).toBe(3)
+    expect(trend[0].coding).toBe(1)
   })
 
   test('returns [] when since is not before until', () => {

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
@@ -4,13 +4,17 @@ import { average, median, percentile } from '~/app/libs/stats'
 
 export type MetricMode = 'median' | 'average'
 
-export type CycleStage = 'coding' | 'pickup' | 'review' | 'deploy'
+/**
+ * Cycle stages tracked by this dashboard. Deploy is intentionally excluded:
+ * the dashboard now bucket-by and total over `mergedAt`, so cycle time is
+ * "first commit → merge". Deploy lag is a separate concern (#328 pending).
+ */
+export type CycleStage = 'coding' | 'pickup' | 'review'
 
 export const STAGES: readonly CycleStage[] = [
   'coding',
   'pickup',
   'review',
-  'deploy',
 ] as const
 
 export interface CycleTimeRawRow {
@@ -24,18 +28,15 @@ export interface CycleTimeRawRow {
   state: 'open' | 'closed' | 'merged'
   pullRequestCreatedAt: string
   mergedAt: string | null
-  releasedAt: string | null
   codingTime: number | null
   pickupTime: number | null
   reviewTime: number | null
-  deployTime: number | null
-  totalTime: number | null
 }
 
 // --- helpers ---
 
 /**
- * Filter raw rows to those released within the week starting at `weekStart`
+ * Filter raw rows to those merged within the week starting at `weekStart`
  * (Monday) in the given timezone. `weekStart` is the `YYYY-MM-DD` key produced
  * by `computeWeeklyTrend`.
  */
@@ -45,8 +46,8 @@ export function filterRowsByWeek(
   timezone: string,
 ): CycleTimeRawRow[] {
   return rows.filter((row) => {
-    if (row.releasedAt === null) return false
-    const wk = startOfWeekMonday(dayjs.utc(row.releasedAt).tz(timezone))
+    if (row.mergedAt === null) return false
+    const wk = startOfWeekMonday(dayjs.utc(row.mergedAt).tz(timezone))
     return wk.format('YYYY-MM-DD') === weekStart
   })
 }
@@ -59,25 +60,23 @@ type StageValues = Record<CycleStage, number[]>
 
 const STAGE_KEY: Record<
   CycleStage,
-  'codingTime' | 'pickupTime' | 'reviewTime' | 'deployTime'
+  'codingTime' | 'pickupTime' | 'reviewTime'
 > = {
   coding: 'codingTime',
   pickup: 'pickupTime',
   review: 'reviewTime',
-  deploy: 'deployTime',
 }
 
 /**
- * Single O(n) pass that splits rows into the four stage value arrays. Used
+ * Single O(n) pass that splits rows into the three stage value arrays. Used
  * by every aggregator so we don't scan rows once per stage.
  */
 function partitionStageValues(rows: CycleTimeRawRow[]): StageValues {
-  const out: StageValues = { coding: [], pickup: [], review: [], deploy: [] }
+  const out: StageValues = { coding: [], pickup: [], review: [] }
   for (const r of rows) {
     if (r.codingTime !== null) out.coding.push(r.codingTime)
     if (r.pickupTime !== null) out.pickup.push(r.pickupTime)
     if (r.reviewTime !== null) out.review.push(r.reviewTime)
-    if (r.deployTime !== null) out.deploy.push(r.deployTime)
   }
   return out
 }
@@ -90,13 +89,31 @@ function aggregateStages(
     coding: aggregateValue(buckets.coding, mode),
     pickup: aggregateValue(buckets.pickup, mode),
     review: aggregateValue(buckets.review, mode),
-    deploy: aggregateValue(buckets.deploy, mode),
   }
 }
 
-function nonNullTotalValues(rows: CycleTimeRawRow[]): number[] {
+/**
+ * Per-PR merge-cycle total: `coding + pickup + review` (= first commit → merge).
+ * Returns null when every stage is null; otherwise treats null stages as 0
+ * so a PR with no review (auto-merged) still contributes a meaningful total.
+ */
+function rowMergeTotal(row: CycleTimeRawRow): number | null {
+  if (
+    row.codingTime === null &&
+    row.pickupTime === null &&
+    row.reviewTime === null
+  ) {
+    return null
+  }
+  return (row.codingTime ?? 0) + (row.pickupTime ?? 0) + (row.reviewTime ?? 0)
+}
+
+function nonNullMergeTotals(rows: CycleTimeRawRow[]): number[] {
   const out: number[] = []
-  for (const r of rows) if (r.totalTime !== null) out.push(r.totalTime)
+  for (const r of rows) {
+    const t = rowMergeTotal(r)
+    if (t !== null) out.push(t)
+  }
   return out
 }
 
@@ -127,15 +144,12 @@ export interface CycleTimeKpi {
   total: number | null
   prCount: number
   review: number | null
-  deploy: number | null
   prevTotal: number | null
   prevPrCount: number
   prevReview: number | null
-  prevDeploy: number | null
   totalDelta: CycleTimeDelta
   prCountDelta: CycleTimeDelta
   reviewDelta: CycleTimeDelta
-  deployDelta: CycleTimeDelta
 }
 
 function makeDelta(
@@ -155,22 +169,19 @@ export function computeKpi(
 ): CycleTimeKpi {
   const cur = aggregateStages(partitionStageValues(rows), mode)
   const prev = aggregateStages(partitionStageValues(prevRows), mode)
-  const total = aggregateValue(nonNullTotalValues(rows), mode)
-  const prevTotal = aggregateValue(nonNullTotalValues(prevRows), mode)
+  const total = aggregateValue(nonNullMergeTotals(rows), mode)
+  const prevTotal = aggregateValue(nonNullMergeTotals(prevRows), mode)
 
   return {
     total,
     prCount: rows.length,
     review: cur.review,
-    deploy: cur.deploy,
     prevTotal,
     prevPrCount: prevRows.length,
     prevReview: prev.review,
-    prevDeploy: prev.deploy,
     totalDelta: makeDelta(total, prevTotal),
     prCountDelta: makeDelta(rows.length, prevRows.length),
     reviewDelta: makeDelta(cur.review, prev.review),
-    deployDelta: makeDelta(cur.deploy, prev.deploy),
   }
 }
 
@@ -183,7 +194,6 @@ export interface WeeklyTrendPoint {
   coding: number | null
   pickup: number | null
   review: number | null
-  deploy: number | null
   total: number | null
 }
 
@@ -213,8 +223,8 @@ export function computeWeeklyTrend(
   }
 
   for (const row of rows) {
-    if (row.releasedAt === null) continue
-    const wk = startOfWeekMonday(dayjs.utc(row.releasedAt).tz(timezone))
+    if (row.mergedAt === null) continue
+    const wk = startOfWeekMonday(dayjs.utc(row.mergedAt).tz(timezone))
     const key = wk.format('YYYY-MM-DD')
     const bucket = buckets.get(key)
     if (bucket) bucket.push(row)
@@ -223,16 +233,12 @@ export function computeWeeklyTrend(
   return weekKeys.map((key) => {
     const bucket = buckets.get(key) ?? []
     const stages = aggregateStages(partitionStageValues(bucket), mode)
-    const stageVals = [
-      stages.coding,
-      stages.pickup,
-      stages.review,
-      stages.deploy,
-    ]
+    const stageVals = [stages.coding, stages.pickup, stages.review]
     // Total = sum of stage aggregates so the line matches the stacked bar
     // height and tooltip components in both median and average modes. (Median
-    // of totalTime ≠ sum of stage medians, which previously caused the line
-    // to disagree with the breakdown.)
+    // of per-PR sums ≠ sum of stage medians, so we keep the chart Total
+    // self-consistent and let the KPI Total card show the median-of-totals
+    // for the typical end-to-end perspective.)
     const total = stageVals.every((v) => v === null)
       ? null
       : stageVals.reduce<number>((s, v) => s + (v ?? 0), 0)
@@ -285,13 +291,11 @@ export function computeBottleneckMix(
 
 const DOMINANT_THRESHOLD = 0.3
 const STAGE_IMPROVEMENT_THRESHOLD = 0.85
-const DEPLOY_VARIANCE_RATIO = 2
 
 const STAGE_LABEL_NICE: Record<CycleStage, string> = {
   coding: 'Coding',
   pickup: 'Pickup',
   review: 'Review',
-  deploy: 'Deploy',
 }
 
 /**
@@ -326,12 +330,11 @@ function directionVsPrev(
 export function computeInsights(args: {
   current: CycleTimeRawRow[]
   previous: CycleTimeRawRow[]
-  weekly: WeeklyTrendPoint[]
   mix: BottleneckMix
   prevMix: BottleneckMix
   mode: MetricMode
 }): string[] {
-  const { current, previous, weekly, mix, prevMix, mode } = args
+  const { current, previous, mix, prevMix, mode } = args
   const insights: string[] = []
 
   if (current.length === 0) return insights
@@ -387,25 +390,7 @@ export function computeInsights(args: {
     }
   }
 
-  // 3. Deploy variance across the period (skip when deploy is dominant —
-  // the level message above already covers it).
-  if (!dominant || dominant.stage !== 'deploy') {
-    const deployValues = weekly
-      .map((w) => w.deploy)
-      .filter((v): v is number => v !== null && v > 0)
-    if (deployValues.length >= 3) {
-      const sortedDeploy = [...deployValues].sort((a, b) => a - b)
-      const med = sortedDeploy[Math.floor(sortedDeploy.length / 2)]
-      const max = sortedDeploy[sortedDeploy.length - 1]
-      if (med > 0 && max >= med * DEPLOY_VARIANCE_RATIO) {
-        insights.push(
-          `Deploy time variance is high. Some weeks exceed ${formatDays(max)}.`,
-        )
-      }
-    }
-  }
-
-  // 4. Fallback: dominant stage exists but didn't reach the threshold (no
+  // 3. Fallback: dominant stage exists but didn't reach the threshold (no
   // previous data, or below 30%). Report direction vs prev so the panel
   // isn't empty.
   if (insights.length === 0 && dominant && dominant.ratio > 0) {
@@ -489,11 +474,11 @@ export function computeAuthorRows(
       }
     }
 
-    const total = aggregateValue(nonNullTotalValues(authorRows), mode)
+    const total = aggregateValue(nonNullMergeTotals(authorRows), mode)
     const reviewP75 = percentile(buckets.review, 0.75)
 
     const prevList = groupPrev.get(authorKey) ?? []
-    const prevTotal = aggregateValue(nonNullTotalValues(prevList), mode)
+    const prevTotal = aggregateValue(nonNullMergeTotals(prevList), mode)
 
     out.push({
       author: authorRows[0].author,
@@ -526,25 +511,30 @@ export interface LongestPrRow {
   author: string
   authorDisplayName: string | null
   state: 'open' | 'closed' | 'merged'
+  /** first commit → merge, computed as coding + pickup + review (null stages count as 0). */
   totalTime: number
   codingTime: number | null
   pickupTime: number | null
   reviewTime: number | null
-  deployTime: number | null
   bottleneck: CycleStage | null
-  updatedAt: string
+  /** mergedAt — when the PR closed as merged. */
+  mergedAt: string
 }
 
 export function computeLongestPrs(
   rows: CycleTimeRawRow[],
   limit = 10,
 ): LongestPrRow[] {
-  const filtered = rows.filter(
-    (r): r is CycleTimeRawRow & { totalTime: number; releasedAt: string } =>
-      r.totalTime !== null && r.releasedAt !== null,
-  )
-  filtered.sort((a, b) => b.totalTime - a.totalTime)
-  return filtered.slice(0, limit).map((r) => ({
+  type Decorated = CycleTimeRawRow & { mergedAt: string; mergeTotal: number }
+  const decorated: Decorated[] = []
+  for (const r of rows) {
+    if (r.mergedAt === null) continue
+    const t = rowMergeTotal(r)
+    if (t === null) continue
+    decorated.push({ ...r, mergedAt: r.mergedAt, mergeTotal: t })
+  }
+  decorated.sort((a, b) => b.mergeTotal - a.mergeTotal)
+  return decorated.slice(0, limit).map((r) => ({
     repositoryId: r.repositoryId,
     repo: r.repo,
     number: r.number,
@@ -553,12 +543,11 @@ export function computeLongestPrs(
     author: r.author,
     authorDisplayName: r.authorDisplayName,
     state: r.state,
-    totalTime: r.totalTime,
+    totalTime: r.mergeTotal,
     codingTime: r.codingTime,
     pickupTime: r.pickupTime,
     reviewTime: r.reviewTime,
-    deployTime: r.deployTime,
     bottleneck: bottleneckStage(r),
-    updatedAt: r.releasedAt,
+    mergedAt: r.mergedAt,
   }))
 }

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/aggregate.ts
@@ -194,7 +194,6 @@ export interface WeeklyTrendPoint {
   coding: number | null
   pickup: number | null
   review: number | null
-  total: number | null
 }
 
 export function computeWeeklyTrend(
@@ -233,21 +232,11 @@ export function computeWeeklyTrend(
   return weekKeys.map((key) => {
     const bucket = buckets.get(key) ?? []
     const stages = aggregateStages(partitionStageValues(bucket), mode)
-    const stageVals = [stages.coding, stages.pickup, stages.review]
-    // Total = sum of stage aggregates so the line matches the stacked bar
-    // height and tooltip components in both median and average modes. (Median
-    // of per-PR sums ≠ sum of stage medians, so we keep the chart Total
-    // self-consistent and let the KPI Total card show the median-of-totals
-    // for the typical end-to-end perspective.)
-    const total = stageVals.every((v) => v === null)
-      ? null
-      : stageVals.reduce<number>((s, v) => s + (v ?? 0), 0)
     return {
       weekStart: key,
       weekLabel: dayjs(key).format('MMM D'),
       prCount: bucket.length,
       ...stages,
-      total,
     }
   })
 }

--- a/app/routes/$orgSlug/analysis/cycle-time/+functions/queries.server.ts
+++ b/app/routes/$orgSlug/analysis/cycle-time/+functions/queries.server.ts
@@ -8,8 +8,11 @@ import { getTenantDb } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
 /**
- * Cycle time raw rows for released PRs in [sinceDate, untilDate).
+ * Cycle time raw rows for merged PRs in [sinceDate, untilDate).
  * `untilDate` を null にすると上限なしで取得する（current period 用）。
+ *
+ * 母集団は `mergedAt is not null` の PR。released か否かは問わない。
+ * Deploy time / releasedAt は本ダッシュボードで使わない。
  */
 export const getCycleTimeRawData = async (
   organizationId: OrganizationId,
@@ -30,11 +33,10 @@ export const getCycleTimeRawData = async (
         (eb) => eb.fn('lower', ['companyGithubUsers.login']),
       ),
     )
-    .where('pullRequests.releasedAt', 'is not', null)
-    .where('pullRequests.totalTime', 'is not', null)
-    .where('pullRequests.releasedAt', '>=', sinceDate)
+    .where('pullRequests.mergedAt', 'is not', null)
+    .where('pullRequests.mergedAt', '>=', sinceDate)
     .$if(untilDate !== null, (qb) =>
-      qb.where('pullRequests.releasedAt', '<', untilDate as string),
+      qb.where('pullRequests.mergedAt', '<', untilDate as string),
     )
     .$if(teamId != null, (qb) =>
       qb.where('repositories.teamId', '=', teamId as string),
@@ -55,12 +57,9 @@ export const getCycleTimeRawData = async (
       'pullRequests.state',
       'pullRequests.pullRequestCreatedAt',
       'pullRequests.mergedAt',
-      'pullRequests.releasedAt',
       'pullRequests.codingTime',
       'pullRequests.pickupTime',
       'pullRequests.reviewTime',
-      'pullRequests.deployTime',
-      'pullRequests.totalTime',
     ])
     .execute()
 }
@@ -86,9 +85,8 @@ export const countCycleTimePullRequests = async (
         (eb) => eb.fn('lower', ['companyGithubUsers.login']),
       ),
     )
-    .where('pullRequests.releasedAt', 'is not', null)
-    .where('pullRequests.totalTime', 'is not', null)
-    .where('pullRequests.releasedAt', '>=', sinceDate)
+    .where('pullRequests.mergedAt', 'is not', null)
+    .where('pullRequests.mergedAt', '>=', sinceDate)
     .$if(teamId != null, (qb) =>
       qb.where('repositories.teamId', '=', teamId as string),
     )

--- a/app/routes/$orgSlug/analysis/cycle-time/index.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/index.tsx
@@ -203,7 +203,6 @@ export const clientLoader = async ({
   const insights = computeInsights({
     current: data.currentRows,
     previous: data.previousRows,
-    weekly,
     mix,
     prevMix,
     mode: data.metricMode,
@@ -317,7 +316,8 @@ export default function CycleTimePage({
         <PageHeaderHeading>
           <PageHeaderTitle>Cycle Time</PageHeaderTitle>
           <PageHeaderDescription>
-            {periodLabel} trend of PR delivery speed and bottlenecks.
+            {periodLabel} trend of PR cycle time (first commit → merge) and
+            bottlenecks. Deploy lag is tracked separately.
           </PageHeaderDescription>
         </PageHeaderHeading>
         <PageHeaderActions className="flex flex-wrap">

--- a/docs/rdd/issue-327-cycle-time-dashboard.md
+++ b/docs/rdd/issue-327-cycle-time-dashboard.md
@@ -92,20 +92,22 @@ org 配下の route は [`app/routes/$orgSlug/_layout.tsx`](../../app/routes/$or
 - 既存の Review Bottleneck / Inventory と同じ Analysis 配下に置くと情報設計が自然
 - テナント内全員が見られる画面なので settings や admin 配下には置かない
 
-### 2. 初期スコープは released PR を基準にした 3 か月の週次集計にする
+### 2. 初期スコープは merged PR を基準にした 3 か月の週次集計にする
 
-結論: デフォルトでは `released_at IS NOT NULL` の PR を、組織 timezone 基準の直近 3 か月で集計する。期間判定は `released_at >= sinceDate` を基準にする。
+結論: デフォルトでは `merged_at IS NOT NULL` の PR を、組織 timezone 基準の直近 3 か月で集計する。期間判定・週バケット・filterRowsByWeek すべて `merged_at` を基準にする。Cycle time は first commit → merge (= coding + pickup + review)、Deploy stage はこのダッシュボードでは扱わない。
 
 理由:
 
-- `total_time` は first commit から release までの値であり、release 済み PR を母集団にするのが最も整合する
-- `deploy_time` を含めた end-to-end のサイクルタイムを見たい画面なので、merged 基準にすると deploy が未確定の PR が混ざる
-- 既存 `throughput/deployed` も deployed/released PR をサイクルタイム表示の中心にしている
+- `released_at` は `repositories.release_detection_method` 依存の派生値で、monorepo (#328) や release stream の仕様が決まりきっていない現状では精度が出ない (release branch を main に取り込むタイミングで PR がまとめて同一 `released_at` に揃ってしまうアーティファクトが #329 で確認された)
+- engineering team がコントロールできる範囲のサイクルタイム (= merge までの時間) を主役にすることで、外部要因 (App Store 審査、deploy schedule の business decision) の揺れを排除できる
+- 「PR が完成した」という developer experience の感覚と一致する
+- DORA 系の lead-time-to-merge 定義に近い
 
 補足:
 
-- open / merged but not released の滞留はこの画面では主対象にしない。Open PR Inventory / Review Bottleneck 側で扱う
-- 将来 `merged` 基準の toggle を追加する余地はあるが、初期実装には含めない
+- Deploy time は意味のある指標だが、本ダッシュボードではなく **将来の独立 KPI / 独立画面 (Deploy Lag)** として扱う。#328 (release stream) 完了後に再構成する
+- open / merged but not released の滞留は本画面では主対象にしない。Open PR Inventory / Review Bottleneck 側で扱う
+- 当初の released_at-based 設計から #333 で切り替えた。詳細は issue 参照
 
 ### 3. 週次 bucket は組織 timezone の週始まりで作り、ラベルだけ client 側で整形する
 
@@ -485,7 +487,11 @@ Phase 1 implemented.
 - raw query: `+functions/queries.server.ts`
 - aggregate: `+functions/aggregate.ts` (unit test 同居)
 - UI: `+components/` (KPI, Weekly Trend, Bottleneck Mix, Insights, By Author, Longest PRs)
-- 週 bucket: `releasedAt` を組織 timezone で Monday-start に変換し、`untilDate` は exclusive として扱う
+- 週 bucket: `mergedAt` を組織 timezone で Monday-start に変換し、`untilDate` は exclusive として扱う (#333 で `releasedAt` 基準から切り替え)
+- 母集団: `mergedAt is not null` の PR (released か否かを問わない)
+- 工程: Coding / Pickup / Review の 3 stage。Deploy は本ダッシュボードでは扱わない (#333)
+- KPI: Median/Avg Total / PRs / Review の 3 枚
 - previous period: 同じ長さの直前期間 (`prevSinceDate = calcSinceDate(periodMonths * 2, timezone)`, `prevUntilDate = sinceDate`)
 - repository filter: team filter で絞り込んだ repositories list を `Select` で表示し、URL `?repository=<id>` に保存
 - business days toggle / drawer / 詳細 mini timeline は Phase 1 では未実装。GitHub の PR ページへのリンクと chevron で代用
+- follow-ups: #328 (monorepo release stream) / #330 (chart keyboard a11y) / #332 (constraint reframe)


### PR DESCRIPTION
## Summary

Closes #333. Re-bases the Cycle Time dashboard from `released_at` to `merged_at` for population, week bucketing, and total computation. Drops Deploy from the dashboard (to be revisited as a dedicated "Deploy Lag" view after #328).

The previous `released_at` basis bucketed PRs by when their code transitively reached main. Under branch=main detection, `feature → release-branch → main` flows produce artificial spikes — at the moment a long-running release branch is merged back to main, dozens of PRs from prior weeks all get the same `released_at`. We observed this pattern on a monorepo tenant (75 PRs marked released within the same second on a single day in March). Cycle Time KPI / Weekly Trend / Bottleneck Mix all inherited the artifact.

## What changed

| Item | Before | After |
|---|---|---|
| Population WHERE | `releasedAt is not null AND totalTime is not null` | `mergedAt is not null` |
| Period filter column | `releasedAt >= sinceDate` | `mergedAt >= sinceDate` |
| Week bucket key | `releasedAt` Monday-start | `mergedAt` Monday-start |
| filterRowsByWeek | matches releasedAt week | matches mergedAt week |
| Cycle stages | 4 (Coding/Pickup/Review/Deploy) | 3 (Coding/Pickup/Review) |
| Per-PR total | `pullRequests.total_time` column | `coding + pickup + review` (null stages → 0; null when all null) |
| KPI cards | 4 (Total/PRs/Review/Deploy) | 3 (Total/PRs/Review) |
| Longest PRs date column | Released | Merged |
| Weekly Trend overlay line | Total = sum of stage aggregates (= top of stack, no info) | PRs merged on right Y axis (throughput signal) |
| User-facing copy ("Released PRs", "No released pull requests…") | released-based | merged-based |
| Page description | "PR delivery speed and bottlenecks" | "PR cycle time (first commit → merge) and bottlenecks. Deploy lag is tracked separately." |

## Verified against real data

For the monorepo tenant on the merge-basis: the burst of PRs that previously concentrated in a single second now disperses to the PRs' actual merge weeks across the prior weeks of activity. The peak week's count is meaningfully lower than the artifact under the old basis.

## What is NOT changed

- DB schema is untouched (`released_at`, `deploy_time`, `total_time` remain populated).
- Other routes that use `released_at` (throughput/deployed, etc.) are unaffected.
- The release detection layer for monorepo support (#328) is still pending.

Deploy time will resurface in a dedicated "Deploy Lag" KPI / view after #328 stabilises the release-stream signal.

## Tests

- 28 cycle-time unit tests rewritten to cover the new contract: merge-week bucketing (timezone-aware), per-PR total with null handling, regression for the release-branch burst (verifies PRs spread across weeks), mergedAt exposed on LongestPrRow, 3-stage Bottleneck Mix, author casing preserved.
- Full suite: 470/470 pass.

## Out of scope (deferred)

- Deploy Lag dedicated view (will be created after #328).
- Constraint-based reframe of the dashboard (#332).
- Chart keyboard accessibility (#330).
- Strategic re-evaluation of the entire Cycle Time dashboard (#335 — umbrella for switching to action-mapped views).

## Test plan

- [ ] Sidebar Analysis → Cycle Time loads without errors
- [ ] Default 3-month view shows weekly trend bucketed by merge date
- [ ] No artificial merge-burst spike for monorepo tenants (peaks reflect actual merge activity, not release-branch合流)
- [ ] KPI cards show 3 (Total / PRs / Review), not 4
- [ ] Bottleneck Mix shows 3 segments
- [ ] By Author composition bar shows 3 segments
- [ ] Longest PRs table has "Merged" column with merge dates
- [ ] Weekly Trend chart shows PRs merged line on right Y axis (count, not days)
- [ ] All user-facing empty states / descriptions read "merged" (not "released")
- [ ] PR title filter, repository filter, period selector, median/avg toggle all still work
- [ ] Drill-down by clicking a week bar still works
- [ ] By Author 'vs prev' is em-dash during week drill-down

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **改良**
  * サイクルタイムダッシュボードを再構成：デプロイステージを削除し、集計基準を「マージ日時（merged）」に変更。
  * サイクルタイム定義を「最初のコミット→マージ（コーディング+ピックアップ+レビュー）」に更新。デプロイは別KPIへ。
  * KPIカードからデプロイカード削除、SMブレークポイントでのカード列を3列に調整。
  * 最長PR一覧やチャート表記を「Released」→「Merged」に変更。

* **ドキュメント**
  * ダッシュボード仕様と背景説明をマージ基準へ更新。

* **テスト**
  * テスト群をマージベースと3ステージ集計に合わせて更新。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->