### PR TITLE
Drop redundant --retry-all-errors from symphony tick curl

### DIFF
--- a/.github/workflows/symphony-tick.yml
+++ b/.github/workflows/symphony-tick.yml
@@ -44,14 +44,22 @@ jobs:
           # + container init + pnpm install can take 60-90s. Fly's edge
           # times out at ~50s and returns 502, so without retries the
           # very first cron tick of an idle period silently no-ops.
-          # `--retry-all-errors` is required because the default retry
-          # logic ignores HTTP error responses (it only retries
-          # transport-level failures).
+          # curl's default `--retry` already treats 5xx (incl. 500/502)
+          # as transient, which is exactly the cold-boot signal we need
+          # to retry on; no `--retry-all-errors` (that flag would also
+          # retry 4xx like an auth failure, which we don't want).
+          #
+          # A 500 from `handleTick` itself (e.g. GitHub API failure
+          # while transitioning labels) gets retried too, which can mask
+          # the failure on the second attempt if the issue is left in
+          # the `symphony:running` state. The boot-time orphan check
+          # in `bin/symphony-serve.ts` (`reconcileOrphans`) catches this
+          # on the next cold start and marks such issues `failed`, so
+          # the worst-case visibility loss is one cron cycle.
           curl --fail-with-body \
                --max-time 5400 \
                --retry 5 \
                --retry-delay 30 \
-               --retry-all-errors \
                -sS \
                -X POST \
                -H "Authorization: Bearer ${TICK_TOKEN}" \


### PR DESCRIPTION
## Summary

Follow-up to #391, addressing [CodeRabbit's review](https://github.com/coji/upflow/pull/391#discussion_r) on the `--retry-all-errors` flag.

CodeRabbit's premise was partially right but the diagnosis was off:

- **The flag wasn't actually needed for cold-boot recovery.** curl's default `--retry` already treats `5xx` (500, 502, 503, 504) as transient, so the 502 we saw on cold boot would have retried without the flag. My justification on #391 ("curl's default retry logic ignores HTTP error responses") was wrong — I confused 4xx with 5xx behavior in the curl docs.
- **What `--retry-all-errors` actually adds is 4xx retries**, which is the opposite of what we want — an auth failure (401) should fail loudly.
- **The 500-masking concern is real but mitigated.** If `handleTick` itself returns 500 (GitHub API failure during label transitions etc.), the second attempt could find the issue in `symphony:running`, return `idle 200`, and mask the failure. But `reconcileOrphans` in `bin/symphony-serve.ts:264` catches exactly this on the next cold boot and marks orphaned `running` issues as `failed`. Worst-case visibility loss is ~one cron cycle.

## Diff

```diff
           curl --fail-with-body \
                --max-time 5400 \
                --retry 5 \
                --retry-delay 30 \
-               --retry-all-errors \
                -sS \
                ...
```

Plus an updated comment block reflecting the actual rationale and the orphan safety net.

## Test plan

- [x] `pnpm validate` passes (no code changed, only YAML comments + 1 flag drop)
- [ ] Next cold-boot tick still recovers via the default 5xx retry behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)