### PR TITLE
Document takt operational gotchas and pre-select quiet mode

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -156,12 +156,18 @@ jobs:
       - name: 🏗 Build app
         run: pnpm run build
 
+      - name: 🔢 Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(node -p "require('./package.json').devDependencies['@playwright/test'] || require('./package.json').dependencies['@playwright/test']")
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: 💾 Cache Playwright browsers
         id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: 🌐 Install Playwright browsers
         if: steps.playwright-cache.outputs.cache-hit != 'true'

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -123,6 +123,67 @@ jobs:
       - name: ⚡ Run vitest
         run: pnpm run test
 
+  playwright:
+    name: 🎭 Playwright
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v6
+
+      - name: 🏄 Copy test env vars
+        run: cp .env.example .env
+
+      - uses: pnpm/action-setup@v5
+        name: Install pnpm
+
+      - name: ⎔ Setup node
+        uses: actions/setup-node@v6
+        with:
+          node-version-file: 'package.json'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install
+
+      - name: 🛠 Install Atlas
+        run: curl -sSf https://atlasgo.sh | sh
+
+      - name: 🛠 Setup Database
+        run: pnpm db:setup
+        env:
+          UPFLOW_DATA_DIR: ./data
+
+      - name: 🏗 Build app
+        run: pnpm run build
+
+      - name: 💾 Cache Playwright browsers
+        id: playwright-cache
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: playwright-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}
+
+      - name: 🌐 Install Playwright browsers
+        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: 🌐 Install Playwright system deps
+        if: steps.playwright-cache.outputs.cache-hit == 'true'
+        run: pnpm exec playwright install-deps chromium
+
+      - name: 🎭 Run Playwright e2e
+        run: pnpm test:e2e:run
+        env:
+          UPFLOW_DATA_DIR: ./data
+
+      - name: ⬆️ Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
   build:
     name: 🐳 Build
     # only build/deploy main branch on pushes

--- a/.takt/workflows/spec-implement-accept.yaml
+++ b/.takt/workflows/spec-implement-accept.yaml
@@ -3,6 +3,13 @@ description: 'Bootstrap -> Spec generation -> Spec refinement -> Implementation 
 max_steps: 30
 initial_step: setup
 
+# Pre-select "quiet" in the interactive mode menu so the operator only needs
+# Enter to confirm. Full TUI bypass requires takt >= 0.40 (issue nrslib/takt#605
+# closed 2026-05-02, not yet released as of takt 0.39.0). Revisit and switch to
+# `interactive_mode: none` + `skip_interactive_mode_selection: true` once
+# released — see issue #365.
+interactive_mode: quiet
+
 # Custom facets
 personas:
   bootstrapper: ../facets/personas/bootstrapper.md

--- a/docs/takt-ops.md
+++ b/docs/takt-ops.md
@@ -1,0 +1,84 @@
+# takt 運用メモ
+
+このリポジトリで [`takt`](https://github.com/nrslib/takt) を実運用したときに遭遇した挙動と回避策をまとめる。issue #365 の追跡ノート。
+
+## 起動
+
+### 推奨コマンド
+
+```bash
+takt -i <issue#> -w spec-implement-accept
+```
+
+`-w` は workflow 名を明示するため。省略すると `default` が選ばれてしまう (project-local default 指定の方法は要調査)。
+
+### TUI 対話モード (現状の挙動)
+
+`takt 0.39.0` は `-i` で起動しても「アシスタント / ペルソナ / クワイエット / Cancel」の選択 TUI が出る。Claude Code バックグラウンドや CI から puppet できない。
+
+**緩和策**: workflow YAML に `interactive_mode: quiet` を書くとデフォルト選択が quiet になり、Enter 1 回で進める。本リポジトリでは `.takt/workflows/spec-implement-accept.yaml` で設定済み。
+
+**完全 bypass**: upstream の [nrslib/takt#605](https://github.com/nrslib/takt/issues/605) (closed 2026-05-02) で `interactive_mode: none` と `skip_interactive_mode_selection` が追加された。0.39.0 にはまだ含まれない。**0.40.0 リリース後**にこのファイルと workflow YAML を更新する。
+
+## worktree
+
+### 「対話 → 実行 (execute)」では worktree が作られない
+
+upstream の [#412](https://github.com/nrslib/takt/issues/412) / [#411](https://github.com/nrslib/takt/issues/411) / [#482](https://github.com/nrslib/takt/issues/482) で「execute action では worktree を作らない」が design 決定済み。
+
+→ 「対話モードで /go して execute」フローでは現在の checkout 上で直接動く。`main` 上で takt を回すと作業中の uncommitted change と混ざるリスクあり。
+
+### worktree を確実に使いたい場合
+
+タスクをキューに積んでから run する経路:
+
+```bash
+takt add  # task spec 作成 → .takt/tasks/<slug>/order.md
+takt run  # キュー消化 (この経路では worktree が作られる)
+```
+
+または `takt --pipeline` (CI 用、worktree 無しで現在のブランチに直接 commit する別物なので注意)。
+
+実運用上の安全策: **takt 起動前に必ずクリーンな branch を切る**。`main` で起動しない。
+
+## 残骸
+
+### `order.md` がプロジェクト root に残る
+
+`-i` で直接起動した場合、`spec-draft` step の agent が `order.md` を **cwd (= project root)** に書く。takt 自身は `.takt/runs/<slug>/context/task/order.md` を期待するが、`-i` 経路ではこのファイルを書き出さないため agent が独自に作る。
+
+**回避策**: `.gitignore` に `/order.md` を追加済み (PR #364)。コミット時に巻き込まれない。
+
+upstream に「`-i` 経路でも takt 側で context/task/order.md を書き出す or facet prompt で path を明示できるようにする」を要望予定。
+
+## PR / git ops
+
+### `auto_pr: false` (現状)
+
+`.takt/config.yaml` で `auto_pr: false` 運用。ブランチ切り → commit → push → PR は人間が叩く。
+
+`auto_pr: true` に切り替えると supervise step 完了後に自動 PR 作成。次の takt run で 1 度試して挙動を見る予定。
+
+### ブランチ命名
+
+`pipeline.default_branch_prefix: 'takt/'` は **pipeline モード専用**。通常モード + worktree-execute 経路では適用されない。
+
+## Claude Code 連携
+
+### Skill 起動が takt 表面から見えない
+
+takt のステップが Claude Code 経由で `Skill('simplify')` など Claude Code skill を起動しても、takt の TUI には agent の最終 text response しか表示されない。「skill 使ったか?」が判別できないため誤解を生む。
+
+確認したい場合は Claude Code セッションの jsonl ログ (`~/.claude/projects/<project-hash>/<session-uuid>.jsonl`) で `tool_use.name == "Skill"` を grep する。
+
+upstream に「skill / sub-agent invocation を trace に拾う」を要望予定。
+
+### artifact discovery
+
+run 完了後の生成物 (worktree path / RDD ファイル / commit hash / 変更ファイル一覧) は手動 `git status` 頼り。upstream に `--report-json` 的な機械可読サマリを要望予定。
+
+## 関連
+
+- issue #365 (本ドキュメントの追跡 issue)
+- PR #364 (takt 初実運用 — e2e foundation)
+- nrslib/takt v0.39.0 / 0.40.0 (#605 含む)

--- a/docs/takt-ops.md
+++ b/docs/takt-ops.md
@@ -20,6 +20,16 @@ takt -i <issue#> -w spec-implement-accept
 
 **完全 bypass**: upstream の [nrslib/takt#605](https://github.com/nrslib/takt/issues/605) (closed 2026-05-02) で `interactive_mode: none` と `skip_interactive_mode_selection` が追加された。0.39.0 にはまだ含まれない。**0.40.0 リリース後**にこのファイルと workflow YAML を更新する。
 
+### 単発ワークフロー (issue 紐付けなし) のサクッと実行
+
+issue を伴わずワークフローだけ動かしたい場合は `-t` に 1 文字渡すと `passthrough` モードが選択肢に入り、menu 1 ステップ + 即実行で済む:
+
+```bash
+takt -w <ワークフロー名> -t y
+```
+
+**ただし `-i` を併用すると `-t` は無視される** (`routing.js` で `directTask = undefined` にリセットされるため)。issue 経路ではこの近道は使えず、上記の `interactive_mode: quiet` プリセレクトが現状最善。
+
 ## worktree
 
 ### 「対話 → 実行 (execute)」では worktree が作られない


### PR DESCRIPTION
## Summary

issue #365 (takt 運用改善) のローカル吸収トラックを 1 PR にまとめたもの。

- `.takt/workflows/spec-implement-accept.yaml` に `interactive_mode: quiet` を追加。0.39.0 では menu 自体は出るが**デフォルトが quiet になり Enter 1 回で進める**。完全 bypass は takt 0.40 (nrslib/takt#605) リリース後に再対応する旨を facet 内コメントに残してある。
- `docs/takt-ops.md` を新設。issue #365 で挙がった 10 項目を以下のグループ別に文書化:
  - 起動 (interactive mode 制約と緩和策)
  - worktree (execute = worktree なしが design / queue → run で worktree が生まれる仕様の整理)
  - 残骸 (root に order.md が出る原因と回避策)
  - PR/git ops (auto_pr 試運転計画)
  - Claude Code 連携 (skill 可視化 / artifact discovery が無いこと)

## あえてやらないこと

- `auto_pr: true` への切り替え: 次の takt 実運用で 1 度試して挙動を観察してから判断
- `spec-draft.md` facet の order.md path 明示: 将来 upstream 修正で解決する可能性が高い領域、文書化のみで先送り
- nrslib/takt への upstream issue 起票 (5 / 9 / 10): 別途まとめて起票予定

## Test plan

- [x] `pnpm validate` green (497 tests pass)
- [x] 次回 takt 実運用時に `interactive_mode: quiet` が menu のデフォルトになることを確認

Refs #365

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# リリースノート

* **Tests**
  * Playwright E2Eテストの自動実行機能を追加。ビルド後にテストが実行され、レポートが自動保存されます。

* **New Features**
  * taktワークフローの対話モードを簡素化。ユーザーの選択入力が不要になり、プロセスがより効率的に進みます。

* **Documentation**
  * takt運用ガイドを新規追加。実運用での推奨手順、既知の動作、および回避策をまとめました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->