### PR TITLE
Run Playwright e2e in CI on PRs and main pushes

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,12 +156,18 @@ jobs:
       - name: 🏗 Build app
         run: pnpm run build
 
+      - name: 🔢 Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(node -p "require('./package.json').devDependencies['@playwright/test'] || require('./package.json').dependencies['@playwright/test']")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: 💾 Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: 🌐 Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,6 +123,67 @@ jobs:
       - name: ⚡ Run vitest
         run: pnpm run test
 
+  playwright:
+    name: 🎭 Playwright
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v6
+
+      - name: 🏄 Copy test env vars
+        run: cp .env.example .env
+
+      - uses: pnpm/action-setup@v5
+        name: Install pnpm
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: 🛠 Install Atlas
+        run: curl -sSf https://atlasgo.sh | sh
+
+      - name: 🛠 Setup Database
+        run: pnpm db:setup
+        env:
+          UPFLOW_DATA_DIR: ./data
+
+      - name: 🏗 Build app
+        run: pnpm run build
+
+      - name: 💾 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: 🌐 Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: 🌐 Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: 🎭 Run Playwright e2e
+        run: pnpm test:e2e:run
+        env:
+          UPFLOW_DATA_DIR: ./data
+
+      - name: ⬆️ Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   build:
     name: 🐳 Build
     # only build/deploy main branch on pushes


### PR DESCRIPTION
## Summary

- `deploy.yml` に `playwright` ジョブを追加し、PR/main push 時に e2e (PR #364 のダッシュボード smoke) を回す
- Playwright browser を `~/.cache/ms-playwright` で pnpm-lock.yaml キーでキャッシュ → 依存変化時のみダウンロード
- `ENABLE_E2E_LOGIN=1` は `pnpm start:e2e` script 内に閉じて運用 (workflow/job env や secret に出さない、漏れる先がない)
- 失敗時は `playwright-report` を 7 日間 artifact に上げる

## あえて見送ったこと

- **`deploy` ジョブの `needs:` に `playwright` を追加するゲート化は今回しない**。最初の数 PR で安定性を観察してから絞めたい。flaky な状態でゲートにすると `--no-verify` 誘惑を生むため

## Test plan

- [ ] このPRの CI 上で `playwright` ジョブが green になる
- [ ] 失敗ケース確認は別途ローカルで実施済み (PR #364 で 2/2 pass)
- [ ] 後続 PR で 2-3 回安定動作したら `deploy.needs` に追加する別 PR を切る

Refs #363, #364