### PR TITLE
Add self-review checklist to CLAUDE.md before pushing PRs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,28 @@ LLM に投げるプロンプト（system instruction 等）を作成・編集す
 5. 凝集度が高いか: 関数・モジュールが単一の責務に集中しているか。複数の関心事が混在していたら分割する
 6. 結合度が低いか: 依存を引数で受け取れるようにしてテスト可能にする。ロジックの重複は共通化する
 
+### PR を出す前の self-review
+
+happy path だけ書いて push、レビューで指摘を受けて直す、という流れを減らすために `git push` の前に **必ず一度** 以下を声に出して確認する。CodeRabbit / 人間レビューが拾うパターンを先回りで潰すための関門。
+
+1. **既存の output contract / type / facet を full read で参照したか**
+   - 出力フォーマットを heuristic で grep する前に、契約ファイル (`.takt/facets/output-contracts/*.md`、`*.d.ts`、schema) を全部読んで構造マーカーを使う。例: takt の supervise 出力なら `## Judgment: COMPLETE | FIX | SPEC_REVIEW` を直接読む。Remaining Issues セクションを正規表現で拾うのは最後の手段
+2. **failure / cleanup path を 1 周なぞる**
+   - signal handler (SIGTERM/SIGINT) が必要な subprocess を spawn したか? 該当する場合、子プロセスへの伝播 + grace timeout + SIGKILL fallback を仕込んだか
+   - 長時間 stream を扱うとき stdout/stderr を全量バッファしていないか (`captureOutput: false` 相当の逃げ道があるか)
+   - ファイルや lock の cleanup、tmp dir の削除、http connection の close
+3. **transient vs deterministic を分けたか**
+   - 「empty / parse 失敗 / 一時的に存在しない」を success に倒していないか。**確証が取れない曖昧ケースは failure_transient**。retry した方が安全
+   - 1 回目 read miss は backoff retry してから fail にしているか
+4. **入力 validation の strictness**
+   - regex は意図通り厳密か (例: `!==?` は `!=` も通す。`!==` を要求するなら `!==` と書く)
+   - allow list / enum 比較は完全一致か、prefix 一致で済ませて事故らないか
+5. **やったこと / やらなかったこと を PR 説明に書いたか**
+   - 「scope 外で skip した観察」「heuristic で済ませた箇所」「次の PR に持ち越す改善」を明示
+   - 「やらない」理由は「APIコスト倍増で実益がない」のように具体的に (「スコープ外」だけは禁則)
+
+このチェックリストに引っかかった項目を先に直してから commit + push する。「self-review で N 項目修正した」と PR description にも書くと、レビュー側が二度手間にならない。
+
 ### Git ワークフロー
 
 - **main に直接 push 禁止**: コミットは必ずブランチを切って PR 経由でマージする。`git push origin main` は絶対にやらない


### PR DESCRIPTION
## Summary

直近の Symphony 関連 PR (#364 / #366 / #377 / #382 / #383) で **CodeRabbit が同じ 5 系統の指摘を繰り返し**ていた:

1. **Resource cleanup** — SIGTERM forwarding, memory buffering, child kill
2. **既存 contract 未活用** — takt `## Judgment: COMPLETE` marker が output-contract に書いてあるのに使わず heuristic で実装、retry meta 読みなし
3. **Optimistic empty handling** — empty supervise を success に誤分類
4. **Regex strictness** — NODE_ENV `!=?` で `!=` も通る
5. **Silent skip** — 「scope 外」と書くだけで理由を述べない

これは **私 (Claude Opus 4.7) のデフォルト挙動の弱点** で、user prompt が悪いわけではない (Anthropic 公式 [Claude 4 best practices](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices) に「self-check を append すべき」と明記されている)。

CLAUDE.md に 5 項目の self-review pass を追加して、`git push` 前に必ず一度通る関門を作る。今後の PR で同種指摘が減るはず。

## やらないこと

- pre-commit hook での自動強制 (オーバーキル、まず CLAUDE.md instruction で挙動が変わるか観察)
- 既存 PR の retro-fix (該当 PR は個別対応済み)

## Test plan

- [x] CLAUDE.md の追記内容を本 PR の self-review として実際に走らせた (doc only なので項目 1-4 は該当なし、項目 5 を commit message + PR body で実施)

Refs Anthropic [Claude 4 best practices](https://docs.claude.com/en/docs/build-with-claude/prompt-engineering/claude-4-best-practices)