### PR TITLE
Symphony D2: in-sprite Service runner (poll-only, no public endpoint)

### DIFF
--- a/bin/symphony-runner.ts
+++ b/bin/symphony-runner.ts
@@ -16,6 +16,7 @@
 
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
+import type { ChildProcess } from 'node:child_process'
 import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { join } from 'node:path'
@@ -108,8 +109,18 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
   ].join(' ')
 
   // Stream stdout/stderr to the Service's log so it shows up in
-  // `sprite api .../services/symphony-runner/logs`.
-  const r = await run('bash', ['-lc', cmd], { streamPrefix: '[takt] ' })
+  // `sprite api .../services/symphony-runner/logs`. Don't keep them in
+  // memory — a long takt run can produce many MB of output.
+  const r = await run('bash', ['-lc', cmd], {
+    streamPrefix: '[takt] ',
+    captureOutput: false,
+    onChild: (child) => {
+      activeChild = child
+      child.on('exit', () => {
+        if (activeChild === child) activeChild = null
+      })
+    },
+  })
   const elapsedMs = Date.now() - startMs
 
   const runDir = findLatestRunDir(startMs)
@@ -218,6 +229,7 @@ async function reconcileOrphans(): Promise<void> {
 }
 
 let stopRequested = false
+let activeChild: ChildProcess | null = null
 
 async function loop(): Promise<void> {
   console.log(`[boot] symphony-runner starting at ${dayjs.utc().toISOString()}`)
@@ -245,10 +257,25 @@ async function loop(): Promise<void> {
   console.log('[shutdown] loop exited')
 }
 
+const FORWARD_GRACE_MS = 10_000
+
 for (const sig of ['SIGTERM', 'SIGINT'] as const) {
   process.on(sig, () => {
     console.log(`[signal] received ${sig}, requesting shutdown`)
     stopRequested = true
+    const child = activeChild
+    if (child !== null && child.exitCode === null) {
+      console.log(`[signal] forwarding SIGTERM to takt child pid=${child.pid}`)
+      child.kill('SIGTERM')
+      setTimeout(() => {
+        if (child.exitCode === null) {
+          console.log(
+            `[signal] takt child still alive after ${FORWARD_GRACE_MS / 1000}s, sending SIGKILL`,
+          )
+          child.kill('SIGKILL')
+        }
+      }, FORWARD_GRACE_MS).unref()
+    }
   })
 }
 

--- a/bin/symphony-runner.ts
+++ b/bin/symphony-runner.ts
@@ -1,0 +1,258 @@
+/**
+ * Symphony runner — long-lived loop that runs *inside* the worker sprite as
+ * a Service. Polls GitHub for `symphony:ready` issues, spawns takt as a
+ * direct child process, and transitions labels + posts attempt comments.
+ *
+ * This avoids the `sprite exec` long-connection failure mode (issue #378)
+ * because takt is now a local child process, not behind an HTTP exec.
+ *
+ * Concurrency is naturally 1 because the loop awaits one takt run at a
+ * time. On startup we reconcile any orphaned `symphony:running` issue
+ * from a prior crash by transitioning it to `failed` with a transient
+ * reason.
+ *
+ * See issue #370 for the overall design and #379 (D2) for this iteration.
+ */
+
+import dayjs from 'dayjs'
+import utc from 'dayjs/plugin/utc'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import { homedir } from 'node:os'
+import { join } from 'node:path'
+import {
+  BUDGET_MS,
+  type IssueRef,
+  LABEL,
+  TAKT_WORKFLOW,
+  type TaktMetaStatus,
+  classifyTakt,
+  elapsedMarker,
+  ghAddLabel,
+  ghComment,
+  ghIssueList,
+  ghRemoveLabel,
+  run,
+  sleep,
+  usedBudgetMs,
+} from './symphony-shared'
+
+dayjs.extend(utc)
+
+const POLL_INTERVAL_MS = 60_000
+const REPO_DIR = process.env.SYMPHONY_REPO_DIR ?? join(homedir(), 'upflow')
+
+interface TaktChildResult {
+  metaStatus: TaktMetaStatus
+  superviseReport: string
+  elapsedMs: number
+  iterations?: number
+}
+
+function findLatestRunDir(startedAtMs: number): string | null {
+  const runsRoot = join(REPO_DIR, '.takt', 'runs')
+  if (!existsSync(runsRoot)) return null
+  const candidates = readdirSync(runsRoot, { withFileTypes: true })
+    .filter((d) => d.isDirectory())
+    .map((d) => {
+      const full = join(runsRoot, d.name)
+      const meta = join(full, 'meta.json')
+      const mtime = existsSync(meta) ? statSync(meta).mtimeMs : 0
+      return { full, mtime }
+    })
+    .filter((c) => c.mtime >= startedAtMs - 5_000)
+    .sort((a, b) => b.mtime - a.mtime)
+  return candidates[0]?.full ?? null
+}
+
+interface TaktMeta {
+  status: TaktMetaStatus
+  iterations?: number
+}
+
+function readMeta(runDir: string): TaktMeta | null {
+  const path = join(runDir, 'meta.json')
+  if (!existsSync(path)) return null
+  try {
+    return JSON.parse(readFileSync(path, 'utf-8')) as TaktMeta
+  } catch {
+    return null
+  }
+}
+
+function readSuperviseReport(runDir: string): string {
+  const path = join(runDir, 'reports', 'supervise-report.md')
+  if (!existsSync(path)) return ''
+  return readFileSync(path, 'utf-8')
+}
+
+async function runTakt(issueNumber: number): Promise<TaktChildResult> {
+  const startMs = Date.now()
+  const cmd = [
+    'cd',
+    REPO_DIR,
+    '&&',
+    'git fetch --quiet',
+    '&&',
+    'git checkout main',
+    '&&',
+    'git pull --ff-only --quiet',
+    '&&',
+    'pnpm install --frozen-lockfile --silent',
+    '&&',
+    'takt',
+    '--pipeline',
+    '-i',
+    String(issueNumber),
+    '-w',
+    TAKT_WORKFLOW,
+  ].join(' ')
+
+  // Stream stdout/stderr to the Service's log so it shows up in
+  // `sprite api .../services/symphony-runner/logs`.
+  const r = await run('bash', ['-lc', cmd], { streamPrefix: '[takt] ' })
+  const elapsedMs = Date.now() - startMs
+
+  const runDir = findLatestRunDir(startMs)
+  if (runDir === null) {
+    return { metaStatus: 'startup_failed', superviseReport: '', elapsedMs }
+  }
+  const meta = readMeta(runDir)
+  const status: TaktMetaStatus =
+    meta?.status ?? (r.code === 0 ? 'completed' : 'failed')
+  return {
+    metaStatus: status,
+    superviseReport: status === 'completed' ? readSuperviseReport(runDir) : '',
+    elapsedMs,
+    iterations: meta?.iterations,
+  }
+}
+
+async function processIssue(issue: IssueRef): Promise<void> {
+  console.log(`[pick] #${issue.number} ${issue.title}`)
+  const startedAt = dayjs.utc().toISOString()
+  const used = await usedBudgetMs(issue.number)
+  const remainingMs = BUDGET_MS - used
+  if (remainingMs <= 0) {
+    await ghComment(
+      issue.number,
+      [
+        '🤖 symphony: budget exceeded, marking as failed',
+        `- used: ${Math.round(used / 60000)} min / ${BUDGET_MS / 60000} min`,
+        '- re-add `symphony:ready` after addressing the underlying issue to retry',
+      ].join('\n'),
+    )
+    await ghRemoveLabel(issue.number, LABEL.ready)
+    await ghAddLabel(issue.number, LABEL.failed)
+    return
+  }
+
+  await ghRemoveLabel(issue.number, LABEL.ready)
+  await ghAddLabel(issue.number, LABEL.running)
+  await ghComment(
+    issue.number,
+    [
+      `🤖 symphony attempt starting at ${startedAt}`,
+      `- workflow: ${TAKT_WORKFLOW}`,
+      `- runner: in-sprite Service`,
+      `- budget remaining: ${Math.round(remainingMs / 60000)} min`,
+    ].join('\n'),
+  )
+
+  let taktResult: TaktChildResult
+  try {
+    taktResult = await runTakt(issue.number)
+  } catch (e) {
+    taktResult = {
+      metaStatus: 'failed',
+      superviseReport: '',
+      elapsedMs: Date.now() - dayjs(startedAt).valueOf(),
+    }
+    console.error(
+      '[error] takt subprocess threw:',
+      e instanceof Error ? e.message : e,
+    )
+  }
+
+  const result = classifyTakt(taktResult)
+  const finishedAt = dayjs.utc().toISOString()
+  const nextLabel = result.outcome === 'success' ? LABEL.inReview : LABEL.failed
+  await ghRemoveLabel(issue.number, LABEL.running)
+  await ghAddLabel(issue.number, nextLabel)
+  await ghComment(
+    issue.number,
+    [
+      `🤖 symphony attempt complete at ${finishedAt}`,
+      `- outcome: ${result.outcome}`,
+      `- elapsed: ${Math.round(result.elapsedMs / 60000)} min`,
+      `- next label: ${nextLabel}`,
+      `- reason: ${result.reason}`,
+      '',
+      elapsedMarker(result.elapsedMs),
+    ].join('\n'),
+  )
+  console.log(`[done] #${issue.number} → ${nextLabel} (${result.outcome})`)
+}
+
+/**
+ * On Service startup, an issue can be left with `symphony:running` because
+ * the previous Service process died (sprite hibernation, restart, crash).
+ * Reconcile by transitioning to failed with a transient reason; the human
+ * can re-label `ready` to retry. Without this we'd never pick a new issue
+ * because the running guard would block forever.
+ */
+async function reconcileOrphans(): Promise<void> {
+  const orphans = await ghIssueList(LABEL.running)
+  for (const issue of orphans) {
+    console.log(`[orphan] #${issue.number} was left running, marking failed`)
+    await ghComment(
+      issue.number,
+      [
+        '🤖 symphony: previous attempt did not complete (Service restart or crash)',
+        '- transitioning to failed (transient reason)',
+        '- re-add `symphony:ready` to retry',
+      ].join('\n'),
+    )
+    await ghRemoveLabel(issue.number, LABEL.running)
+    await ghAddLabel(issue.number, LABEL.failed)
+  }
+}
+
+let stopRequested = false
+
+async function loop(): Promise<void> {
+  console.log(`[boot] symphony-runner starting at ${dayjs.utc().toISOString()}`)
+  console.log(`[boot] repo dir: ${REPO_DIR}`)
+  console.log(`[boot] poll interval: ${POLL_INTERVAL_MS / 1000}s`)
+  console.log(`[boot] budget per issue: ${BUDGET_MS / 60000} min`)
+
+  await reconcileOrphans()
+
+  while (!stopRequested) {
+    try {
+      const ready = await ghIssueList(LABEL.ready)
+      if (ready.length > 0) {
+        await processIssue(ready[0])
+      }
+    } catch (e) {
+      console.error(
+        '[error] loop iteration failed:',
+        e instanceof Error ? e.message : e,
+      )
+    }
+    if (stopRequested) break
+    await sleep(POLL_INTERVAL_MS)
+  }
+  console.log('[shutdown] loop exited')
+}
+
+for (const sig of ['SIGTERM', 'SIGINT'] as const) {
+  process.on(sig, () => {
+    console.log(`[signal] received ${sig}, requesting shutdown`)
+    stopRequested = true
+  })
+}
+
+loop().catch((err) => {
+  console.error('[fatal]', err instanceof Error ? err.message : err)
+  process.exit(1)
+})

--- a/bin/symphony-shared.ts
+++ b/bin/symphony-shared.ts
@@ -1,4 +1,4 @@
-import { spawn } from 'node:child_process'
+import { type ChildProcess, spawn } from 'node:child_process'
 
 export const REPO = 'coji/upflow'
 export const TAKT_WORKFLOW = 'spec-implement-accept'
@@ -24,23 +24,50 @@ export interface RunResult {
   stderr: string
 }
 
+export interface RunOptions {
+  input?: string
+  streamPrefix?: string
+  /**
+   * When false, do not buffer stdout/stderr in memory. Returned strings
+   * are empty. Useful for long-running children whose output is large
+   * and only needed live (already streaming via streamPrefix).
+   * Default true for backward compatibility.
+   */
+  captureOutput?: boolean
+  /**
+   * Invoked once with the live child handle right after spawn. Lets the
+   * caller forward signals (e.g. propagate SIGTERM during shutdown) or
+   * inspect the PID. Errors thrown here are swallowed so they cannot
+   * abort the run.
+   */
+  onChild?: (child: ChildProcess) => void
+}
+
 export async function run(
   cmd: string,
   args: readonly string[],
-  opts: { input?: string; streamPrefix?: string } = {},
+  opts: RunOptions = {},
 ): Promise<RunResult> {
+  const capture = opts.captureOutput !== false
   return await new Promise<RunResult>((resolve, reject) => {
     const child = spawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] })
+    if (opts.onChild) {
+      try {
+        opts.onChild(child)
+      } catch {
+        // Caller-side bookkeeping shouldn't block the run.
+      }
+    }
     let stdout = ''
     let stderr = ''
     child.stdout.on('data', (chunk: Buffer) => {
       const s = chunk.toString('utf-8')
-      stdout += s
+      if (capture) stdout += s
       if (opts.streamPrefix) process.stdout.write(`${opts.streamPrefix}${s}`)
     })
     child.stderr.on('data', (chunk: Buffer) => {
       const s = chunk.toString('utf-8')
-      stderr += s
+      if (capture) stderr += s
       if (opts.streamPrefix) process.stderr.write(`${opts.streamPrefix}${s}`)
     })
     child.on('error', (err) => reject(err))
@@ -190,28 +217,37 @@ export function classifyTakt(args: {
       elapsedMs,
     }
   }
-  const remaining = superviseReport.match(
-    /Remaining Issues[^\n]*\n+([\s\S]*?)(\n## |$)/i,
-  )
-  const tail = remaining?.[1]?.trim()
-  if (tail === undefined || tail === '') {
+  // Use takt's own structured judgment marker. The supervise-report
+  // contract (`.takt/facets/output-contracts/supervise-report.md`)
+  // requires `## Judgment: COMPLETE | FIX | SPEC_REVIEW`. Anything else
+  // means we can't trust the report; treat as transient and let a retry
+  // produce a clean one.
+  const judgment = superviseReport.match(
+    /^##\s*Judgment:\s*(COMPLETE|FIX|SPEC_REVIEW)\b/im,
+  )?.[1]
+  if (judgment === undefined) {
     return {
       outcome: 'failure_transient',
       reason:
-        'takt meta.status=completed but the supervise report had no parseable Remaining Issues section',
+        'takt meta.status=completed but supervise report had no `## Judgment:` marker',
       elapsedMs,
     }
   }
-  if (/^なし。?$/.test(tail) || /^none\.?$/i.test(tail)) {
+  if (judgment === 'COMPLETE') {
     return {
       outcome: 'success',
-      reason: 'takt completed and supervise reports no remaining issues',
+      reason: 'takt supervise judgment: COMPLETE',
       elapsedMs,
     }
   }
+  // FIX / SPEC_REVIEW — capture the Remaining Issues section for context
+  const remaining = superviseReport.match(
+    /Remaining Issues[^\n]*\n+([\s\S]*?)(\n## |$)/i,
+  )
+  const tail = remaining?.[1]?.trim() ?? ''
   return {
     outcome: 'failure_deterministic',
-    reason: `takt completed but supervise lists remaining issues: ${tail.slice(0, 200)}`,
+    reason: `takt supervise judgment: ${judgment}${tail ? ` — ${tail.slice(0, 200)}` : ''}`,
     elapsedMs,
   }
 }

--- a/bin/symphony-shared.ts
+++ b/bin/symphony-shared.ts
@@ -1,0 +1,225 @@
+import { spawn } from 'node:child_process'
+
+export const REPO = 'coji/upflow'
+export const TAKT_WORKFLOW = 'spec-implement-accept'
+export const BUDGET_MS = 90 * 60 * 1000
+
+export const LABEL = {
+  ready: 'symphony:ready',
+  running: 'symphony:running',
+  inReview: 'symphony:in-review',
+  failed: 'symphony:failed',
+} as const
+
+export interface IssueRef {
+  number: number
+  title: string
+  url: string
+  createdAt: string
+}
+
+export interface RunResult {
+  code: number
+  stdout: string
+  stderr: string
+}
+
+export async function run(
+  cmd: string,
+  args: readonly string[],
+  opts: { input?: string; streamPrefix?: string } = {},
+): Promise<RunResult> {
+  return await new Promise<RunResult>((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ['pipe', 'pipe', 'pipe'] })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.on('data', (chunk: Buffer) => {
+      const s = chunk.toString('utf-8')
+      stdout += s
+      if (opts.streamPrefix) process.stdout.write(`${opts.streamPrefix}${s}`)
+    })
+    child.stderr.on('data', (chunk: Buffer) => {
+      const s = chunk.toString('utf-8')
+      stderr += s
+      if (opts.streamPrefix) process.stderr.write(`${opts.streamPrefix}${s}`)
+    })
+    child.on('error', (err) => reject(err))
+    child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }))
+    if (opts.input !== undefined) {
+      child.stdin.end(opts.input)
+    } else {
+      child.stdin.end()
+    }
+  })
+}
+
+async function gh(args: readonly string[], input?: string): Promise<string> {
+  const r = await run('gh', args, { input })
+  if (r.code !== 0) {
+    throw new Error(`gh ${args.join(' ')} failed (${r.code}): ${r.stderr}`)
+  }
+  return r.stdout
+}
+
+export async function ghIssueList(label: string): Promise<IssueRef[]> {
+  const json = await gh([
+    'issue',
+    'list',
+    '--repo',
+    REPO,
+    '--state',
+    'open',
+    '--label',
+    label,
+    '--json',
+    'number,title,url,createdAt',
+    '--limit',
+    '20',
+  ])
+  const list = JSON.parse(json) as IssueRef[]
+  // Oldest first — gh issue list doesn't expose --sort; sort client-side.
+  return list.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
+}
+
+export async function ghAddLabel(issue: number, label: string): Promise<void> {
+  await gh([
+    'issue',
+    'edit',
+    String(issue),
+    '--repo',
+    REPO,
+    '--add-label',
+    label,
+  ])
+}
+
+export async function ghRemoveLabel(
+  issue: number,
+  label: string,
+): Promise<void> {
+  await gh([
+    'issue',
+    'edit',
+    String(issue),
+    '--repo',
+    REPO,
+    '--remove-label',
+    label,
+  ])
+}
+
+export async function ghComment(issue: number, body: string): Promise<void> {
+  await gh(
+    ['issue', 'comment', String(issue), '--repo', REPO, '--body-file', '-'],
+    body,
+  )
+}
+
+async function ghComments(issue: number): Promise<{ body: string }[]> {
+  const json = await gh([
+    'issue',
+    'view',
+    String(issue),
+    '--repo',
+    REPO,
+    '--json',
+    'comments',
+  ])
+  const parsed = JSON.parse(json) as { comments: { body: string }[] }
+  return parsed.comments
+}
+
+/**
+ * Sum elapsed_ms reported by previous symphony attempt comments. Lets us
+ * enforce per-issue budget across attempts without a separate state store.
+ */
+export async function usedBudgetMs(issue: number): Promise<number> {
+  const comments = await ghComments(issue)
+  let total = 0
+  for (const c of comments) {
+    const m = c.body.match(/symphony:elapsed_ms=(\d+)/)
+    if (m) total += Number.parseInt(m[1], 10)
+  }
+  return total
+}
+
+export interface TaktOutcome {
+  outcome: 'success' | 'failure_transient' | 'failure_deterministic'
+  reason: string
+  elapsedMs: number
+}
+
+export type TaktMetaStatus =
+  | 'completed'
+  | 'failed'
+  | 'running'
+  | 'startup_failed'
+  | 'budget_exceeded'
+
+/**
+ * Heuristic outcome classification; M0 will replace this once takt's
+ * supervise step emits a structured outcome field. Today we look at the
+ * takt-reported `meta.status` and the "Remaining Issues" section of the
+ * supervise report.
+ */
+export function classifyTakt(args: {
+  metaStatus: TaktMetaStatus
+  superviseReport: string
+  elapsedMs: number
+  iterations?: number
+}): TaktOutcome {
+  const { metaStatus, superviseReport, elapsedMs, iterations } = args
+  if (metaStatus === 'startup_failed') {
+    return {
+      outcome: 'failure_transient',
+      reason: 'takt did not produce a run meta.json (startup failed)',
+      elapsedMs,
+    }
+  }
+  if (metaStatus === 'budget_exceeded') {
+    return {
+      outcome: 'failure_deterministic',
+      reason: 'takt run exceeded per-issue budget without finishing',
+      elapsedMs,
+    }
+  }
+  if (metaStatus === 'failed' || metaStatus === 'running') {
+    return {
+      outcome: 'failure_transient',
+      reason: `takt meta.status=${metaStatus} after polling (iterations=${iterations ?? '?'})`,
+      elapsedMs,
+    }
+  }
+  const remaining = superviseReport.match(
+    /Remaining Issues[^\n]*\n+([\s\S]*?)(\n## |$)/i,
+  )
+  const tail = remaining?.[1]?.trim()
+  if (tail === undefined || tail === '') {
+    return {
+      outcome: 'failure_transient',
+      reason:
+        'takt meta.status=completed but the supervise report had no parseable Remaining Issues section',
+      elapsedMs,
+    }
+  }
+  if (/^なし。?$/.test(tail) || /^none\.?$/i.test(tail)) {
+    return {
+      outcome: 'success',
+      reason: 'takt completed and supervise reports no remaining issues',
+      elapsedMs,
+    }
+  }
+  return {
+    outcome: 'failure_deterministic',
+    reason: `takt completed but supervise lists remaining issues: ${tail.slice(0, 200)}`,
+    elapsedMs,
+  }
+}
+
+export function elapsedMarker(elapsedMs: number): string {
+  return `<!-- symphony:elapsed_ms=${elapsedMs} -->`
+}
+
+export function sleep(ms: number): Promise<void> {
+  return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}

--- a/bin/symphony.ts
+++ b/bin/symphony.ts
@@ -1,233 +1,34 @@
 /**
- * Symphony tick — see issue #370 for design and #372 for acceptance.
- * Picks one `symphony:ready` issue, runs takt --pipeline inside the worker
- * sprite, then transitions the label and posts an attempt comment. Single
- * shot; no watch loop. Concurrency capped at 1 by the running label guard.
+ * Symphony tick (local) — single-shot orchestrator that runs *outside* the
+ * sprite. Picks one `symphony:ready` issue, runs takt over `sprite exec
+ * --http-post`, then transitions labels. Useful for local debugging or
+ * one-off manual ticks; the always-on production path is the in-sprite
+ * Service in `bin/symphony-runner.ts`. See issue #370 for design.
  */
 
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
-import { spawn } from 'node:child_process'
+import {
+  BUDGET_MS,
+  LABEL,
+  TAKT_WORKFLOW,
+  type TaktMetaStatus,
+  type TaktOutcome,
+  classifyTakt,
+  elapsedMarker,
+  ghAddLabel,
+  ghComment,
+  ghIssueList,
+  ghRemoveLabel,
+  run,
+  sleep,
+  usedBudgetMs,
+} from './symphony-shared'
 
 dayjs.extend(utc)
 
-const REPO = 'coji/upflow'
 const SPRITE_NAME = 'symphony-worker'
-const TAKT_WORKFLOW = 'spec-implement-accept'
-const BUDGET_MS = 90 * 60 * 1000
 
-const LABEL = {
-  ready: 'symphony:ready',
-  running: 'symphony:running',
-  inReview: 'symphony:in-review',
-  failed: 'symphony:failed',
-} as const
-
-interface IssueRef {
-  number: number
-  title: string
-  url: string
-  createdAt: string
-}
-
-async function run(
-  cmd: string,
-  args: readonly string[],
-  opts: { input?: string; streamPrefix?: string } = {},
-): Promise<{ code: number; stdout: string; stderr: string }> {
-  return await new Promise((resolve, reject) => {
-    const child = spawn(cmd, args, {
-      stdio: ['pipe', 'pipe', 'pipe'],
-    })
-    let stdout = ''
-    let stderr = ''
-    child.stdout.on('data', (chunk: Buffer) => {
-      const s = chunk.toString('utf-8')
-      stdout += s
-      if (opts.streamPrefix) process.stdout.write(`${opts.streamPrefix}${s}`)
-    })
-    child.stderr.on('data', (chunk: Buffer) => {
-      const s = chunk.toString('utf-8')
-      stderr += s
-      if (opts.streamPrefix) process.stderr.write(`${opts.streamPrefix}${s}`)
-    })
-    child.on('error', (err) => reject(err))
-    child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }))
-    if (opts.input !== undefined) {
-      child.stdin.end(opts.input)
-    } else {
-      child.stdin.end()
-    }
-  })
-}
-
-async function gh(args: readonly string[], input?: string): Promise<string> {
-  const r = await run('gh', args, { input })
-  if (r.code !== 0) {
-    throw new Error(`gh ${args.join(' ')} failed (${r.code}): ${r.stderr}`)
-  }
-  return r.stdout
-}
-
-async function ghIssueList(label: string): Promise<IssueRef[]> {
-  const json = await gh([
-    'issue',
-    'list',
-    '--repo',
-    REPO,
-    '--state',
-    'open',
-    '--label',
-    label,
-    '--json',
-    'number,title,url,createdAt',
-    '--limit',
-    '20',
-  ])
-  const list = JSON.parse(json) as IssueRef[]
-  // Oldest first — gh issue list doesn't expose --sort; sort client-side.
-  return list.sort((a, b) => a.createdAt.localeCompare(b.createdAt))
-}
-
-async function ghAddLabel(issue: number, label: string): Promise<void> {
-  await gh([
-    'issue',
-    'edit',
-    String(issue),
-    '--repo',
-    REPO,
-    '--add-label',
-    label,
-  ])
-}
-
-async function ghRemoveLabel(issue: number, label: string): Promise<void> {
-  await gh([
-    'issue',
-    'edit',
-    String(issue),
-    '--repo',
-    REPO,
-    '--remove-label',
-    label,
-  ])
-}
-
-async function ghComment(issue: number, body: string): Promise<void> {
-  await gh(
-    ['issue', 'comment', String(issue), '--repo', REPO, '--body-file', '-'],
-    body,
-  )
-}
-
-async function ghComments(issue: number): Promise<{ body: string }[]> {
-  const json = await gh([
-    'issue',
-    'view',
-    String(issue),
-    '--repo',
-    REPO,
-    '--json',
-    'comments',
-  ])
-  const parsed = JSON.parse(json) as { comments: { body: string }[] }
-  return parsed.comments
-}
-
-/**
- * Sum elapsed_ms reported by previous symphony attempt comments. Lets us
- * enforce per-issue budget across attempts without a separate state store.
- */
-async function usedBudgetMs(issue: number): Promise<number> {
-  const comments = await ghComments(issue)
-  let total = 0
-  for (const c of comments) {
-    const m = c.body.match(/symphony:elapsed_ms=(\d+)/)
-    if (m) total += Number.parseInt(m[1], 10)
-  }
-  return total
-}
-
-interface TaktOutcome {
-  outcome: 'success' | 'failure_transient' | 'failure_deterministic'
-  reason: string
-  elapsedMs: number
-}
-
-/**
- * Heuristic outcome classification; M0 will replace this once takt's
- * supervise step emits a structured outcome field. Today we look at the
- * takt-reported `meta.status` and the "Remaining Issues" section of the
- * supervise report.
- */
-function classifyTakt(args: {
-  metaStatus:
-    | 'completed'
-    | 'failed'
-    | 'running'
-    | 'startup_failed'
-    | 'budget_exceeded'
-  superviseReport: string
-  elapsedMs: number
-  iterations?: number
-}): TaktOutcome {
-  const { metaStatus, superviseReport, elapsedMs, iterations } = args
-  if (metaStatus === 'startup_failed') {
-    return {
-      outcome: 'failure_transient',
-      reason: 'takt did not produce a run meta.json (startup failed)',
-      elapsedMs,
-    }
-  }
-  if (metaStatus === 'budget_exceeded') {
-    return {
-      outcome: 'failure_deterministic',
-      reason: 'takt run exceeded per-issue budget without finishing',
-      elapsedMs,
-    }
-  }
-  if (metaStatus === 'failed' || metaStatus === 'running') {
-    return {
-      outcome: 'failure_transient',
-      reason: `takt meta.status=${metaStatus} after polling (iterations=${iterations ?? '?'})`,
-      elapsedMs,
-    }
-  }
-  // completed: require an explicit "no issues" marker in the supervise
-  // report. An empty / unparseable report means we cannot confirm success
-  // and is classified as transient — better to retry than to silently flip
-  // a bad run to in-review.
-  const remaining = superviseReport.match(
-    /Remaining Issues[^\n]*\n+([\s\S]*?)(\n## |$)/i,
-  )
-  const tail = remaining?.[1]?.trim()
-  if (tail === undefined || tail === '') {
-    return {
-      outcome: 'failure_transient',
-      reason:
-        'takt meta.status=completed but the supervise report had no parseable Remaining Issues section',
-      elapsedMs,
-    }
-  }
-  if (/^なし。?$/.test(tail) || /^none\.?$/i.test(tail)) {
-    return {
-      outcome: 'success',
-      reason: 'takt completed and supervise reports no remaining issues',
-      elapsedMs,
-    }
-  }
-  return {
-    outcome: 'failure_deterministic',
-    reason: `takt completed but supervise lists remaining issues: ${tail.slice(0, 200)}`,
-    elapsedMs,
-  }
-}
-
-/**
- * State written by takt itself into `.takt/runs/<slug>/meta.json`.
- * Polled by symphony so that we don't depend on the sprite exec exit
- * code, which is unreliable over `--http-post` on long sessions.
- */
 interface TaktMeta {
   runSlug: string
   status: 'running' | 'completed' | 'failed'
@@ -275,8 +76,17 @@ async function readSuperviseReport(runSlug: string): Promise<string> {
   return r.stdout
 }
 
-async function sleep(ms: number): Promise<void> {
-  await new Promise<void>((resolve) => setTimeout(resolve, ms))
+async function stopTaktInSprite(issueNumber: number): Promise<void> {
+  // Best-effort: takt --pipeline launches with the issue number in argv,
+  // so pkill -f matches the active process. Ignore exit codes — pkill
+  // returns 1 if no match, which is fine when the process already died.
+  try {
+    await spriteExec(
+      `pkill -TERM -f 'takt --pipeline -i ${issueNumber}' 2>/dev/null; sleep 5; pkill -KILL -f 'takt --pipeline -i ${issueNumber}' 2>/dev/null; true`,
+    )
+  } catch (e) {
+    console.warn('[stop] pkill failed:', e instanceof Error ? e.message : e)
+  }
 }
 
 async function runTaktInSprite(
@@ -285,7 +95,7 @@ async function runTaktInSprite(
 ): Promise<{
   superviseReport: string
   elapsedMs: number
-  metaStatus: TaktMeta['status'] | 'startup_failed' | 'budget_exceeded'
+  metaStatus: TaktMetaStatus
   iterations?: number
 }> {
   const startMs = Date.now()
@@ -300,13 +110,8 @@ async function runTaktInSprite(
     `takt --pipeline -i ${issueNumber} -w ${TAKT_WORKFLOW}`,
   ].join(' && ')
 
-  // First call: kick takt off and wait. Over --http-post the call may
-  // either return cleanly when takt finishes, or return mid-run with a
-  // best-effort exit code. Either way, we follow up with a meta.json poll.
   await spriteExec(taktCmd, { stream: true })
 
-  // Sprite is sometimes slow to flush the just-written meta.json after
-  // takt's setup step. Retry briefly before declaring startup failure.
   let meta = await readLatestRunMeta(startIso)
   for (let i = 0; i < 5 && meta === null; i++) {
     await sleep(5_000)
@@ -323,8 +128,6 @@ async function runTaktInSprite(
   const POLL_INTERVAL_MS = 30_000
   while (meta.status === 'running') {
     if (Date.now() - startMs >= budgetRemainingMs) {
-      // Stop the takt run inside the sprite before reporting; otherwise the
-      // process keeps consuming sprite resources until natural termination.
       await stopTaktInSprite(issueNumber)
       const final = await readLatestRunMeta(startIso)
       return {
@@ -353,19 +156,6 @@ async function runTaktInSprite(
   }
 }
 
-async function stopTaktInSprite(issueNumber: number): Promise<void> {
-  // Best-effort: takt --pipeline launches with the issue number in argv,
-  // so pkill -f matches the active process. Ignore exit codes — pkill
-  // returns 1 if no match, which is fine when the process already died.
-  try {
-    await spriteExec(
-      `pkill -TERM -f 'takt --pipeline -i ${issueNumber}' 2>/dev/null; sleep 5; pkill -KILL -f 'takt --pipeline -i ${issueNumber}' 2>/dev/null; true`,
-    )
-  } catch (e) {
-    console.warn('[stop] pkill failed:', e instanceof Error ? e.message : e)
-  }
-}
-
 async function tick(): Promise<void> {
   const startedAt = dayjs.utc().toISOString()
   console.log(`[tick] started at ${startedAt}`)
@@ -389,12 +179,14 @@ async function tick(): Promise<void> {
   const used = await usedBudgetMs(issue.number)
   const remainingMs = BUDGET_MS - used
   if (remainingMs <= 0) {
-    const msg = [
-      '🤖 symphony: budget exceeded, marking as failed',
-      `- used: ${Math.round(used / 60000)} min / ${BUDGET_MS / 60000} min`,
-      '- re-add `symphony:ready` after addressing the underlying issue to retry',
-    ].join('\n')
-    await ghComment(issue.number, msg)
+    await ghComment(
+      issue.number,
+      [
+        '🤖 symphony: budget exceeded, marking as failed',
+        `- used: ${Math.round(used / 60000)} min / ${BUDGET_MS / 60000} min`,
+        '- re-add `symphony:ready` after addressing the underlying issue to retry',
+      ].join('\n'),
+    )
     await ghRemoveLabel(issue.number, LABEL.ready)
     await ghAddLabel(issue.number, LABEL.failed)
     return
@@ -437,7 +229,7 @@ async function tick(): Promise<void> {
       `- next label: ${nextLabel}`,
       `- reason: ${result.reason}`,
       '',
-      `<!-- symphony:elapsed_ms=${result.elapsedMs} -->`,
+      elapsedMarker(result.elapsedMs),
     ].join('\n'),
   )
   console.log(`[done] #${issue.number} → ${nextLabel} (${result.outcome})`)

--- a/docs/symphony-setup.md
+++ b/docs/symphony-setup.md
@@ -141,7 +141,46 @@ sprite exec -- bash -lc 'cd ~/upflow && cursor-agent -p --force "say only: hello
 
 それぞれ `hello` を返せば認証 + 動作完了。
 
-## 10. メンテナンス
+## 10. Symphony Runner Service の登録
+
+長時間 takt を `sprite exec` 越しに動かすと HTTP/WebSocket 接続が切れる (issue #378 参照)。
+そこで `bin/symphony-runner.ts` を sprite 内の Service として常駐させ、外向き poll で sprite を起動させたまま GitHub から `symphony:ready` issue を拾わせる。
+
+### Service の登録
+
+```bash
+sprite api -X PUT /v1/sprites/symphony-worker/services/symphony-runner \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "cmd": "bash",
+    "args": ["-lc", "cd ~/upflow && git pull --ff-only --quiet && pnpm install --frozen-lockfile --silent && pnpm symphony:run"]
+  }'
+```
+
+### 起動
+
+```bash
+sprite api -X POST /v1/sprites/symphony-worker/services/symphony-runner/start
+```
+
+### ログ確認
+
+```bash
+sprite api /v1/sprites/symphony-worker/services/symphony-runner/logs?lines=200
+```
+
+### 停止
+
+```bash
+sprite api -X POST /v1/sprites/symphony-worker/services/symphony-runner/stop
+```
+
+### Service が落ちた場合
+
+Service は sprite が wake する際に auto-restart される (sprites.dev の Service 仕様)。
+manual restart したい場合は上記 `start` を再実行。
+
+## 11. メンテナンス
 
 ### CLI の更新
 

--- a/docs/symphony-setup.md
+++ b/docs/symphony-setup.md
@@ -146,6 +146,12 @@ sprite exec -- bash -lc 'cd ~/upflow && cursor-agent -p --force "say only: hello
 長時間 takt を `sprite exec` 越しに動かすと HTTP/WebSocket 接続が切れる (issue #378 参照)。
 そこで `bin/symphony-runner.ts` を sprite 内の Service として常駐させ、外向き poll で sprite を起動させたまま GitHub から `symphony:ready` issue を拾わせる。
 
+### 前提
+
+Service は GitHub 操作を sprite 内の `gh` CLI 経由で行う。**§7 の `gh auth login` が済んでいて `~/.config/gh/hosts.yml` に token が保存されていること**が前提。
+`GH_TOKEN` / `GITHUB_TOKEN` env を Service に渡す必要はない (`gh` が自動で credential を読む)。
+別 PAT で動かしたいときだけ Service spec の `env` で渡す。
+
 ### Service の登録
 
 ```bash

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
     "start": "NODE_ENV=production NODE_OPTIONS='--import ./instrument.server.mjs' react-router-serve ./build/server/index.js",
     "start:e2e": "NODE_ENV=test ENABLE_E2E_LOGIN=1 PORT=8811 BETTER_AUTH_URL=http://localhost:8811 NODE_OPTIONS='--import ./instrument.server.mjs' react-router-serve ./build/server/index.js",
     "symphony:tick": "tsx bin/symphony.ts tick",
+    "symphony:run": "tsx bin/symphony-runner.ts",
     "format": "prettier --cache -c . --experimental-cli",
     "format:fix": "prettier --cache -w . --experimental-cli",
     "lint": "biome lint .",


### PR DESCRIPTION
## Summary

issue #379 (sprite fs corruption の根本原因 = sprite exec の長時間接続) と issue #378 残課題への根本対応。

これまで `bin/symphony.ts` は ローカルから `sprite exec` 越しに takt を回していたが、http-post でも 50 分前後で接続が切れる。設計を反転して **takt を sprite 内 Service として動かす**:

- 公開 HTTP endpoint は作らない (D1 案は却下、attack surface が大きい)
- Service は GitHub を outbound で 60 秒ごとに poll、その poll 自体が "active TCP" として sprite 起動を維持
- 認証は GitHub PAT のみ (Service は sprite 内、claude/codex/cursor token は sprite に閉じてる)
- Concurrency=1 は loop 構造で自然に enforced

## 実装

- **`bin/symphony-shared.ts`** (新規): gh / 分類 / budget / sleep の共通ユーティリティ。ローカル tick とランナー両方で参照。
- **`bin/symphony-runner.ts`** (新規): sprite 内で動く長寿命ループ。SIGTERM/SIGINT で graceful 停止。起動時に \`symphony:running\` が残っている issue があれば「Service 再起動による中断」として \`failed\` に reconcile (孤児防止)。
- **`bin/symphony.ts`** (refactored): shared module 利用に変更、挙動は同じ。デバッグ用途の単発 tick として残す。
- **`package.json`**: \`pnpm symphony:run\` で runner を起動。
- **`docs/symphony-setup.md`** §10: Service 登録 / start / stop / logs / 再起動の手順を追加。

## やらないこと

- public HTTP endpoint (D1) は採用しない
- Service の auto-restart 監視 (Routine 経由 watchdog) は別 PR
- M0 (takt facet 構造化 outcome) はまだ heuristic のまま

## Test plan

- [x] \`pnpm validate\` pass (497 tests pass)
- [x] \`pnpm symphony:tick\` の idle path で動作確認 (refactor 後も互換)
- [ ] sprite に Service を登録して end-to-end で 1 issue 完走 (別 follow-up セッションで実走)

Closes #379. Refs #370, #378.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * 長時間稼働するランナーサービスを追加。GitHub課題を定期チェックして1件ずつ処理し、実行結果に応じてラベルと状況を自動更新、試行履歴をコメントで記録します。予算超過時の扱いと再試行制御を含む。

* **Documentation**
  * ランナーの登録・起動・ログ確認・停止と自動再起動に関するセットアップ手順を追記。

* **Refactor**
  * オーケストレーション共通処理を共有ユーティリティに集約。

* **Chores**
  * ランナー起動用のnpmスクリプトを追加。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->