### PR TITLE
Silence regex-error logs in release-detect tests

### DIFF
--- a/batch/github/__tests__/release-detect.test.ts
+++ b/batch/github/__tests__/release-detect.test.ts
@@ -1,4 +1,5 @@
-import { describe, expect, test } from 'vitest'
+import { describe, expect, test, vi } from 'vitest'
+import { logger } from '~/batch/helper/logger'
 import type { ShapedGitHubPullRequest } from '../model'
 import {
   buildBranchReleaseLookup,
@@ -232,6 +233,7 @@ describe('buildTagReleaseList', () => {
   })
 
   test('無効な正規表現では空配列を返す', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {})
     const result = await buildTagReleaseList(
       {
         tags: async () => [
@@ -242,9 +244,14 @@ describe('buildTagReleaseList', () => {
     )
 
     expect(result).toEqual([])
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Invalid tag regex pattern'),
+    )
+    errorSpy.mockRestore()
   })
 
   test('長すぎるパターンでは空配列を返す', async () => {
+    const errorSpy = vi.spyOn(logger, 'error').mockImplementation(() => {})
     const result = await buildTagReleaseList(
       {
         tags: async () => [
@@ -255,6 +262,10 @@ describe('buildTagReleaseList', () => {
     )
 
     expect(result).toEqual([])
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining('Tag regex pattern too long'),
+    )
+    errorSpy.mockRestore()
   })
 })
 


### PR DESCRIPTION
## Summary

`pnpm test` 実行時に毎回出ていた赤字 2 行:

```
[error] Invalid tag regex pattern: [
[error] Tag regex pattern too long (201 chars)
```

の出所を特定して silence しました。

## 原因

`batch/github/__tests__/release-detect.test.ts` の 2 件のテストが、`buildTagReleaseList` の **エラーパス** を意図的に発火させて `[]` が返ることを検証している:

- `'無効な正規表現では空配列を返す'`: 不正 regex `'['` を渡す
- `'長すぎるパターンでは空配列を返す'`: 201 文字の長文を渡す

`buildTagReleaseList` (`batch/github/release-detect.ts`) はそれぞれの場合に `logger.error(...)` を呼んでから `[]` を返す設計。テスト自体は PASS していたが、`logger.error` の出力が test runner の stderr に流れて赤字として目立っていた。

## Fix

`vi.spyOn(logger, 'error').mockImplementation(() => {})` で出力を sink + 呼び出し検証に切り替え。

- 副作用としての出力が消える
- 「エラーパスが実際に通った」ことを `expect(errorSpy).toHaveBeenCalledWith(...)` で明示的に検証できるようになり、テストの精度が上がる

## Verification

```bash
$ pnpm test
 Test Files  60 passed | 1 skipped (61)
      Tests  481 passed | 2 skipped (483)
```

赤字 2 行が消えました。

🤖 Generated with [Claude Code](https://claude.com/claude-code)