### PR TITLE
Run claude in full permission mode to make takt runs unattended

### DIFF
--- a/.takt/config.yaml
+++ b/.takt/config.yaml
@@ -42,7 +42,7 @@ provider_profiles:
   codex:
     default_permission_mode: full
   claude:
-    default_permission_mode: edit
+    default_permission_mode: full
 
 # Pipeline mode (`takt --pipeline`) — used by CI for non-interactive runs.
 # Templates only apply when --pipeline is set; regular `takt run` ignores them.


### PR DESCRIPTION
## Summary

claude のデフォルト権限 `edit` (= `acceptEdits`) は file edit を自動承認するが **Bash 実行は確認プロンプトを出す**。takt は subprocess で claude を呼ぶため対話 UI が無く、`pnpm install` などで永遠に approval 待ちになり 36 秒で ABORT する。

PR #341 で `setup` step が `pnpm install` / `pnpm db:setup` / `pnpm typecheck` を走らせるようになったので、人がターミナルを見ていない状態の takt run は最初の bootstrapper step で必ず止まっていた（issue #336 § B 前段の rule-inventory タスクで遭遇）。

## Change

`.takt/config.yaml` の `provider_profiles.claude.default_permission_mode` を `edit` → `full` に変更。これで cursor / codex と同じく完全 non-interactive で動く。

## Trade-off

`full` = `bypassPermissions`。受容できる理由:

- takt run は **worktree (`git clone --shared`) で実行される**ので、メイン作業ツリーへの影響はない
- persona facet (bootstrapper / supervisor / simplifier / spec-author) に do / do-not 境界が明文化されている
- 失敗時は worktree ごと破棄できる

## Validation

- `npx takt prompt spec-implement-accept` パース通過
- 次の rule-inventory タスク再走でセットアップ通過を確認予定

Refs #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)