### PR TITLE
Skip lefthook in production installs to fix Docker build

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "format:fix": "prettier --cache -w . --experimental-cli",
     "lint": "biome lint .",
     "lint:deps": "dependency-cruiser --validate -- app batch",
-    "prepare": "lefthook install",
+    "prepare": "lefthook install || true",
     "db:setup": "mkdir -p data && run-s db:apply db:seed",
     "db:migrate-integrations-to-shared": "tsx db/migrate-integrations-to-shared.ts",
     "db:seed": "tsx db/seed.ts",


### PR DESCRIPTION
## Summary
- The Docker `production-deps` stage runs `pnpm install --prod`, which strips devDependencies and then triggers the `prepare` script. `lefthook` is a devDependency, so the script crashed with `sh: 1: lefthook: not found` and broke every `main` deploy since #340 restored the prepare hook.
- Append `|| true` so prod installs silently skip the hook while local dev installs still wire up the git hook (the pattern lefthook's docs recommend for prod-only environments).

## Test plan
- [ ] Confirm `🚀 Deploy` workflow passes on this branch (Docker build reaches subsequent stages instead of failing in `production-deps`)
- [ ] Local `pnpm install` still installs the git hook (lefthook output appears, `.git/hooks/pre-commit` updated)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * セットアップ処理の堅牢性を向上させました。インストール時に特定のツールが失敗した場合でも、プロセス全体が中断されないよう改善しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->