### PR TITLE
Track mechanization progress in the rule inventory

### DIFF
--- a/docs/rdd/issue-336-rule-inventory.md
+++ b/docs/rdd/issue-336-rule-inventory.md
@@ -151,6 +151,19 @@
 
 逆に、(b) のコミュニケーション規範・設計トレードオフの説明・「やらない理由を言い切る」類は自動化が効きにくいため、ペルソナまたは人間レビューに残す。
 
+## Mechanization Progress
+
+機械化が完了したルールを実装手段とリンクで追跡する。すべての (a) が enforced になり CI で長期間 green が続いた段階で、`arch-review persona instruction 改訂提案` に従ってペルソナ instruction から該当項目を外す。
+
+### Enforced
+
+- **DG-314-POPOVER** — `issue-314-pr-popover-resource-route.md:103` — PRPopover の `useFetcher` key に `orgSlug` を含める
+  Vitest structural test (`tests/structural/popover-fetcher-key.test.ts`), shipped in #344
+
+### Pending
+
+残る (a) machine-checkable ルールは未着手。`機械化対象の優先順位` セクションの推奨実装順に従って順次対応する。
+
 ## Scan notes（走査方法のメモ）
 
 - 英文シグナル（`must` / `do not` / `never` 等）と日本語シグナル（`必ず` / `禁止` / `〜すること` 等）を手動走査し、設計の背景説明のみの文は (b) に寄せた。


### PR DESCRIPTION
## Summary

PR #344 で `DG-314-POPOVER` (PRPopover の `useFetcher` key に `orgSlug` を含める) を Vitest structural test で機械化したので、inventory にも反映させる。

`arch-review persona instruction 改訂提案` セクションに「すべての (a) が enforced になったらペルソナ instruction から該当項目を外す」と書かれているが、その移行を追跡する場所が無かった。新たに **Mechanization Progress** セクションを追加し、enforced / pending を明記する。

## Changes

`docs/rdd/issue-336-rule-inventory.md` に以下のセクションを追加:

- **Enforced**: `DG-314-POPOVER` を `tests/structural/popover-fetcher-key.test.ts` (#344) で enforce 済みと記録
- **Pending**: 残る (a) ルールは推奨実装順に従って未着手と明記

これで「あといくつ機械化が残っているか」「どのルールがどうやって enforce されているか」が inventory を読めば分かる。

Refs #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)