### PR TITLE
Pass SENTRY_AUTH_TOKEN via BuildKit secret mount

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -163,9 +163,10 @@ jobs:
           build-args: |
             COMMIT_SHA=${{ github.sha }}
             SENTRY_DSN=${{ secrets.SENTRY_DSN }}
-            SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
             SENTRY_TRACES_SAMPLE_RATE=${{ secrets.SENTRY_TRACES_SAMPLE_RATE }}
             SENTRY_PUBLISH_RELEASE=1
+          secrets: |
+            sentry_auth_token=${{ secrets.SENTRY_AUTH_TOKEN }}
           provenance: false
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -75,17 +75,19 @@ COPY . .
 
 # Sentry (optional). DSN is baked into the client bundle at build time; server reads SENTRY_DSN at runtime.
 # SENTRY_PUBLISH_RELEASE=1 enables source map upload (requires SENTRY_AUTH_TOKEN).
+# SENTRY_AUTH_TOKEN is a real secret — passed via BuildKit secret mount so it
+# never lands in image layer history. Other Sentry vars are public/config.
 ARG SENTRY_DSN
-ARG SENTRY_AUTH_TOKEN
 ARG SENTRY_TRACES_SAMPLE_RATE
 ARG SENTRY_PUBLISH_RELEASE
 
-RUN SENTRY_DSN="$SENTRY_DSN" \
+RUN --mount=type=secret,id=sentry_auth_token \
+    SENTRY_DSN="$SENTRY_DSN" \
     VITE_SENTRY_DSN="$SENTRY_DSN" \
     SENTRY_TRACES_SAMPLE_RATE="$SENTRY_TRACES_SAMPLE_RATE" \
     VITE_SENTRY_TRACES_SAMPLE_RATE="$SENTRY_TRACES_SAMPLE_RATE" \
-    SENTRY_AUTH_TOKEN="$SENTRY_AUTH_TOKEN" \
     SENTRY_PUBLISH_RELEASE="$SENTRY_PUBLISH_RELEASE" \
+    SENTRY_AUTH_TOKEN="$([ -f /run/secrets/sentry_auth_token ] && cat /run/secrets/sentry_auth_token)" \
     pnpm run build
 
 


### PR DESCRIPTION
## Summary
- BuildKit's lint flagged `ARG SENTRY_AUTH_TOKEN` (Dockerfile:79) on every build with `SecretsUsedInArgOrEnv` — ARG values land in the build stage's layer history (visible via `docker history`), so a real secret should never go through ARG.
- Switch the token to `RUN --mount=type=secret,id=sentry_auth_token`, which exposes it via tmpfs only during that RUN and leaves no trace in any image layer.
- The other Sentry build-args (`SENTRY_DSN`, `SENTRY_TRACES_SAMPLE_RATE`, `SENTRY_PUBLISH_RELEASE`) stay as ARGs — DSN is intentionally baked into the client bundle, the rest are non-sensitive config.
- `deploy.yml` moves `SENTRY_AUTH_TOKEN` from `build-args:` into the new `secrets:` block of `docker/build-push-action@v7`.

## Behavior preserved
- Local `pnpm build`: no secret mount → the `[ -f /run/secrets/sentry_auth_token ]` guard short-circuits and `SENTRY_AUTH_TOKEN` ends up empty, same as the previous unset-ARG path. `SENTRY_PUBLISH_RELEASE` is still the gate that loads the sentryReactRouter plugin at all (per CLAUDE.md), so this branch is inert without the env var.
- CI `deploy.yml`: secret is now mounted via tmpfs; sentry CLI / vite plugin still receives it via the env var set in the same RUN.

## Test plan
- [ ] CI 🐳 Build job no longer reports `SecretsUsedInArgOrEnv` warning on Dockerfile#79
- [ ] CI 🚀 Deploy succeeds (Sentry release / source-map upload still works — `SENTRY_PUBLISH_RELEASE=1` path)
- [ ] After deploy, verify in Sentry that the new release appears with source maps attached