### PR TITLE
Use `sprite exec --http-post` and meta.json polling so symphony tick survives long takt runs

### DIFF
--- a/bin/symphony.ts
+++ b/bin/symphony.ts
@@ -193,12 +193,23 @@ function classifyTakt(args: {
       elapsedMs,
     }
   }
-  // completed
+  // completed: require an explicit "no issues" marker in the supervise
+  // report. An empty / unparseable report means we cannot confirm success
+  // and is classified as transient — better to retry than to silently flip
+  // a bad run to in-review.
   const remaining = superviseReport.match(
     /Remaining Issues[^\n]*\n+([\s\S]*?)(\n## |$)/i,
   )
-  const tail = remaining?.[1]?.trim() ?? ''
-  if (tail === '' || /^なし。?$/.test(tail) || /^none\.?$/i.test(tail)) {
+  const tail = remaining?.[1]?.trim()
+  if (tail === undefined || tail === '') {
+    return {
+      outcome: 'failure_transient',
+      reason:
+        'takt meta.status=completed but the supervise report had no parseable Remaining Issues section',
+      elapsedMs,
+    }
+  }
+  if (/^なし。?$/.test(tail) || /^none\.?$/i.test(tail)) {
     return {
       outcome: 'success',
       reason: 'takt completed and supervise reports no remaining issues',
@@ -294,7 +305,13 @@ async function runTaktInSprite(
   // best-effort exit code. Either way, we follow up with a meta.json poll.
   await spriteExec(taktCmd, { stream: true })
 
+  // Sprite is sometimes slow to flush the just-written meta.json after
+  // takt's setup step. Retry briefly before declaring startup failure.
   let meta = await readLatestRunMeta(startIso)
+  for (let i = 0; i < 5 && meta === null; i++) {
+    await sleep(5_000)
+    meta = await readLatestRunMeta(startIso)
+  }
   if (meta === null) {
     return {
       superviseReport: '',
@@ -306,11 +323,15 @@ async function runTaktInSprite(
   const POLL_INTERVAL_MS = 30_000
   while (meta.status === 'running') {
     if (Date.now() - startMs >= budgetRemainingMs) {
+      // Stop the takt run inside the sprite before reporting; otherwise the
+      // process keeps consuming sprite resources until natural termination.
+      await stopTaktInSprite(issueNumber)
+      const final = await readLatestRunMeta(startIso)
       return {
         superviseReport: '',
         elapsedMs: Date.now() - startMs,
         metaStatus: 'budget_exceeded',
-        iterations: meta.iterations,
+        iterations: final?.iterations ?? meta.iterations,
       }
     }
     console.log(
@@ -329,6 +350,19 @@ async function runTaktInSprite(
     elapsedMs: Date.now() - startMs,
     metaStatus: meta.status,
     iterations: meta.iterations,
+  }
+}
+
+async function stopTaktInSprite(issueNumber: number): Promise<void> {
+  // Best-effort: takt --pipeline launches with the issue number in argv,
+  // so pkill -f matches the active process. Ignore exit codes — pkill
+  // returns 1 if no match, which is fine when the process already died.
+  try {
+    await spriteExec(
+      `pkill -TERM -f 'takt --pipeline -i ${issueNumber}' 2>/dev/null; sleep 5; pkill -KILL -f 'takt --pipeline -i ${issueNumber}' 2>/dev/null; true`,
+    )
+  } catch (e) {
+    console.warn('[stop] pkill failed:', e instanceof Error ? e.message : e)
   }
 }
 

--- a/bin/symphony.ts
+++ b/bin/symphony.ts
@@ -151,54 +151,135 @@ async function usedBudgetMs(issue: number): Promise<number> {
 interface TaktOutcome {
   outcome: 'success' | 'failure_transient' | 'failure_deterministic'
   reason: string
-  exitCode: number
   elapsedMs: number
 }
 
 /**
  * Heuristic outcome classification; M0 will replace this once takt's
- * supervise step emits a structured outcome field. Today we just look at
- * the takt exit code and a couple of strings in the supervise report.
+ * supervise step emits a structured outcome field. Today we look at the
+ * takt-reported `meta.status` and the "Remaining Issues" section of the
+ * supervise report.
  */
-function classifyTakt(
-  exitCode: number,
-  superviseReport: string,
-  elapsedMs: number,
-): TaktOutcome {
-  if (exitCode === 0) {
-    const remaining = superviseReport.match(
-      /Remaining Issues[^\n]*\n+([\s\S]*?)(\n## |$)/i,
-    )
-    const tail = remaining?.[1]?.trim() ?? ''
-    if (tail === '' || /^なし。?$/.test(tail) || /^none\.?$/i.test(tail)) {
-      return {
-        outcome: 'success',
-        reason: 'takt exited 0 and supervise reports no remaining issues',
-        exitCode,
-        elapsedMs,
-      }
+function classifyTakt(args: {
+  metaStatus:
+    | 'completed'
+    | 'failed'
+    | 'running'
+    | 'startup_failed'
+    | 'budget_exceeded'
+  superviseReport: string
+  elapsedMs: number
+  iterations?: number
+}): TaktOutcome {
+  const { metaStatus, superviseReport, elapsedMs, iterations } = args
+  if (metaStatus === 'startup_failed') {
+    return {
+      outcome: 'failure_transient',
+      reason: 'takt did not produce a run meta.json (startup failed)',
+      elapsedMs,
     }
+  }
+  if (metaStatus === 'budget_exceeded') {
     return {
       outcome: 'failure_deterministic',
-      reason: `takt exited 0 but supervise lists remaining issues: ${tail.slice(0, 200)}`,
-      exitCode,
+      reason: 'takt run exceeded per-issue budget without finishing',
+      elapsedMs,
+    }
+  }
+  if (metaStatus === 'failed' || metaStatus === 'running') {
+    return {
+      outcome: 'failure_transient',
+      reason: `takt meta.status=${metaStatus} after polling (iterations=${iterations ?? '?'})`,
+      elapsedMs,
+    }
+  }
+  // completed
+  const remaining = superviseReport.match(
+    /Remaining Issues[^\n]*\n+([\s\S]*?)(\n## |$)/i,
+  )
+  const tail = remaining?.[1]?.trim() ?? ''
+  if (tail === '' || /^なし。?$/.test(tail) || /^none\.?$/i.test(tail)) {
+    return {
+      outcome: 'success',
+      reason: 'takt completed and supervise reports no remaining issues',
       elapsedMs,
     }
   }
   return {
-    outcome: 'failure_transient',
-    reason: `takt exited with code ${exitCode}`,
-    exitCode,
+    outcome: 'failure_deterministic',
+    reason: `takt completed but supervise lists remaining issues: ${tail.slice(0, 200)}`,
     elapsedMs,
   }
 }
 
-async function runTaktInSprite(issueNumber: number): Promise<{
-  exitCode: number
+/**
+ * State written by takt itself into `.takt/runs/<slug>/meta.json`.
+ * Polled by symphony so that we don't depend on the sprite exec exit
+ * code, which is unreliable over `--http-post` on long sessions.
+ */
+interface TaktMeta {
+  runSlug: string
+  status: 'running' | 'completed' | 'failed'
+  startTime: string
+  updatedAt: string
+  endTime?: string
+  iterations?: number
+  currentStep?: string
+}
+
+async function spriteExec(
+  cmd: string,
+  opts: { stream?: boolean } = {},
+): Promise<{ code: number; stdout: string; stderr: string }> {
+  // `--http-post` survives the long-running case where the WebSocket would
+  // otherwise drop after ~15-17 min; the trade-off is that the exit code is
+  // best-effort, so callers must use other signals (meta.json, file
+  // existence) to determine real outcome. See issue #378.
+  return await run(
+    'sprite',
+    ['exec', '-s', SPRITE_NAME, '--http-post', '--', 'bash', '-lc', cmd],
+    opts.stream ? { streamPrefix: '[sprite] ' } : {},
+  )
+}
+
+async function readLatestRunMeta(
+  newerThanIso: string,
+): Promise<TaktMeta | null> {
+  const r = await spriteExec(
+    `cd ~/upflow && find .takt/runs -maxdepth 2 -name meta.json -newermt '${newerThanIso}' -printf '%T@ %p\\n' 2>/dev/null | sort -nr | head -1 | awk '{print $2}' | xargs -r cat 2>/dev/null`,
+  )
+  const out = r.stdout.trim()
+  if (!out) return null
+  try {
+    return JSON.parse(out) as TaktMeta
+  } catch {
+    return null
+  }
+}
+
+async function readSuperviseReport(runSlug: string): Promise<string> {
+  const r = await spriteExec(
+    `cat ~/upflow/.takt/runs/${runSlug}/reports/supervise-report.md 2>/dev/null || true`,
+  )
+  return r.stdout
+}
+
+async function sleep(ms: number): Promise<void> {
+  await new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+async function runTaktInSprite(
+  issueNumber: number,
+  budgetRemainingMs: number,
+): Promise<{
   superviseReport: string
   elapsedMs: number
+  metaStatus: TaktMeta['status'] | 'startup_failed' | 'budget_exceeded'
+  iterations?: number
 }> {
-  const start = Date.now()
+  const startMs = Date.now()
+  const startIso = dayjs.utc().subtract(5, 'second').toISOString()
+
   const taktCmd = [
     'cd ~/upflow',
     'git fetch --quiet',
@@ -207,32 +288,47 @@ async function runTaktInSprite(issueNumber: number): Promise<{
     'pnpm install --frozen-lockfile --silent',
     `takt --pipeline -i ${issueNumber} -w ${TAKT_WORKFLOW}`,
   ].join(' && ')
-  const r = await run(
-    'sprite',
-    ['exec', '-s', SPRITE_NAME, '--', 'bash', '-lc', taktCmd],
-    { streamPrefix: '[sprite] ' },
-  )
-  const elapsedMs = Date.now() - start
 
-  const reportPath =
-    'find .takt/runs -name supervise-report.md -newer ~/upflow/.git/HEAD | head -1'
-  const reportR = await run(
-    'sprite',
-    [
-      'exec',
-      '-s',
-      SPRITE_NAME,
-      '--',
-      'bash',
-      '-lc',
-      `cd ~/upflow && cat $(${reportPath}) 2>/dev/null || true`,
-    ],
-    {},
-  )
+  // First call: kick takt off and wait. Over --http-post the call may
+  // either return cleanly when takt finishes, or return mid-run with a
+  // best-effort exit code. Either way, we follow up with a meta.json poll.
+  await spriteExec(taktCmd, { stream: true })
+
+  let meta = await readLatestRunMeta(startIso)
+  if (meta === null) {
+    return {
+      superviseReport: '',
+      elapsedMs: Date.now() - startMs,
+      metaStatus: 'startup_failed',
+    }
+  }
+
+  const POLL_INTERVAL_MS = 30_000
+  while (meta.status === 'running') {
+    if (Date.now() - startMs >= budgetRemainingMs) {
+      return {
+        superviseReport: '',
+        elapsedMs: Date.now() - startMs,
+        metaStatus: 'budget_exceeded',
+        iterations: meta.iterations,
+      }
+    }
+    console.log(
+      `[poll] takt still running (step=${meta.currentStep ?? '?'} iter=${meta.iterations ?? '?'})`,
+    )
+    await sleep(POLL_INTERVAL_MS)
+    const next = await readLatestRunMeta(startIso)
+    if (next !== null) meta = next
+  }
+
+  const superviseReport =
+    meta.status === 'completed' ? await readSuperviseReport(meta.runSlug) : ''
+
   return {
-    exitCode: r.code,
-    superviseReport: reportR.stdout,
-    elapsedMs,
+    superviseReport,
+    elapsedMs: Date.now() - startMs,
+    metaStatus: meta.status,
+    iterations: meta.iterations,
   }
 }
 
@@ -284,17 +380,12 @@ async function tick(): Promise<void> {
 
   let result: TaktOutcome
   try {
-    const taktResult = await runTaktInSprite(issue.number)
-    result = classifyTakt(
-      taktResult.exitCode,
-      taktResult.superviseReport,
-      taktResult.elapsedMs,
-    )
+    const taktResult = await runTaktInSprite(issue.number, remainingMs)
+    result = classifyTakt(taktResult)
   } catch (e) {
     result = {
       outcome: 'failure_transient',
       reason: e instanceof Error ? e.message : String(e),
-      exitCode: -1,
       elapsedMs: Date.now() - dayjs(startedAt).valueOf(),
     }
   }


### PR DESCRIPTION
## Summary

issue #378 の対応。M1c (#373) で観測した「`sprite exec` の WebSocket が ~17 分で drop し takt が中途死する」問題を解消する。

### 変更点

- **`sprite exec --http-post` に切替**: HTTP/1.1 POST モードは長時間 request を維持できる (実測で 20 分の sleep を完走、後述検証参照)。
- **完了検出を `meta.json` polling に変更**: takt が `.takt/runs/<slug>/meta.json` に書き出す `status` field を 30 秒間隔で poll。`status === 'running'` の間は budget 範囲内でループ。`completed` / `failed` で打ち切り。
- **outcome 分類から exit code を削除**: `--http-post` の exit signal は best-effort なので、`meta.status` + supervise report の "Remaining Issues" セクションだけで分類するよう書き直し。
- **budget 超過の機械検出**: poll 中に残 budget を超えたら `failure_deterministic`（`budget_exceeded`）扱いで打ち切り。

### 検証

| 項目 | 旧 (WebSocket) | 新 (`--http-post`) |
|---|---|---|
| 5 分 sleep | OK | OK |
| 17 分付近の長時間 | drop して死亡 (M1c) | — |
| **20 分 sleep** | **未検証** (drop が早い) | **OK (sprite-start/end 両方記録、20:01 で完走)** |
| exit code 信頼性 | 高 | 低 (`Error: no exit frame received` が出ることあり) — meta.json で代替 |

### `--http-post` の使用条件

CLI doc に "non-TTY only" とあるため、interactive auth flow には引き続き WebSocket (`--tty`) が要る。symphony が呼ぶのは takt --pipeline (non-TTY) なので問題なし。

### Out of scope

- M1c 観測中に発生した sprite filesystem 破損 (#379) — 別 issue で再現性検証 + 対応
- M0 takt facet の構造化 outcome — まだ heuristic、別タスク

## Test plan

- [x] `pnpm typecheck` pass
- [x] `pnpm symphony:tick` の idle path: `[idle] no ready issues` で正常終了
- [x] **20 分 background sleep test**: `sprite exec --http-post -- bash -lc 'sleep 1200'` がプロセス完走、sprite 内の echo マーカーが両方記録された
- [ ] 実 takt 走行で完走確認 (#373 と同じ test issue で再走 — 別 follow-up タスク)

Closes #378. Refs #370, #373, #379.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリース ノート

* **改善**
  * 監視メカニズムの信頼性を大幅に向上させました。ステータス判定ロジックを最適化し、監視レポートに基づいた詳細な検証機能を実装。タイムアウト管理を強化し、エラー分類の精密化により、より正確で安定した運用体験を実現しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->