### PR TITLE
Enforce no-format() rule in batch/ with structural test

### DIFF
--- a/docs/rdd/issue-336-rule-inventory.md
+++ b/docs/rdd/issue-336-rule-inventory.md
@@ -162,7 +162,9 @@
 - **`String(e)` 禁止 / `getErrorMessage[ForLog]` 強制** — `CLAUDE.md:219` (inventory row 38) — `String(err)` は `[object Error]` になるので使わない
   Vitest structural test (`tests/structural/no-string-error.test.ts`), shipped in #346. 既存違反 4 箇所 (`run-in-worker.ts`、`classify-pull-requests.ts`、`llm-classify.ts`) は同 PR で `getErrorMessageForLog` に置換済み
 - **`~/` import エイリアス** — `CLAUDE.md:146-151` — `app/` 配下 import は `~/app/...` を使う。`../../` 以上の relative path はサイドリーフを跨ぎがちで refactor 不安定
-  Vitest structural test (`tests/structural/tilde-alias-import.test.ts`), shipped in this PR. 既存違反 11 箇所（`app/routes/$orgSlug/settings/...` および `workload/+components/team-stacks-chart.tsx`）は同 PR で `~/app/...` に置換済み
+  Vitest structural test (`tests/structural/tilde-alias-import.test.ts`), shipped in #347. 既存違反 11 箇所（`app/routes/$orgSlug/settings/...` および `workload/+components/team-stacks-chart.tsx`）は同 PR で `~/app/...` に置換済み
+- **batch では `.format(...)` 禁止 (helper を除く)** — `CLAUDE.md:137` — GitHub API の ISO 8601 をそのまま DB に保存し、独自フォーマット変換をかけない。レポート / スプレッドシート出力用には `batch/helper/timeformat.ts` の `timeFormatTz` を使う
+  Vitest structural test (`tests/structural/no-format-in-batch.test.ts`), shipped in this PR. 既存違反なし（`batch/helper/timeformat.ts` のみ legit、exempt list に登録済み）
 
 ### Pending
 

--- a/tests/structural/no-format-in-batch.test.ts
+++ b/tests/structural/no-format-in-batch.test.ts
@@ -1,0 +1,139 @@
+import { type Dirent, readdirSync } from 'node:fs'
+import path from 'node:path'
+import { Project, SyntaxKind } from 'ts-morph'
+import { describe, expect, it } from 'vitest'
+
+// Structural test: in batch/, do not call `.format(...)` to convert datetime
+// values. GitHub API returns ISO 8601 strings; save them to the DB as-is.
+// The only place a custom format is allowed is the dedicated helper at
+// `batch/helper/timeformat.ts`, which is for report / spreadsheet output.
+//
+// Source rule: CLAUDE.md:137, catalogued in
+// docs/rdd/issue-336-rule-inventory.md (inventory row "batch では GitHub API
+// の ISO 8601 をそのまま DB に保存し、独自フォーマット変換をかけない").
+
+const ROOT = path.resolve(__dirname, '../..')
+
+const SCAN_ROOT = 'batch'
+const SOURCE_EXTS = ['.ts', '.tsx']
+
+// Files where `.format(...)` is the documented intended behavior. Keep this
+// list as small as possible; every entry is an exception that must be
+// justified in CLAUDE.md or a relevant RDD.
+const EXEMPT_FILES = new Set<string>(['batch/helper/timeformat.ts'])
+
+function isTestFile(filename: string): boolean {
+  return /\.(test|spec)\.tsx?$/.test(filename)
+}
+
+function readEntries(dir: string): Dirent<string>[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+}
+
+function collectSourceFiles(absDir: string): string[] {
+  const out: string[] = []
+  const stack: string[] = [absDir]
+  for (let dir = stack.pop(); dir !== undefined; dir = stack.pop()) {
+    for (const entry of readEntries(dir)) {
+      if (entry.name === 'node_modules' || entry.name.startsWith('.')) continue
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(full)
+        continue
+      }
+      if (
+        SOURCE_EXTS.some((ext) => entry.name.endsWith(ext)) &&
+        !isTestFile(entry.name)
+      ) {
+        out.push(full)
+      }
+    }
+  }
+  return out
+}
+
+interface Violation {
+  file: string
+  line: number
+  text: string
+}
+
+function findFormatCalls(absFilePath: string): Violation[] {
+  const project = new Project({
+    skipAddingFilesFromTsConfig: true,
+    skipFileDependencyResolution: true,
+  })
+  const sf = project.addSourceFileAtPath(absFilePath)
+  const violations: Violation[] = []
+  const relPath = path.relative(ROOT, absFilePath)
+
+  sf.forEachDescendant((node) => {
+    if (node.getKind() !== SyntaxKind.CallExpression) return
+    const call = node.asKindOrThrow(SyntaxKind.CallExpression)
+    const expr = call.getExpression()
+    if (expr.getKind() !== SyntaxKind.PropertyAccessExpression) return
+    const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression)
+    if (propAccess.getName() !== 'format') return
+
+    violations.push({
+      file: relPath,
+      line: call.getStartLineNumber(),
+      text: call.getText().slice(0, 80),
+    })
+  })
+
+  return violations
+}
+
+describe('No `.format(...)` outside batch/helper/timeformat.ts', () => {
+  const matchedFiles = collectSourceFiles(path.resolve(ROOT, SCAN_ROOT)).filter(
+    (p) => !EXEMPT_FILES.has(path.relative(ROOT, p)),
+  )
+
+  it(`scans at least one file (matched ${matchedFiles.length})`, () => {
+    expect(matchedFiles.length).toBeGreaterThan(0)
+  })
+
+  it('has no `.format(...)` calls outside the timeformat helper', () => {
+    const allViolations: Violation[] = []
+    for (const abs of matchedFiles) {
+      allViolations.push(...findFormatCalls(abs))
+    }
+    expect(allViolations).toEqual([])
+  })
+
+  it('catches a synthetic violation (sanity check on the matcher)', () => {
+    const project = new Project({
+      skipAddingFilesFromTsConfig: true,
+      skipFileDependencyResolution: true,
+    })
+    const sf = project.createSourceFile(
+      'synthetic.ts',
+      `
+        import dayjs from 'dayjs'
+        export function bad(value: string) {
+          return dayjs(value).format('YYYY-MM-DD HH:mm:ss')
+        }
+      `,
+    )
+    const found: Violation[] = []
+    sf.forEachDescendant((node) => {
+      if (node.getKind() !== SyntaxKind.CallExpression) return
+      const call = node.asKindOrThrow(SyntaxKind.CallExpression)
+      const expr = call.getExpression()
+      if (expr.getKind() !== SyntaxKind.PropertyAccessExpression) return
+      const propAccess = expr.asKindOrThrow(SyntaxKind.PropertyAccessExpression)
+      if (propAccess.getName() !== 'format') return
+      found.push({
+        file: 'synthetic.ts',
+        line: call.getStartLineNumber(),
+        text: call.getText(),
+      })
+    })
+    expect(found).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

棚卸し Easy 残 2 件のうち #5「batch では GitHub API の ISO 8601 をそのまま DB に保存し、独自フォーマット変換をかけない」(CLAUDE.md:137) を構造テスト化。

## Rule

`batch/` 配下で `.format(...)` を呼ばない。GitHub API が返す ISO 8601 文字列をそのまま DB に流す。レポート / スプレッドシート出力など、書式変換が要る場面では専用ヘルパー `batch/helper/timeformat.ts` の `timeFormatTz` を経由する。

## Implementation

- `tests/structural/no-format-in-batch.test.ts` (新規)
  - `batch/` 配下の TS を ts-morph で走査
  - `xxx.format(...)` の `CallExpression` を検出
  - `batch/helper/timeformat.ts` のみ exempt list に登録（CLAUDE.md で許可されている helper）
  - 合成違反の sanity check 1 本

リファクタは無し（既存違反が helper 1 箇所のみ、それは合法）。

## Verification

```bash
$ pnpm vitest run tests/structural/no-format-in-batch.test.ts
 Test Files  1 passed (1)
      Tests  3 passed (3)

$ pnpm validate   # ✅ 481 passed
```

## Inventory

`docs/rdd/issue-336-rule-inventory.md` の Mechanization Progress § Enforced に 4 件目として記録。

これで Easy 5 件中 4 件が enforced。残り 1 件は #4 (DB 保存日時 ISO 8601、migration SQL の literal scan)。

Refs #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)