### PR TITLE
Force HOME=/data/home for symphony SSH sessions

### DIFF
--- a/docs/symphony-setup.md
+++ b/docs/symphony-setup.md
@@ -51,7 +51,7 @@ container は `gh auth` 未設定を検知して `sleep infinity` に入る (`in
 ## 4. SSH で interactive auth を一回だけ
 
 ```bash
-flyctl ssh console --app upflow-symphony
+flyctl ssh console --app upflow-symphony -u symphony
 # 以下、container 内 (HOME は /data/home に自動設定済み)
 
 gh auth login                        # GitHub device flow
@@ -66,7 +66,9 @@ ls $HOME/.codex/auth.json $HOME/.config/cursor/auth.json
 exit
 ```
 
-`/etc/profile.d/symphony-home.sh` で SSH session の `HOME` を `/data/home` に固定しているので、上記コマンドの保存先は自動的に Volume 配下になる。machine restart や image rebuild を跨いで永続化する。`codex login` は browser-redirect 形式で remote machine だと完了しないので、必ず `--device-auth` を付ける。
+`-u symphony` で SSH すると、container 内のサービスユーザー (uid 1001) として log in する。同じ uid で auth ファイルを書くので、`pnpm symphony:serve` がそのまま読める。`/etc/profile.d/symphony-home.sh` が SSH session の `HOME` を `/data/home` に固定しているので、保存先は自動的に Volume 配下になり、machine restart や image rebuild を跨いで永続化する。`codex login` は browser-redirect 形式で remote machine だと完了しないので、必ず `--device-auth` を付ける。
+
+`-u symphony` を忘れて root として SSH してしまっても、entrypoint.sh が次回起動時に `chown -R 1001:1001 /data` で所有権を直すので最終的には動く。ただ毎回 `-u symphony` を付けておけば余計な restart を 1 回省ける。
 
 ## 5. 再起動して通常動作モードへ
 

--- a/docs/symphony-setup.md
+++ b/docs/symphony-setup.md
@@ -68,7 +68,7 @@ exit
 
 `-u symphony` で SSH すると、container 内のサービスユーザー (uid 1001) として log in する。同じ uid で auth ファイルを書くので、`pnpm symphony:serve` がそのまま読める。`/etc/profile.d/symphony-home.sh` が SSH session の `HOME` を `/data/home` に固定しているので、保存先は自動的に Volume 配下になり、machine restart や image rebuild を跨いで永続化する。`codex login` は browser-redirect 形式で remote machine だと完了しないので、必ず `--device-auth` を付ける。
 
-`-u symphony` を忘れて root として SSH してしまっても、entrypoint.sh が次回起動時に `chown -R 1001:1001 /data` で所有権を直すので最終的には動く。ただ毎回 `-u symphony` を付けておけば余計な restart を 1 回省ける。
+root として SSH してしまうと auth ファイルが `/root` 配下に書かれて Volume に永続化されない可能性がある (`fly ssh console` がどのモードで shell を起動するかに依存する)。必ず `-u symphony` を付ける。
 
 ## 5. 再起動して通常動作モードへ
 

--- a/docs/symphony-setup.md
+++ b/docs/symphony-setup.md
@@ -52,22 +52,21 @@ container は `gh auth` 未設定を検知して `sleep infinity` に入る (`in
 
 ```bash
 flyctl ssh console --app upflow-symphony
-# 以下、container 内
-mkdir -p /data/home && export HOME=/data/home
+# 以下、container 内 (HOME は /data/home に自動設定済み)
 
 gh auth login                        # GitHub device flow
 claude auth login --claudeai          # Claude Max
-codex login                           # Codex Plus
+codex login --device-auth             # Codex Plus (remote: device flow)
 cursor-agent login                    # Cursor Pro
 
-# 全部成功してることを確認
+# 全部成功してることを確認 (すべて /data/home 配下に保存されているはず)
 gh auth status
 claude auth status
-ls /data/home/.codex/auth.json /data/home/.config/cursor/auth.json
+ls $HOME/.codex/auth.json $HOME/.config/cursor/auth.json
 exit
 ```
 
-token はすべて Volume (`/data/home`) 配下に書かれる。machine restart や image rebuild を跨いで永続化する。
+`/etc/profile.d/symphony-home.sh` で SSH session の `HOME` を `/data/home` に固定しているので、上記コマンドの保存先は自動的に Volume 配下になる。machine restart や image rebuild を跨いで永続化する。`codex login` は browser-redirect 形式で remote machine だと完了しないので、必ず `--device-auth` を付ける。
 
 ## 5. 再起動して通常動作モードへ
 

--- a/infra/symphony/Dockerfile
+++ b/infra/symphony/Dockerfile
@@ -57,6 +57,17 @@ RUN groupadd --system --gid 1001 symphony \
   && mkdir -p /app /data \
   && chown -R symphony:symphony /app /data
 
+# `flyctl ssh console` opens an interactive login shell (default: root). Without
+# this, HOME stays at /root for root sessions and /home/symphony for `-u symphony`,
+# so any `gh auth login` etc. lands on the ephemeral image rootfs and is lost on
+# restart. Forcing HOME=/data/home here keeps every interactive auth on the Volume.
+RUN printf '%s\n' \
+      'export HOME=/data/home' \
+      'mkdir -p "$HOME" 2>/dev/null || true' \
+      'cd "$HOME" 2>/dev/null || true' \
+    > /etc/profile.d/symphony-home.sh \
+  && chmod +x /etc/profile.d/symphony-home.sh
+
 WORKDIR /app
 COPY --chown=symphony:symphony infra/symphony/entrypoint.sh /app/entrypoint.sh
 RUN chmod +x /app/entrypoint.sh

--- a/infra/symphony/Dockerfile
+++ b/infra/symphony/Dockerfile
@@ -20,9 +20,11 @@ ARG CODEX_VERSION
 # - curl + ca-certificates: cursor-agent installer + general HTTPS
 # - openssl: needed by gh / git over https
 # - procps: ps / pkill used by symphony for child cleanup
+# - gosu: lets entrypoint chown the Volume as root then drop to the
+#         service user, so SSH'd-as-root auth files self-heal each boot
 RUN apt-get update \
   && apt-get install --no-install-recommends -y \
-       git curl ca-certificates openssl procps tini gnupg \
+       git curl ca-certificates openssl procps tini gnupg gosu \
   && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
        | gpg --dearmor -o /usr/share/keyrings/githubcli-archive-keyring.gpg \
   && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
@@ -74,7 +76,10 @@ RUN chmod +x /app/entrypoint.sh
 
 ENV HOME=/data/home
 
-USER symphony
+# Entrypoint starts as root so it can chown the Volume contents (auth files
+# created from a SSH'd-as-root session belong to root and would otherwise
+# block the unprivileged service user). After fixing ownership, the script
+# re-execs itself under `gosu symphony`. There is no `USER symphony` here.
 
 # Fly proxy hits port 8080. The HTTP server in bin/symphony-serve.ts
 # listens on 0.0.0.0:8080.

--- a/infra/symphony/Dockerfile
+++ b/infra/symphony/Dockerfile
@@ -54,8 +54,11 @@ RUN mkdir -p /tmp/cursor-install \
 
 # Run the server as a non-root user. /data is the Volume mount and is
 # owned by symphony so the persisted auth/repo state can be read+written.
+# `--no-create-home` because HOME is forced to /data/home everywhere
+# (Dockerfile ENV, /etc/profile.d/symphony-home.sh, entrypoint.sh) — a
+# physical /home/symphony directory is dead weight.
 RUN groupadd --system --gid 1001 symphony \
-  && useradd --system --uid 1001 --gid symphony --create-home --home-dir /home/symphony symphony \
+  && useradd --system --uid 1001 --gid symphony --no-create-home --home-dir /home/symphony symphony \
   && mkdir -p /app /data \
   && chown -R symphony:symphony /app /data
 
@@ -66,7 +69,6 @@ RUN groupadd --system --gid 1001 symphony \
 RUN printf '%s\n' \
       'export HOME=/data/home' \
       'mkdir -p "$HOME" 2>/dev/null || true' \
-      'cd "$HOME" 2>/dev/null || true' \
     > /etc/profile.d/symphony-home.sh \
   && chmod +x /etc/profile.d/symphony-home.sh
 

--- a/infra/symphony/entrypoint.sh
+++ b/infra/symphony/entrypoint.sh
@@ -22,16 +22,19 @@ HOME_DIR=/data/home
 # instead of a stuck state.
 if [ "$(id -u)" = "0" ]; then
   mkdir -p "$HOME_DIR"
-  chown -R 1001:1001 /data
+  chown -R symphony:symphony /data
   exec gosu symphony env HOME="$HOME_DIR" "$0" "$@"
 fi
 
 mkdir -p "$HOME_DIR"
 export HOME="$HOME_DIR"
 
-# Persist sprite-style auth + git config under the Volume so first-boot
-# `gh auth login` / `claude auth login` etc. via SSH stay valid across
-# machine restarts and image redeploys.
+# HOME=/data/home is locked in via three independent paths — drop any one
+# and the auth-check below silently looks at the wrong directory:
+#   1. /etc/profile.d/symphony-home.sh — for `flyctl ssh console` sessions
+#   2. HOME_DIR=/data/home above       — for this script's own logic
+#   3. `env HOME=...` on the gosu line — for the root → symphony hand-off
+# All three are intentional belt-and-suspenders; see PR #386 for context.
 
 if [ ! -f "$HOME/.config/gh/hosts.yml" ]; then
   echo "[entrypoint] gh is not authenticated yet."

--- a/infra/symphony/entrypoint.sh
+++ b/infra/symphony/entrypoint.sh
@@ -9,6 +9,18 @@ set -euo pipefail
 REPO_DIR="${SYMPHONY_REPO_DIR:-/data/upflow}"
 HOME_DIR="${HOME:-/data/home}"
 
+# Root path: fix Volume ownership and re-exec self as symphony (uid 1001).
+# `flyctl ssh console` defaults to root, so any `gh auth login` from SSH
+# writes auth files under /data/home owned by root. Without this chown,
+# the symphony user can't read them and the server crash-loops on every
+# boot. Fixing perms here makes the wrong SSH user a transient mistake
+# instead of a stuck state.
+if [ "$(id -u)" = "0" ]; then
+  mkdir -p "$HOME_DIR"
+  chown -R 1001:1001 /data
+  exec gosu symphony "$0" "$@"
+fi
+
 mkdir -p "$HOME_DIR"
 export HOME="$HOME_DIR"
 

--- a/infra/symphony/entrypoint.sh
+++ b/infra/symphony/entrypoint.sh
@@ -41,7 +41,7 @@ if [ ! -f "$HOME/.config/gh/hosts.yml" ]; then
   echo "[entrypoint] flyctl ssh console into this machine and run:"
   echo "[entrypoint]   gh auth login"
   echo "[entrypoint]   claude auth login --claudeai"
-  echo "[entrypoint]   codex login"
+  echo "[entrypoint]   codex login --device-auth"
   echo "[entrypoint]   cursor-agent login"
   echo "[entrypoint] then 'flyctl machine restart' to drop into the server."
   echo "[entrypoint] sleeping so the machine stays up for ssh access..."

--- a/infra/symphony/entrypoint.sh
+++ b/infra/symphony/entrypoint.sh
@@ -7,7 +7,12 @@
 set -euo pipefail
 
 REPO_DIR="${SYMPHONY_REPO_DIR:-/data/upflow}"
-HOME_DIR="${HOME:-/data/home}"
+# Force HOME to the Volume unconditionally. The Dockerfile sets
+# `ENV HOME=/data/home`, but we re-exec across `gosu symphony` and the
+# child saw a different HOME in practice (auth check failed even though
+# /data/home/.config/gh/hosts.yml was on disk). Hard-coding here, plus
+# explicit `env HOME=...` on the gosu line below, removes the ambiguity.
+HOME_DIR=/data/home
 
 # Root path: fix Volume ownership and re-exec self as symphony (uid 1001).
 # `flyctl ssh console` defaults to root, so any `gh auth login` from SSH
@@ -18,7 +23,7 @@ HOME_DIR="${HOME:-/data/home}"
 if [ "$(id -u)" = "0" ]; then
   mkdir -p "$HOME_DIR"
   chown -R 1001:1001 /data
-  exec gosu symphony "$0" "$@"
+  exec gosu symphony env HOME="$HOME_DIR" "$0" "$@"
 fi
 
 mkdir -p "$HOME_DIR"


### PR DESCRIPTION
## Summary

- `flyctl ssh console` opens an interactive login shell as root (default), and root's HOME from passwd is `/root` — Dockerfile `ENV HOME=/data/home` only applies to the container's main process tree, not to SSH sessions.
- Without HOME forced, every `gh auth login` / `claude auth login` from §4 of the runbook landed under `/root/.config/...` (ephemeral image rootfs) and was wiped on the next restart, leaving entrypoint.sh stuck at the auth-check `sleep infinity`.
- Add `/etc/profile.d/symphony-home.sh` so any interactive shell (root or `-u symphony`) auto-exports `HOME=/data/home`. Auth artifacts now land on the Volume by default. Drop the manual `mkdir -p /data/home && export HOME=...` step from the runbook.
- Switch `codex login` to `--device-auth` in the runbook — the default browser-redirect flow shows `Starting local login server on http://localhost:1455` and never completes on a remote machine.

Discovered while running through `docs/symphony-setup.md` end-to-end on the freshly created `upflow-symphony` app.

## Test plan

- [x] `fly deploy` rebuilds image with new `/etc/profile.d/symphony-home.sh`
- [ ] `fly ssh console --app upflow-symphony` lands with `HOME=/data/home`, no manual export needed
- [ ] All four CLI logins (gh / claude / codex / cursor-agent) write to `/data/home/...`
- [ ] `fly machine restart` followed by `fly logs` shows `[ready] listening on 0.0.0.0:8080` (entrypoint passes auth check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Fly の SSH インタラクティブ認証手順を更新し、SSH 接続は symphony ユーザーでの実行を前提にしました。認証手順の例が $HOME を使う形に統一されました。
  * リモートでの認証完了は --device-auth を必須化する旨を追記しました。

* **改善**
  * 認証情報やリポジトリデータが永続ボリュームに保存されるようになり、再起動や再デプロイ後も保持されやすくなりました。
  * root での SSH 利用は推奨されず、永続化の問題を避ける旨を明確化しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->