### PR TITLE
Enforce DROP TABLE IF EXISTS in migrations with regex structural test

### DIFF
--- a/docs/rdd/issue-336-rule-inventory.md
+++ b/docs/rdd/issue-336-rule-inventory.md
@@ -166,7 +166,9 @@
 - **batch では `.format(...)` 禁止 (helper を除く)** — `CLAUDE.md:137` — GitHub API の ISO 8601 をそのまま DB に保存し、独自フォーマット変換をかけない。レポート / スプレッドシート出力用には `batch/helper/timeformat.ts` の `timeFormatTz` を使う
   Vitest structural test (`tests/structural/no-format-in-batch.test.ts`), shipped in #350. 既存違反なし（`batch/helper/timeformat.ts` のみ legit、exempt list に登録済み）
 - **`.server.ts` 隔離** — `CLAUDE.md:155-159` — `.server.ts` モジュールはクライアント束に出てはいけない。`app/components/`、`app/hooks/`、`app/types/`、それと `app/libs/` / `app/services/` の non-server ファイルからは import 禁止。型のみインポート（`import type { ... }`）はビルド時に消えるため許容
-  dependency-cruiser (`.dependency-cruiser.cjs` の `no-server-from-client-module` rule)、`pnpm lint:deps` で実行。`pnpm validate` の前段に組み込み済み。shipped in this PR. 既存違反なし
+  dependency-cruiser (`.dependency-cruiser.cjs` の `no-server-from-client-module` rule)、`pnpm lint:deps` で実行。`pnpm validate` の前段に組み込み済み。shipped in #352. 既存違反なし
+- **DG-MIGRATION-ATLAS** — `CLAUDE.md:127` + `step-implementation.md:20-27` — マイグレーション内の手動 `DROP TABLE` には `IF EXISTS` を付ける。Atlas が生成するテーブル再作成中の `DROP TABLE`（直前の `INSERT INTO new_X SELECT ... FROM X` で安全が担保されているもの）は対象外
+  Vitest structural test (`tests/structural/sql-drop-table-safety.test.ts`), shipped in this PR. SQL ファイルを正規表現で走査し、`DROP TABLE`（`IF EXISTS` 無し）について **直前に `INSERT INTO \`new\_<table>\` ... FROM \`<table>\`` があるか** を確認、無ければ違反とする。既存違反なし
 
 ### Pending
 

--- a/tests/structural/sql-drop-table-safety.test.ts
+++ b/tests/structural/sql-drop-table-safety.test.ts
@@ -54,16 +54,19 @@ interface Violation {
 const DROP_TABLE_REGEX =
   /(^|\n)\s*DROP\s+TABLE\s+(?!IF\s+EXISTS\s+)`?([A-Za-z_][A-Za-z0-9_]*)`?\s*;/gi
 
-function findUnsafeDropTables(absFilePath: string): Violation[] {
-  const text = readFileSync(absFilePath, 'utf8')
+function detectUnsafeDropsInText(text: string, filePath: string): Violation[] {
   const violations: Violation[] = []
-  const relPath = path.relative(ROOT, absFilePath)
 
   for (const match of text.matchAll(DROP_TABLE_REGEX)) {
     const table = match[2]
     const matchIndex = match.index ?? 0
     const before = text.slice(0, matchIndex)
-    const line = before.split('\n').length
+    // The regex captures a leading `\n` as part of the match (group 1), but
+    // `before` stops just before that `\n`. Include it when present so the
+    // reported line number points to the line where DROP TABLE actually sits.
+    const beforeWithCapturedNewline =
+      text[matchIndex] === '\n' ? `${before}\n` : before
+    const line = beforeWithCapturedNewline.split('\n').length
 
     // Atlas-style table rebuild: an INSERT INTO `new_<table>` ... FROM `<table>`
     // before this DROP TABLE in the same file. The Atlas pattern always uses
@@ -75,10 +78,15 @@ function findUnsafeDropTables(absFilePath: string): Violation[] {
     )
     if (rebuildPattern.test(before)) continue
 
-    violations.push({ file: relPath, line, table })
+    violations.push({ file: filePath, line, table })
   }
 
   return violations
+}
+
+function findUnsafeDropTables(absFilePath: string): Violation[] {
+  const text = readFileSync(absFilePath, 'utf8')
+  return detectUnsafeDropsInText(text, path.relative(ROOT, absFilePath))
 }
 
 describe('Manual DROP TABLE statements must include IF EXISTS', () => {
@@ -97,46 +105,25 @@ describe('Manual DROP TABLE statements must include IF EXISTS', () => {
   })
 
   it('catches a synthetic violation (manual DROP without IF EXISTS)', () => {
-    // Hand-rolled mini-runner against an in-memory SQL string: same regex,
-    // same rebuild check, no INSERT before the DROP.
     const text = ['-- some manual cleanup', 'DROP TABLE `legacy_users`;'].join(
       '\n',
     )
-
-    const violations: Violation[] = []
-    for (const match of text.matchAll(DROP_TABLE_REGEX)) {
-      const table = match[2]
-      const before = text.slice(0, match.index ?? 0)
-      const rebuildPattern = new RegExp(
-        `INSERT\\s+INTO\\s+\`new_${table}\`[\\s\\S]*?FROM\\s+\`${table}\``,
-        'i',
-      )
-      if (rebuildPattern.test(before)) continue
-      violations.push({ file: 'synthetic', line: 0, table })
-    }
+    const violations = detectUnsafeDropsInText(text, 'synthetic.sql')
     expect(violations).toHaveLength(1)
+    expect(violations[0]).toMatchObject({
+      file: 'synthetic.sql',
+      line: 2,
+      table: 'legacy_users',
+    })
   })
 
   it('does not flag the Atlas-style rebuild pattern', () => {
-    // Same regex, but with an INSERT INTO new_X ... FROM X before the DROP.
     const text = [
       'CREATE TABLE `new_users` (...);',
       'INSERT INTO `new_users` (id) SELECT id FROM `users`;',
       'DROP TABLE `users`;',
       'ALTER TABLE `new_users` RENAME TO `users`;',
     ].join('\n')
-
-    const violations: Violation[] = []
-    for (const match of text.matchAll(DROP_TABLE_REGEX)) {
-      const table = match[2]
-      const before = text.slice(0, match.index ?? 0)
-      const rebuildPattern = new RegExp(
-        `INSERT\\s+INTO\\s+\`new_${table}\`[\\s\\S]*?FROM\\s+\`${table}\``,
-        'i',
-      )
-      if (rebuildPattern.test(before)) continue
-      violations.push({ file: 'synthetic', line: 0, table })
-    }
-    expect(violations).toEqual([])
+    expect(detectUnsafeDropsInText(text, 'synthetic.sql')).toEqual([])
   })
 })

--- a/tests/structural/sql-drop-table-safety.test.ts
+++ b/tests/structural/sql-drop-table-safety.test.ts
@@ -1,0 +1,142 @@
+import { type Dirent, readdirSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+// Structural test: hand-written `DROP TABLE` statements in migrations must
+// include `IF EXISTS`. Atlas-generated table-rebuild blocks emit `DROP TABLE`
+// without `IF EXISTS` but only after a successful
+// `INSERT INTO `new_X` ... SELECT ... FROM `X`` for the same table — those
+// are safe to leave alone per CLAUDE.md:127.
+//
+// Source rule: CLAUDE.md:127 + .takt/facets/policies/step-implementation.md
+// (DG-MIGRATION-ATLAS), catalogued in docs/rdd/issue-336-rule-inventory.md.
+
+const ROOT = path.resolve(__dirname, '../..')
+const MIGRATIONS_ROOT = path.resolve(ROOT, 'db/migrations')
+
+function readEntries(dir: string): Dirent<string>[] {
+  try {
+    return readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return []
+  }
+}
+
+function collectSqlFiles(absDir: string): string[] {
+  const out: string[] = []
+  const stack: string[] = [absDir]
+  for (let dir = stack.pop(); dir !== undefined; dir = stack.pop()) {
+    for (const entry of readEntries(dir)) {
+      if (entry.name.startsWith('.')) continue
+      const full = path.join(dir, entry.name)
+      if (entry.isDirectory()) {
+        stack.push(full)
+        continue
+      }
+      if (entry.name.endsWith('.sql')) {
+        out.push(full)
+      }
+    }
+  }
+  return out
+}
+
+interface Violation {
+  file: string
+  line: number
+  table: string
+}
+
+// Match `DROP TABLE \`X\``; capture the table name. Skips the `IF EXISTS`
+// variant. Backticked or unquoted identifiers, case-insensitive on the
+// keywords. The leading line-or-start anchor avoids matching `DROP TABLE`
+// inside string literals starting mid-line.
+const DROP_TABLE_REGEX =
+  /(^|\n)\s*DROP\s+TABLE\s+(?!IF\s+EXISTS\s+)`?([A-Za-z_][A-Za-z0-9_]*)`?\s*;/gi
+
+function findUnsafeDropTables(absFilePath: string): Violation[] {
+  const text = readFileSync(absFilePath, 'utf8')
+  const violations: Violation[] = []
+  const relPath = path.relative(ROOT, absFilePath)
+
+  for (const match of text.matchAll(DROP_TABLE_REGEX)) {
+    const table = match[2]
+    const matchIndex = match.index ?? 0
+    const before = text.slice(0, matchIndex)
+    const line = before.split('\n').length
+
+    // Atlas-style table rebuild: an INSERT INTO `new_<table>` ... FROM `<table>`
+    // before this DROP TABLE in the same file. The Atlas pattern always uses
+    // `new_<original>` as the staging table, so checking for that and the
+    // `FROM \`<table>\`` clause is enough to recognize the safe context.
+    const rebuildPattern = new RegExp(
+      `INSERT\\s+INTO\\s+\`new_${table}\`[\\s\\S]*?FROM\\s+\`${table}\``,
+      'i',
+    )
+    if (rebuildPattern.test(before)) continue
+
+    violations.push({ file: relPath, line, table })
+  }
+
+  return violations
+}
+
+describe('Manual DROP TABLE statements must include IF EXISTS', () => {
+  const files = collectSqlFiles(MIGRATIONS_ROOT)
+
+  it(`scans at least one migration file (matched ${files.length})`, () => {
+    expect(files.length).toBeGreaterThan(0)
+  })
+
+  it('has no unsafe `DROP TABLE` statements', () => {
+    const allViolations: Violation[] = []
+    for (const abs of files) {
+      allViolations.push(...findUnsafeDropTables(abs))
+    }
+    expect(allViolations).toEqual([])
+  })
+
+  it('catches a synthetic violation (manual DROP without IF EXISTS)', () => {
+    // Hand-rolled mini-runner against an in-memory SQL string: same regex,
+    // same rebuild check, no INSERT before the DROP.
+    const text = ['-- some manual cleanup', 'DROP TABLE `legacy_users`;'].join(
+      '\n',
+    )
+
+    const violations: Violation[] = []
+    for (const match of text.matchAll(DROP_TABLE_REGEX)) {
+      const table = match[2]
+      const before = text.slice(0, match.index ?? 0)
+      const rebuildPattern = new RegExp(
+        `INSERT\\s+INTO\\s+\`new_${table}\`[\\s\\S]*?FROM\\s+\`${table}\``,
+        'i',
+      )
+      if (rebuildPattern.test(before)) continue
+      violations.push({ file: 'synthetic', line: 0, table })
+    }
+    expect(violations).toHaveLength(1)
+  })
+
+  it('does not flag the Atlas-style rebuild pattern', () => {
+    // Same regex, but with an INSERT INTO new_X ... FROM X before the DROP.
+    const text = [
+      'CREATE TABLE `new_users` (...);',
+      'INSERT INTO `new_users` (id) SELECT id FROM `users`;',
+      'DROP TABLE `users`;',
+      'ALTER TABLE `new_users` RENAME TO `users`;',
+    ].join('\n')
+
+    const violations: Violation[] = []
+    for (const match of text.matchAll(DROP_TABLE_REGEX)) {
+      const table = match[2]
+      const before = text.slice(0, match.index ?? 0)
+      const rebuildPattern = new RegExp(
+        `INSERT\\s+INTO\\s+\`new_${table}\`[\\s\\S]*?FROM\\s+\`${table}\``,
+        'i',
+      )
+      if (rebuildPattern.test(before)) continue
+      violations.push({ file: 'synthetic', line: 0, table })
+    }
+    expect(violations).toEqual([])
+  })
+})


### PR DESCRIPTION
## Summary

棚卸し Medium #8 (DG-MIGRATION-ATLAS、`CLAUDE.md:127` + `step-implementation.md:20-27`) を構造テストで機械化。

## Rule

マイグレーション SQL の手動 `DROP TABLE` には `IF EXISTS` を必ず付ける。Atlas 生成のテーブル再作成中の `DROP TABLE`（直前の `INSERT INTO \`new_X\` ... FROM \`X\`` で安全が担保されているもの）は対象外。

## Why regex (not SQL AST parser)

`sql-parser-cst` のような SQL AST パーサーも使えるが、今回ルール 1 件のために dependency を追加するのは投資対効果が悪い。判別ロジック自体は単純（`DROP TABLE` の前に `INSERT INTO new_<table>` があるか）で regex で十分頑健。

将来 SQL 安全性ルールが 2-3 件溜まったら（FK ON DELETE 必須、NOT NULL カラム追加時 DEFAULT 必須、等）、まとめて AST ベースに移行する判断を再考する。

## Implementation

- `tests/structural/sql-drop-table-safety.test.ts` (新規)
  - `db/migrations/**.sql` を `node:fs.readdirSync` で収集
  - 各ファイルを `readFileSync` で読み、`DROP TABLE`(`IF EXISTS` 無し) を regex で抽出
  - 各 hit について、それより前の本文に `INSERT INTO \`new_<table>\` ... FROM \`<table>\`` が出ているかをチェック (Atlas 再作成パターン)
  - 出ていなければ違反としてレポート
  - sanity check: 合成入力で「manual DROP は捕捉する」「rebuild パターンは見逃す」両方を検証

## Verification

```bash
$ pnpm vitest run tests/structural/sql-drop-table-safety.test.ts
 Test Files  1 passed (1)
      Tests  4 passed (4)

$ pnpm validate   # ✅ 485 passed
```

`db/migrations/` 配下、shared / tenant 両方の既存マイグレーション全件で違反 0。

## Inventory

`docs/rdd/issue-336-rule-inventory.md` の Mechanization Progress § Enforced に 6 件目として記録。

| 区分 | Enforced |
|---|---|
| Easy | 4/5 (#4 は Hard 再分類) |
| **Medium** | **2/6** ← 1 増加 |
| Hard | 0/12 |

Refs #336

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Documentation**
  * データベーステーブル削除の安全性ルール（DG-MIGRATION-ATLAS）をドキュメント化。マイグレーション内の `DROP TABLE` ステートメントが `IF EXISTS` 句を含むか、Atlas による安全な再構築パターンであることを確認します。

* **Tests**
  * マイグレーションファイル内の unsafe な `DROP TABLE` ステートメントを検出する構造テストを追加。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->