### PR TITLE
Prefilter sql-template-camelcase structural test to fix CI timeout

### DIFF
--- a/tests/structural/sql-template-camelcase-ref.test.ts
+++ b/tests/structural/sql-template-camelcase-ref.test.ts
@@ -1,4 +1,4 @@
-import { type Dirent, readdirSync } from 'node:fs'
+import { type Dirent, readdirSync, readFileSync } from 'node:fs'
 import path from 'node:path'
 import { Project, type SourceFile, SyntaxKind } from 'ts-morph'
 import { describe, expect, it } from 'vitest'
@@ -155,8 +155,20 @@ describe('No camelCase `table.column` in `sql` template literal text', () => {
       skipFileDependencyResolution: true,
     })
 
+    // ts-morph parsing is the dominant cost. Files that don't even mention
+    // a kysely-shape `sql` tag (`sql\`...\`` or `sql<T>\`...\``) can't
+    // contain a violation, so skip them before parsing.
+    const sqlTagPrefilter = /\bsql[<`]/
+    const candidateFiles = matchedFiles.filter((abs) => {
+      try {
+        return sqlTagPrefilter.test(readFileSync(abs, 'utf8'))
+      } catch {
+        return false
+      }
+    })
+
     const allViolations: Violation[] = []
-    for (const abs of matchedFiles) {
+    for (const abs of candidateFiles) {
       const sf = project.addSourceFileAtPath(abs)
       allViolations.push(
         ...findViolationsInSourceFile(sf, path.relative(ROOT, abs)),


### PR DESCRIPTION
## Summary
- The structural test added in #355 parses every TS/TSX file in `app/` + `batch/` with ts-morph (~870ms locally), pushing past vitest's 5s default timeout on CI runners. Observed on the post-merge deploy of #360.
- Prefilter the candidate file list by the regex `\bsql[<`]/` (matches both `sql\`...\`` and typed `sql<T>\`...\``) before handing files to ts-morph. Drops local test time from ~870ms to ~30ms, giving CI plenty of headroom.
- Synthetic-violation tests are untouched — they construct `SourceFile` in-memory and bypass the file scan.

## Test plan
- [x] `pnpm vitest run tests/structural/sql-template-camelcase-ref.test.ts` — 6 tests pass in ~200ms total
- [x] `pnpm test` — 491 pass / 2 skipped, no regressions
- [ ] CI 🚀 Deploy / ⚡ Vitest passes on this branch