### PR TITLE
Establish structural test pattern with PRPopover orgSlug rule

### DIFF
--- a/package.json
+++ b/package.json
@@ -131,6 +131,7 @@
     "prettier-plugin-tailwindcss": "0.7.2",
     "react-router-auto-routes": "0.8.4",
     "tailwindcss": "4.2.2",
+    "ts-morph": "28.0.0",
     "tsx": "4.21.0",
     "typescript": "6.0.3",
     "vite": "8.0.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -270,6 +270,9 @@ importers:
       tailwindcss:
         specifier: 4.2.2
         version: 4.2.2
+      ts-morph:
+        specifier: 28.0.0
+        version: 28.0.0
       tsx:
         specifier: 4.21.0
         version: 4.21.0
@@ -3642,6 +3645,9 @@ packages:
     peerDependencies:
       '@testing-library/dom': '>=7.21.4'
 
+  '@ts-morph/common@0.29.0':
+    resolution: {integrity: sha512-35oUmphHbJvQ/+UTwFNme/t2p3FoKiGJ5auTjjpNTop2dyREspirjMy82PLSC1pnDJ8ah1GU98hwpVt64YXQsg==}
+
   '@tybys/wasm-util@0.10.1':
     resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
@@ -4140,6 +4146,9 @@ packages:
     peerDependencies:
       react: ^18 || ^19 || ^19.0.0-rc
       react-dom: ^18 || ^19 || ^19.0.0-rc
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@1.9.3:
     resolution: {integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==}
@@ -5485,6 +5494,9 @@ packages:
     resolution: {integrity: sha512-CiyeOxFT/JZyN5m0z9PfXw4SCBJ6Sygz1Dpl0wqjlhDEGGBP1GnsUVEL0p63hoG1fcj3fHynXi9NYO4nWOL+qQ==}
     engines: {node: '>= 0.8'}
 
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
+
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
     engines: {node: '>=8'}
@@ -6223,6 +6235,9 @@ packages:
   tr46@5.1.1:
     resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
     engines: {node: '>=18'}
+
+  ts-morph@28.0.0:
+    resolution: {integrity: sha512-Wp3tnZ2bzwxyTZMtgWVzXDfm7lB1Drz+y9DmmYH/L702PQhPyVrp3pkou3yIz4qjS14GY9kcpmLiOOMvl8oG1g==}
 
   ts-pattern@5.9.0:
     resolution: {integrity: sha512-6s5V71mX8qBUmlgbrfL33xDUwO0fq48rxAu2LBE11WBeGdpCPOsXksQbZJHvHwhrd3QjUusd3mAOM5Gg0mFBLg==}
@@ -10128,6 +10143,12 @@ snapshots:
     dependencies:
       '@testing-library/dom': 10.4.1
 
+  '@ts-morph/common@0.29.0':
+    dependencies:
+      minimatch: 10.2.5
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.16
+
   '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
@@ -10645,6 +10666,8 @@ snapshots:
     transitivePeerDependencies:
       - '@types/react'
       - '@types/react-dom'
+
+  code-block-writer@13.0.3: {}
 
   color-convert@1.9.3:
     dependencies:
@@ -12062,6 +12085,8 @@ snapshots:
 
   parseurl@1.3.3: {}
 
+  path-browserify@1.0.1: {}
+
   path-exists@4.0.0: {}
 
   path-expression-matcher@1.5.0: {}
@@ -12911,6 +12936,11 @@ snapshots:
     dependencies:
       punycode: 2.3.1
     optional: true
+
+  ts-morph@28.0.0:
+    dependencies:
+      '@ts-morph/common': 0.29.0
+      code-block-writer: 13.0.3
 
   ts-pattern@5.9.0: {}
 

--- a/tests/structural/README.md
+++ b/tests/structural/README.md
@@ -1,0 +1,41 @@
+# Structural tests
+
+ソースコードの構造そのものに対して assert する Vitest テスト。AST を ts-morph で読み、ルール違反があれば落ちる。
+
+## 何のためにあるか
+
+- `arch-review` ペルソナや人手レビューが prose で見ている規約のうち、機械的に判定可能なものをここに移す
+- ルール一覧は [`docs/rdd/issue-336-rule-inventory.md`](../../docs/rdd/issue-336-rule-inventory.md) のカテゴリ (a) machine-checkable
+- `pnpm test` の一部として CI で回す。失敗したらマージ阻止
+
+## ESLint や Biome ではなくここに書く理由
+
+- upflow は Biome を使っており、ESLint と二重持ちにしたくない
+- 単純なテキストパターンは regex / lefthook hook で済む。ここで扱うのは **AST 解析が必要なルール**
+- dependency-cruiser で完結するもの（layer / `~/` import / `.server.ts` 隔離）はそちらに任せる
+- それ以外、特に「kysely クエリの `WHERE organizationId` 必須」「action 内で `requireOrgMember` が `parseWithZod` より前」のような **制御フロー / 型情報を要するルール** がここの守備範囲
+
+## 書き方の型
+
+各テストは:
+
+1. `Project({ skipAddingFilesFromTsConfig: true, skipFileDependencyResolution: true })` でローダーを最小化（高速化）
+2. 走査対象ファイルを `addSourceFileAtPath` で 1 件ずつ追加
+3. `forEachDescendant` で AST を走査して違反を集める
+4. 最後に `expect(violations).toEqual([])`
+
+サンプル: [`popover-fetcher-key.test.ts`](./popover-fetcher-key.test.ts)
+
+## sanity check (synthetic violation)
+
+各テストには「matcher 自体が壊れていないか」を確かめるため、**意図的に違反させた合成ソース**で違反を検知できることを確認する `it()` を 1 本含める。これがないと、AST 走査ロジックがバグで何も拾わなくなった場合、テストは常に green のまま誰も気づかない。
+
+## 新しいルールを追加するときの流れ
+
+1. inventory.md の (a) カテゴリから対象を 1 つ決める
+2. `tests/structural/<rule-slug>.test.ts` を新規作成
+3. テスト内に **どのルールか** をコメントで書く（出典 file:line を含める）
+4. 走査対象ファイルを定数で列挙（無闇に `app/**/*` を全走査しない）
+5. matcher を書く + sanity check も忘れずに
+6. `pnpm vitest tests/structural/<rule-slug>.test.ts` で確認
+7. inventory.md の該当行に「このルールは structural test で強制」と追記する PR を別途出す（or 同じ PR で）

--- a/tests/structural/popover-fetcher-key.test.ts
+++ b/tests/structural/popover-fetcher-key.test.ts
@@ -1,0 +1,100 @@
+import path from 'node:path'
+import { Project, SyntaxKind } from 'ts-morph'
+import { describe, expect, it } from 'vitest'
+
+// Structural test: PRPopover and other tenant-scoped useFetcher calls must
+// include `orgSlug` in their `key` so that switching org doesn't show stale
+// `fetcher.data` from the previous tenant (cross-tenant leak risk).
+//
+// Source rule: docs/rdd/issue-314-pr-popover-resource-route.md (line 103),
+// catalogued in docs/rdd/issue-336-rule-inventory.md row DG-314-POPOVER.
+
+const ROOT = path.resolve(__dirname, '../..')
+
+const TENANT_FETCHER_FILES = [
+  // PRPopover hosts the canonical pattern.
+  'app/routes/$orgSlug/+components/pr-block.tsx',
+] as const
+
+interface KeyViolation {
+  file: string
+  line: number
+  keyText: string
+}
+
+function findUseFetcherKeyViolations(filePath: string): KeyViolation[] {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    skipFileDependencyResolution: true,
+  })
+  const sf = project.addSourceFileAtPath(path.resolve(ROOT, filePath))
+  const violations: KeyViolation[] = []
+
+  sf.forEachDescendant((node) => {
+    if (node.getKind() !== SyntaxKind.CallExpression) return
+    const call = node.asKindOrThrow(SyntaxKind.CallExpression)
+    if (call.getExpression().getText() !== 'useFetcher') return
+
+    const [arg] = call.getArguments()
+    if (!arg || arg.getKind() !== SyntaxKind.ObjectLiteralExpression) return
+
+    const obj = arg.asKindOrThrow(SyntaxKind.ObjectLiteralExpression)
+    const keyProp = obj.getProperty('key')
+    if (!keyProp) return
+
+    const keyText = keyProp.getText()
+    if (!keyText.includes('orgSlug')) {
+      violations.push({
+        file: filePath,
+        line: call.getStartLineNumber(),
+        keyText,
+      })
+    }
+  })
+
+  return violations
+}
+
+describe('Tenant-scoped useFetcher key must include orgSlug', () => {
+  for (const filePath of TENANT_FETCHER_FILES) {
+    it(`${filePath}`, () => {
+      const violations = findUseFetcherKeyViolations(filePath)
+      expect(violations).toEqual([])
+    })
+  }
+
+  it('catches a synthetic violation (sanity check on the matcher)', () => {
+    // Construct a temporary source that mimics the rule violation to confirm
+    // the matcher actually fires when the key is missing orgSlug.
+    const project = new Project({
+      skipAddingFilesFromTsConfig: true,
+      skipFileDependencyResolution: true,
+    })
+    const sf = project.createSourceFile(
+      'synthetic.tsx',
+      `
+        import { useFetcher } from 'react-router'
+        function X() {
+          const f = useFetcher({ key: 'pr-popover:no-org-slug-here' })
+          return null
+        }
+      `,
+    )
+    const violations: KeyViolation[] = []
+    sf.forEachDescendant((node) => {
+      if (node.getKind() !== SyntaxKind.CallExpression) return
+      const call = node.asKindOrThrow(SyntaxKind.CallExpression)
+      if (call.getExpression().getText() !== 'useFetcher') return
+      const [arg] = call.getArguments()
+      if (!arg || arg.getKind() !== SyntaxKind.ObjectLiteralExpression) return
+      const obj = arg.asKindOrThrow(SyntaxKind.ObjectLiteralExpression)
+      const keyProp = obj.getProperty('key')
+      if (!keyProp) return
+      const keyText = keyProp.getText()
+      if (!keyText.includes('orgSlug')) {
+        violations.push({ file: 'synthetic.tsx', line: 0, keyText })
+      }
+    })
+    expect(violations).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

issue #336 § B「Sensors の機械可読化」の最初の structural test を 1 本書く POC。inventory.md の優先順位 #3「PRPopover の useFetcher key に orgSlug を含める」(DG-314-POPOVER) を ts-morph + Vitest で機械検査する。

## Why structural test (not ESLint)

upflow は Biome を使っており、ESLint と二重持ちにすると CI が重複する。inventory が示した (a) 22 ルールの大半は AST 解析が要るので、Vitest structural test を **3 本柱の 1 本** として確立する。

- 単純テキスト → regex / lefthook
- import / layer → dependency-cruiser
- **AST 解析 → Vitest structural test ← これ**

## Changes

- **`tests/structural/popover-fetcher-key.test.ts`** (新規)
  - 実コード `app/routes/$orgSlug/+components/pr-block.tsx` の `useFetcher` 呼び出しを ts-morph でスキャン
  - `key` プロパティが `orgSlug` を含まないものを違反として収集
  - 合成 source code で意図的に違反させて matcher が機能することを確認する **sanity check** を併設
- **`tests/structural/README.md`** (新規)
  - パターンの根拠、書き方の型、sanity check の必要性、新規ルール追加手順を文書化
- **`ts-morph 28.0.0`** を devDependencies に追加

## Verification

```bash
$ pnpm vitest run tests/structural/popover-fetcher-key.test.ts
 Test Files  1 passed (1)
      Tests  2 passed (2)
   Duration  411ms

$ pnpm typecheck   # ✅
$ pnpm test        # ✅ 472 passed (前 470 + 今回 2)
```

## 次のステップ

inventory.md の (a) ルール残り 21 件を、ツール選定して順次:

- regex / lefthook で済む 5 件 (Easy 群)
- dependency-cruiser で 2 件 (`~/` import / `.server.ts` 隔離)
- structural test (このパターン) で 残り (auth guard 順序、`onConflict` キー、`WHERE organizationId`、`dayjs.utc` 等)

## ノート

ts-morph を選んだ理由は @typescript-eslint/parser より高レベル API で書きやすいから。`skipAddingFilesFromTsConfig: true` + `addSourceFileAtPath` で 1 ファイルずつロードするので、tsconfig 全プロジェクトロード（数秒）を回避し 411ms。

Refs #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)