### PR TITLE
Retry symphony tick over cold-boot 502s

### DIFF
--- a/.github/workflows/symphony-tick.yml
+++ b/.github/workflows/symphony-tick.yml
@@ -38,8 +38,20 @@ jobs:
           # drops the request before takt finishes the symphony server
           # still completes the run and posts the GitHub comment from
           # inside the machine.
+          #
+          # Retry on cold-boot races: when the machine is stopped, the
+          # first /tick triggers Fly's auto_start_machines but image pull
+          # + container init + pnpm install can take 60-90s. Fly's edge
+          # times out at ~50s and returns 502, so without retries the
+          # very first cron tick of an idle period silently no-ops.
+          # `--retry-all-errors` is required because the default retry
+          # logic ignores HTTP error responses (it only retries
+          # transport-level failures).
           curl --fail-with-body \
                --max-time 5400 \
+               --retry 5 \
+               --retry-delay 30 \
+               --retry-all-errors \
                -sS \
                -X POST \
                -H "Authorization: Bearer ${TICK_TOKEN}" \


### PR DESCRIPTION
## Summary

Today's manual /tick at `2026-05-05T00:28:04Z` showed the cold-boot race in production:

```
00:28:04  cron curl → /tick (machine stopped)
          Fly auto_start_machines kicks in, container starts pulling image
00:28:55  curl gives up with 502 (Fly edge timed out at ~50s)
00:29:09  Fly machine finally [ready]   ← 65s total boot time
```

Result: GitHub Actions workflow failed, no Symphony work happened that cycle, even though `symphony:ready` issue #328 was waiting. Manual re-trigger after the machine warmed up succeeded immediately, confirming the diagnosis.

## Fix

Add retry options to the `curl` invocation:

```diff
  curl --fail-with-body \
       --max-time 5400 \
+      --retry 5 \
+      --retry-delay 30 \
+      --retry-all-errors \
       -sS \
       ...
```

`--retry-all-errors` is required because curl's default retry logic ignores HTTP error responses — it treats a 502 as "got a response, didn't get a transport error, no retry needed". With this flag, curl retries on 5xx too. 30s spacing means the second attempt lands well after the machine is ready.

## Why not other approaches

- **`fly machine start --wait` before curl**: requires `flyctl` install + Fly auth in the action; more brittle than a curl flag
- **Bump `--max-time`**: doesn't help because the failure is at edge-timeout level, not at curl-overall-time level
- **Switch off `auto_stop_machines` cost-saving**: defeats the whole point of the architecture

## Capacity envelope

`--max-time 5400` (90 min) is unchanged and still caps the total operation including retries. Worst case: 4 × (50s timeout + 30s delay) = 320s of retry overhead before a 5th attempt that connects, leaving 5080s ≈ 84 min for the actual takt run — comfortably above takt's typical runtime.

## Test plan

- [x] Manual /tick after the merge of #389/#390 confirmed cold-boot 502 reproduces
- [ ] Next idle-period cron tick after merge succeeds without manual re-trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **チョア**
  * バックグラウンドプロセスにリトライロジックを追加しました。スタートアップフェーズ中の一時的な接続エラーに対する復元力が向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->