### PR TITLE
Bump symphony VM to 2GB + 1GB swap to fix takt OOM

### DIFF
--- a/infra/symphony/fly.toml
+++ b/infra/symphony/fly.toml
@@ -8,6 +8,14 @@ primary_region = "nrt"
 kill_signal = "SIGTERM"
 kill_timeout = "30s"
 
+# Backstop for memory spikes during agent runs. takt was OOM-killed on a
+# nested `pnpm install --silent` at ~745MB anon-rss with only 1GB RAM,
+# so we both bumped memory below and added swap as a safety net for
+# transient spikes (claude-code / codex / cursor-agent processes can
+# briefly balloon during inference). Swap is free; the real change is
+# the 2GB memory bump in [[vm]].
+swap_size_mb = 1024
+
 [build]
   dockerfile = "Dockerfile"
 
@@ -44,4 +52,4 @@ kill_timeout = "30s"
 [[vm]]
   cpu_kind = "shared"
   cpus = 1
-  memory = "1gb"
+  memory = "2gb"


### PR DESCRIPTION
## Summary

First end-to-end Symphony run on issue #328 hit **OOM** on the nested `pnpm install --silent` that takt fires inside its workflow, dying at ~745MB anon-rss with only 1GB RAM. Symphony itself correctly relabeled the issue `symphony:failed (failure_transient)` and posted attempt-start / attempt-complete comments, but the agent never produced a meta.json so no draft PR was generated.

```
16:14:57  [pick] #328 monorepo の複数リリースストリームに対応する
16:17:11  Out of memory: Killed process 791 (MainThread) ... anon-rss:744908kB
16:17:14  [takt] bash: line 1: 791 Killed   pnpm install --frozen-lockfile --silent
16:17:23  [done] #328 → symphony:failed (failure_transient)
```

- Bump `[[vm]] memory` 1GB → 2GB. Real fix.
- Add `swap_size_mb = 1024` as a backstop for transient inference spikes (claude-code / codex / cursor-agent processes can balloon briefly during model calls). Swap is free.
- Cost impact is minimal because idle-shutdown still puts the machine to sleep within 5 min of no work.

## Test plan

- [ ] `flyctl deploy` succeeds, machine starts with 2GB
- [ ] `[ready] listening on 0.0.0.0:8080`
- [ ] Re-trigger Symphony on a `symphony:ready` issue and confirm takt's `pnpm install` no longer OOM-kills
- [ ] Existing auth state on `/data/home` survives the redeploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)