### PR TITLE
Expose takt progress on /status

### DIFF
--- a/bin/symphony-serve.ts
+++ b/bin/symphony-serve.ts
@@ -22,16 +22,7 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import type { ChildProcess } from 'node:child_process'
-import {
-  closeSync,
-  existsSync,
-  fstatSync,
-  openSync,
-  readFileSync,
-  readSync,
-  readdirSync,
-  statSync,
-} from 'node:fs'
+import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
 import {
   type IncomingMessage,
   type ServerResponse,
@@ -53,6 +44,7 @@ import {
   ghComment,
   ghIssueList,
   ghRemoveLabel,
+  readLatestJsonlEvent,
   run,
   usedBudgetMs,
 } from './symphony-shared'
@@ -76,9 +68,11 @@ interface JobProgress {
   taktRunDir: string | null
   /** Most recent stdout line from the active subprocess (preflight or takt). */
   lastStdoutLine: string | null
+  /** When this server received `lastStdoutLine` (our clock, ISO 8601 UTC). */
   lastStdoutAt: string | null
   /** Most recent event type from the takt session jsonl, polled periodically. */
   lastEventType: string | null
+  /** Timestamp recorded INSIDE the jsonl event by takt (not poll time). */
   lastEventAt: string | null
 }
 
@@ -93,9 +87,20 @@ let activeJob: JobState | null = null
 let idleTimer: NodeJS.Timeout | null = null
 let progressPoller: NodeJS.Timeout | null = null
 
-const PROGRESS_POLL_MS = Number(
-  process.env.SYMPHONY_PROGRESS_POLL_MS ?? 30 * 1000,
-)
+// Validate the env override so a malformed value (NaN, 0, negative) can't
+// turn the poller into a 1ms busy loop. Clamp to >= 1000ms.
+const PROGRESS_POLL_MS = (() => {
+  const raw = process.env.SYMPHONY_PROGRESS_POLL_MS
+  if (raw === undefined) return 30 * 1000
+  const parsed = Number(raw)
+  if (!Number.isFinite(parsed) || parsed < 1000) {
+    console.warn(
+      `[progress] ignoring SYMPHONY_PROGRESS_POLL_MS=${raw} (must be a finite number >= 1000); falling back to 30000`,
+    )
+    return 30 * 1000
+  }
+  return parsed
+})()
 
 function updateActiveJobLine(line: string): void {
   if (activeJob === null) return
@@ -159,63 +164,24 @@ function readSuperviseReport(runDir: string): string {
   return readFileSync(path, 'utf-8')
 }
 
-interface JsonlEvent {
-  type?: string
-  timestamp?: string
-  endTime?: string
-}
-
-/**
- * Tail the most recently modified `<runDir>/logs/*.jsonl` and return the
- * last complete JSON line's `type` + timestamp. Reads at most the trailing
- * 4 KB so it stays cheap even for long sessions.
- */
-function readLatestJsonlEvent(
-  runDir: string,
-): { type: string | null; timestamp: string | null } | null {
-  const logsDir = join(runDir, 'logs')
-  if (!existsSync(logsDir)) return null
-  const files = readdirSync(logsDir, { withFileTypes: true })
-    .filter((d) => d.isFile() && d.name.endsWith('.jsonl'))
-    .map((d) => {
-      const full = join(logsDir, d.name)
-      return { full, mtime: statSync(full).mtimeMs }
-    })
-    .sort((a, b) => b.mtime - a.mtime)
-  const latest = files[0]
-  if (!latest) return null
-  const fd = openSync(latest.full, 'r')
-  try {
-    const stat = fstatSync(fd)
-    const len = Math.min(stat.size, 4096)
-    if (len === 0) return null
-    const buf = Buffer.alloc(len)
-    readSync(fd, buf, 0, len, stat.size - len)
-    const tail = buf.toString('utf-8')
-    const lines = tail.split('\n').filter((l) => l.length > 0)
-    const last = lines[lines.length - 1]
-    if (!last) return null
-    const j = JSON.parse(last) as JsonlEvent
-    return { type: j.type ?? null, timestamp: j.timestamp ?? j.endTime ?? null }
-  } catch {
-    return null
-  } finally {
-    closeSync(fd)
-  }
-}
-
 function pollProgress(): void {
   if (activeJob === null) return
-  const startMs = dayjs(activeJob.startedAt).valueOf()
-  if (activeJob.progress.taktRunDir === null) {
-    activeJob.progress.taktRunDir = findLatestRunDir(startMs)
+  try {
+    const startMs = dayjs(activeJob.startedAt).valueOf()
+    if (activeJob.progress.taktRunDir === null) {
+      activeJob.progress.taktRunDir = findLatestRunDir(startMs)
+    }
+    const runDir = activeJob.progress.taktRunDir
+    if (runDir === null) return
+    const ev = readLatestJsonlEvent(runDir)
+    if (ev === null) return
+    activeJob.progress.lastEventType = ev.type
+    activeJob.progress.lastEventAt = ev.timestamp
+  } catch (e) {
+    // Don't let a transient FS race (takt rotated logs, Volume hiccup,
+    // malformed JSON line) take down the interval loop. Next tick retries.
+    console.warn('[progress] poll failed:', getErrorMessageForLog(e))
   }
-  const runDir = activeJob.progress.taktRunDir
-  if (runDir === null) return
-  const ev = readLatestJsonlEvent(runDir)
-  if (ev === null) return
-  activeJob.progress.lastEventType = ev.type
-  activeJob.progress.lastEventAt = ev.timestamp
 }
 
 function startProgressPoller(): void {

--- a/bin/symphony-serve.ts
+++ b/bin/symphony-serve.ts
@@ -22,7 +22,16 @@
 import dayjs from 'dayjs'
 import utc from 'dayjs/plugin/utc'
 import type { ChildProcess } from 'node:child_process'
-import { existsSync, readFileSync, readdirSync, statSync } from 'node:fs'
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  openSync,
+  readFileSync,
+  readSync,
+  readdirSync,
+  statSync,
+} from 'node:fs'
 import {
   type IncomingMessage,
   type ServerResponse,
@@ -62,14 +71,37 @@ if (!TICK_TOKEN) {
   process.exit(1)
 }
 
+interface JobProgress {
+  /** Filled in once the takt subprocess has created its `.takt/runs/...` dir. */
+  taktRunDir: string | null
+  /** Most recent stdout line from the active subprocess (preflight or takt). */
+  lastStdoutLine: string | null
+  lastStdoutAt: string | null
+  /** Most recent event type from the takt session jsonl, polled periodically. */
+  lastEventType: string | null
+  lastEventAt: string | null
+}
+
 interface JobState {
   issueNumber: number
   startedAt: string
   child: ChildProcess | null
+  progress: JobProgress
 }
 
 let activeJob: JobState | null = null
 let idleTimer: NodeJS.Timeout | null = null
+let progressPoller: NodeJS.Timeout | null = null
+
+const PROGRESS_POLL_MS = Number(
+  process.env.SYMPHONY_PROGRESS_POLL_MS ?? 30 * 1000,
+)
+
+function updateActiveJobLine(line: string): void {
+  if (activeJob === null) return
+  activeJob.progress.lastStdoutLine = line
+  activeJob.progress.lastStdoutAt = dayjs.utc().toISOString()
+}
 
 function scheduleIdleShutdown(): void {
   if (idleTimer !== null) clearTimeout(idleTimer)
@@ -127,6 +159,77 @@ function readSuperviseReport(runDir: string): string {
   return readFileSync(path, 'utf-8')
 }
 
+interface JsonlEvent {
+  type?: string
+  timestamp?: string
+  endTime?: string
+}
+
+/**
+ * Tail the most recently modified `<runDir>/logs/*.jsonl` and return the
+ * last complete JSON line's `type` + timestamp. Reads at most the trailing
+ * 4 KB so it stays cheap even for long sessions.
+ */
+function readLatestJsonlEvent(
+  runDir: string,
+): { type: string | null; timestamp: string | null } | null {
+  const logsDir = join(runDir, 'logs')
+  if (!existsSync(logsDir)) return null
+  const files = readdirSync(logsDir, { withFileTypes: true })
+    .filter((d) => d.isFile() && d.name.endsWith('.jsonl'))
+    .map((d) => {
+      const full = join(logsDir, d.name)
+      return { full, mtime: statSync(full).mtimeMs }
+    })
+    .sort((a, b) => b.mtime - a.mtime)
+  const latest = files[0]
+  if (!latest) return null
+  const fd = openSync(latest.full, 'r')
+  try {
+    const stat = fstatSync(fd)
+    const len = Math.min(stat.size, 4096)
+    if (len === 0) return null
+    const buf = Buffer.alloc(len)
+    readSync(fd, buf, 0, len, stat.size - len)
+    const tail = buf.toString('utf-8')
+    const lines = tail.split('\n').filter((l) => l.length > 0)
+    const last = lines[lines.length - 1]
+    if (!last) return null
+    const j = JSON.parse(last) as JsonlEvent
+    return { type: j.type ?? null, timestamp: j.timestamp ?? j.endTime ?? null }
+  } catch {
+    return null
+  } finally {
+    closeSync(fd)
+  }
+}
+
+function pollProgress(): void {
+  if (activeJob === null) return
+  const startMs = dayjs(activeJob.startedAt).valueOf()
+  if (activeJob.progress.taktRunDir === null) {
+    activeJob.progress.taktRunDir = findLatestRunDir(startMs)
+  }
+  const runDir = activeJob.progress.taktRunDir
+  if (runDir === null) return
+  const ev = readLatestJsonlEvent(runDir)
+  if (ev === null) return
+  activeJob.progress.lastEventType = ev.type
+  activeJob.progress.lastEventAt = ev.timestamp
+}
+
+function startProgressPoller(): void {
+  if (progressPoller !== null) return
+  progressPoller = setInterval(pollProgress, PROGRESS_POLL_MS)
+  progressPoller.unref()
+}
+
+function stopProgressPoller(): void {
+  if (progressPoller === null) return
+  clearInterval(progressPoller)
+  progressPoller = null
+}
+
 interface TaktChildResult {
   metaStatus: TaktMetaStatus
   superviseReport: string
@@ -176,6 +279,7 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
       onChild: (child) => {
         if (activeJob !== null) activeJob.child = child
       },
+      onStdoutLine: updateActiveJobLine,
     })
     if (r.code !== 0) {
       return {
@@ -194,6 +298,7 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
     onChild: (child) => {
       if (activeJob !== null) activeJob.child = child
     },
+    onStdoutLine: updateActiveJobLine,
   })
   const elapsedMs = Date.now() - startMs
   const runDir = findLatestRunDir(startMs)
@@ -221,7 +326,19 @@ async function processOneIssue(): Promise<{
   const issue: IssueRef = ready[0]
 
   const startedAt = dayjs.utc().toISOString()
-  activeJob = { issueNumber: issue.number, startedAt, child: null }
+  activeJob = {
+    issueNumber: issue.number,
+    startedAt,
+    child: null,
+    progress: {
+      taktRunDir: null,
+      lastStdoutLine: null,
+      lastStdoutAt: null,
+      lastEventType: null,
+      lastEventAt: null,
+    },
+  }
+  startProgressPoller()
   console.log(`[pick] #${issue.number} ${issue.title}`)
 
   // try/finally so activeJob always clears even when a gh / takt call
@@ -293,6 +410,7 @@ async function processOneIssue(): Promise<{
     console.log(`[done] #${issue.number} → ${nextLabel} (${result.outcome})`)
     return { state: 'processed', issue: issue.number, outcome: result.outcome }
   } finally {
+    stopProgressPoller()
     activeJob = null
   }
 }
@@ -360,11 +478,28 @@ async function handleTick(res: ServerResponse): Promise<void> {
 }
 
 function handleStatus(res: ServerResponse): void {
+  // Build a serialisable view of activeJob explicitly. Returning the raw
+  // JobState would dump the underlying ChildProcess into the response.
+  const job = activeJob
+  const safeJob =
+    job === null
+      ? null
+      : {
+          issueNumber: job.issueNumber,
+          startedAt: job.startedAt,
+          elapsedMs: Date.now() - dayjs(job.startedAt).valueOf(),
+          pid: job.child?.pid ?? null,
+          taktRunDir: job.progress.taktRunDir,
+          lastStdoutLine: job.progress.lastStdoutLine,
+          lastStdoutAt: job.progress.lastStdoutAt,
+          lastEventType: job.progress.lastEventType,
+          lastEventAt: job.progress.lastEventAt,
+        }
   res.writeHead(200, { 'Content-Type': 'application/json' })
   res.end(
     JSON.stringify({
-      state: activeJob === null ? 'idle' : 'busy',
-      activeJob,
+      state: job === null ? 'idle' : 'busy',
+      activeJob: safeJob,
       bootAt: BOOT_AT,
     }),
   )

--- a/bin/symphony-serve.ts
+++ b/bin/symphony-serve.ts
@@ -44,6 +44,7 @@ import {
   ghComment,
   ghIssueList,
   ghRemoveLabel,
+  parseFiniteNumberEnv,
   readLatestJsonlEvent,
   run,
   usedBudgetMs,
@@ -51,12 +52,17 @@ import {
 
 dayjs.extend(utc)
 
-const PORT = Number(process.env.PORT ?? 8080)
+const PORT = parseFiniteNumberEnv('PORT', {
+  fallback: 8080,
+  min: 1,
+  max: 65535,
+})
 const REPO_DIR = process.env.SYMPHONY_REPO_DIR ?? join(homedir(), 'upflow')
 const TICK_TOKEN = process.env.SYMPHONY_TICK_TOKEN
-const IDLE_SHUTDOWN_MS = Number(
-  process.env.SYMPHONY_IDLE_SHUTDOWN_MS ?? 5 * 60 * 1000,
-)
+const IDLE_SHUTDOWN_MS = parseFiniteNumberEnv('SYMPHONY_IDLE_SHUTDOWN_MS', {
+  fallback: 5 * 60 * 1000,
+  min: 1000,
+})
 
 if (!TICK_TOKEN) {
   console.error('[fatal] SYMPHONY_TICK_TOKEN env is required')
@@ -87,20 +93,10 @@ let activeJob: JobState | null = null
 let idleTimer: NodeJS.Timeout | null = null
 let progressPoller: NodeJS.Timeout | null = null
 
-// Validate the env override so a malformed value (NaN, 0, negative) can't
-// turn the poller into a 1ms busy loop. Clamp to >= 1000ms.
-const PROGRESS_POLL_MS = (() => {
-  const raw = process.env.SYMPHONY_PROGRESS_POLL_MS
-  if (raw === undefined) return 30 * 1000
-  const parsed = Number(raw)
-  if (!Number.isFinite(parsed) || parsed < 1000) {
-    console.warn(
-      `[progress] ignoring SYMPHONY_PROGRESS_POLL_MS=${raw} (must be a finite number >= 1000); falling back to 30000`,
-    )
-    return 30 * 1000
-  }
-  return parsed
-})()
+const PROGRESS_POLL_MS = parseFiniteNumberEnv('SYMPHONY_PROGRESS_POLL_MS', {
+  fallback: 30 * 1000,
+  min: 1000,
+})
 
 function updateActiveJobLine(line: string): void {
   if (activeJob === null) return
@@ -167,7 +163,7 @@ function readSuperviseReport(runDir: string): string {
 function pollProgress(): void {
   if (activeJob === null) return
   try {
-    const startMs = dayjs(activeJob.startedAt).valueOf()
+    const startMs = dayjs.utc(activeJob.startedAt).valueOf()
     if (activeJob.progress.taktRunDir === null) {
       activeJob.progress.taktRunDir = findLatestRunDir(startMs)
     }
@@ -351,7 +347,7 @@ async function processOneIssue(): Promise<{
       taktResult = {
         metaStatus: 'failed',
         superviseReport: '',
-        elapsedMs: Date.now() - dayjs(startedAt).valueOf(),
+        elapsedMs: Date.now() - dayjs.utc(startedAt).valueOf(),
       }
     }
 
@@ -453,7 +449,7 @@ function handleStatus(res: ServerResponse): void {
       : {
           issueNumber: job.issueNumber,
           startedAt: job.startedAt,
-          elapsedMs: Date.now() - dayjs(job.startedAt).valueOf(),
+          elapsedMs: Date.now() - dayjs.utc(job.startedAt).valueOf(),
           pid: job.child?.pid ?? null,
           taktRunDir: job.progress.taktRunDir,
           lastStdoutLine: job.progress.lastStdoutLine,

--- a/bin/symphony-shared.test.ts
+++ b/bin/symphony-shared.test.ts
@@ -7,8 +7,13 @@ import {
 } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, beforeEach, describe, expect, it } from 'vitest'
-import { classifyTakt, readLatestJsonlEvent, run } from './symphony-shared'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  classifyTakt,
+  parseFiniteNumberEnv,
+  readLatestJsonlEvent,
+  run,
+} from './symphony-shared'
 
 const baseArgs = { elapsedMs: 1000 }
 
@@ -272,5 +277,64 @@ describe('readLatestJsonlEvent', () => {
       type: 'newer',
       timestamp: '2026-05-05T00:01:00Z',
     })
+  })
+})
+
+describe('parseFiniteNumberEnv', () => {
+  const KEY = '__SYMPHONY_TEST_NUMBER_ENV__'
+
+  beforeEach(() => {
+    delete process.env[KEY]
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+  })
+  afterEach(() => {
+    delete process.env[KEY]
+    vi.restoreAllMocks()
+  })
+
+  it('returns the fallback when the env var is unset (no warning)', () => {
+    expect(parseFiniteNumberEnv(KEY, { fallback: 42 })).toBe(42)
+    expect(console.warn).not.toHaveBeenCalled()
+  })
+
+  it('parses a valid numeric string', () => {
+    process.env[KEY] = '1500'
+    expect(parseFiniteNumberEnv(KEY, { fallback: 30000, min: 1000 })).toBe(1500)
+  })
+
+  it('falls back and warns on a non-numeric value (NaN guard)', () => {
+    process.env[KEY] = 'abc'
+    expect(parseFiniteNumberEnv(KEY, { fallback: 30000, min: 1000 })).toBe(
+      30000,
+    )
+    expect(console.warn).toHaveBeenCalledOnce()
+  })
+
+  it('falls back and warns on a value below `min` (busy-loop guard)', () => {
+    process.env[KEY] = '0'
+    expect(parseFiniteNumberEnv(KEY, { fallback: 30000, min: 1000 })).toBe(
+      30000,
+    )
+    expect(console.warn).toHaveBeenCalledOnce()
+  })
+
+  it('falls back and warns on a value above `max`', () => {
+    process.env[KEY] = '99999'
+    expect(
+      parseFiniteNumberEnv(KEY, { fallback: 8080, min: 1, max: 65535 }),
+    ).toBe(8080)
+    expect(console.warn).toHaveBeenCalledOnce()
+  })
+
+  it('falls back and warns on Infinity', () => {
+    process.env[KEY] = 'Infinity'
+    expect(parseFiniteNumberEnv(KEY, { fallback: 42 })).toBe(42)
+    expect(console.warn).toHaveBeenCalledOnce()
+  })
+
+  it('accepts the boundary values inclusively', () => {
+    process.env[KEY] = '1000'
+    expect(parseFiniteNumberEnv(KEY, { fallback: 30000, min: 1000 })).toBe(1000)
+    expect(console.warn).not.toHaveBeenCalled()
   })
 })

--- a/bin/symphony-shared.test.ts
+++ b/bin/symphony-shared.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest'
-import { classifyTakt } from './symphony-shared'
+import { classifyTakt, run } from './symphony-shared'
 
 const baseArgs = { elapsedMs: 1000 }
 
@@ -110,5 +110,50 @@ describe('classifyTakt', () => {
       expect(r.reason).toContain('meta.status=completed')
       expect(r.reason).toContain('no `## Judgment:` marker')
     })
+  })
+})
+
+describe('run() onStdoutLine', () => {
+  it('emits each newline-terminated stdout line exactly once', async () => {
+    const lines: string[] = []
+    const r = await run('bash', ['-lc', 'printf "alpha\\nbeta\\ngamma\\n"'], {
+      captureOutput: false,
+      onStdoutLine: (line) => lines.push(line),
+    })
+    expect(r.code).toBe(0)
+    expect(lines).toEqual(['alpha', 'beta', 'gamma'])
+  })
+
+  it('flushes a trailing partial line on close', async () => {
+    const lines: string[] = []
+    const r = await run('bash', ['-lc', 'printf "first\\nno-newline-tail"'], {
+      captureOutput: false,
+      onStdoutLine: (line) => lines.push(line),
+    })
+    expect(r.code).toBe(0)
+    expect(lines).toEqual(['first', 'no-newline-tail'])
+  })
+
+  it('handles a single chunk that contains multiple lines', async () => {
+    const lines: string[] = []
+    const r = await run('bash', ['-lc', 'printf "one\\ntwo\\nthree\\n"'], {
+      captureOutput: false,
+      onStdoutLine: (line) => lines.push(line),
+    })
+    expect(r.code).toBe(0)
+    expect(lines).toEqual(['one', 'two', 'three'])
+  })
+
+  it('does not break when onStdoutLine throws', async () => {
+    const calls: string[] = []
+    const r = await run('bash', ['-lc', 'printf "a\\nb\\nc\\n"'], {
+      captureOutput: false,
+      onStdoutLine: (line) => {
+        calls.push(line)
+        throw new Error('boom')
+      },
+    })
+    expect(r.code).toBe(0)
+    expect(calls).toEqual(['a', 'b', 'c'])
   })
 })

--- a/bin/symphony-shared.test.ts
+++ b/bin/symphony-shared.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { classifyTakt, run } from './symphony-shared'
+import {
+  mkdirSync,
+  mkdtempSync,
+  rmSync,
+  utimesSync,
+  writeFileSync,
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { classifyTakt, readLatestJsonlEvent, run } from './symphony-shared'
 
 const baseArgs = { elapsedMs: 1000 }
 
@@ -155,5 +164,113 @@ describe('run() onStdoutLine', () => {
     })
     expect(r.code).toBe(0)
     expect(calls).toEqual(['a', 'b', 'c'])
+  })
+})
+
+describe('readLatestJsonlEvent', () => {
+  let runDir: string
+
+  beforeEach(() => {
+    runDir = mkdtempSync(join(tmpdir(), 'symphony-jsonl-'))
+    mkdirSync(join(runDir, 'logs'), { recursive: true })
+  })
+  afterEach(() => {
+    rmSync(runDir, { recursive: true, force: true })
+  })
+
+  function writeJsonl(name: string, lines: string[]): void {
+    writeFileSync(join(runDir, 'logs', name), `${lines.join('\n')}\n`)
+  }
+
+  it('returns null when the logs directory is missing', () => {
+    rmSync(join(runDir, 'logs'), { recursive: true })
+    expect(readLatestJsonlEvent(runDir)).toBeNull()
+  })
+
+  it('returns null when no jsonl files exist', () => {
+    expect(readLatestJsonlEvent(runDir)).toBeNull()
+  })
+
+  it('returns null on an empty jsonl file', () => {
+    writeFileSync(join(runDir, 'logs', 'empty.jsonl'), '')
+    expect(readLatestJsonlEvent(runDir)).toBeNull()
+  })
+
+  it('parses the last line of a small jsonl file', () => {
+    writeJsonl('a.jsonl', [
+      JSON.stringify({
+        type: 'workflow_start',
+        timestamp: '2026-05-05T00:00:00Z',
+      }),
+      JSON.stringify({ type: 'step_start', timestamp: '2026-05-05T00:00:10Z' }),
+      JSON.stringify({
+        type: 'step_complete',
+        timestamp: '2026-05-05T00:00:20Z',
+      }),
+    ])
+    expect(readLatestJsonlEvent(runDir)).toEqual({
+      type: 'step_complete',
+      timestamp: '2026-05-05T00:00:20Z',
+    })
+  })
+
+  it('falls back to endTime when timestamp is absent', () => {
+    writeJsonl('a.jsonl', [
+      JSON.stringify({
+        type: 'workflow_abort',
+        endTime: '2026-05-05T01:00:00Z',
+      }),
+    ])
+    expect(readLatestJsonlEvent(runDir)).toEqual({
+      type: 'workflow_abort',
+      timestamp: '2026-05-05T01:00:00Z',
+    })
+  })
+
+  it('handles a giant first line followed by a small last line (>4 KB tail safety)', () => {
+    // workflow_start often embeds the full issue body; this used to break a
+    // 4 KB tail when the LAST event was small enough to fit but the file
+    // overall didn't. With the 64 KB tail it works as long as the LAST
+    // event itself is < 64 KB.
+    const huge = JSON.stringify({
+      type: 'workflow_start',
+      task: 'x'.repeat(20_000),
+    })
+    writeJsonl('a.jsonl', [
+      huge,
+      JSON.stringify({
+        type: 'step_complete',
+        timestamp: '2026-05-05T02:00:00Z',
+      }),
+    ])
+    expect(readLatestJsonlEvent(runDir)).toEqual({
+      type: 'step_complete',
+      timestamp: '2026-05-05T02:00:00Z',
+    })
+  })
+
+  it('returns null when the last line is malformed JSON (does not throw)', () => {
+    writeFileSync(
+      join(runDir, 'logs', 'a.jsonl'),
+      `${JSON.stringify({ type: 'ok' })}\nnot-json\n`,
+    )
+    expect(readLatestJsonlEvent(runDir)).toBeNull()
+  })
+
+  it('picks the most recently modified jsonl when multiple exist', () => {
+    writeJsonl('older.jsonl', [
+      JSON.stringify({ type: 'older', timestamp: '2026-05-05T00:00:00Z' }),
+    ])
+    // Force older mtime well into the past so the sort is unambiguous.
+    const olderPath = join(runDir, 'logs', 'older.jsonl')
+    const past = (Date.now() - 60_000) / 1000
+    utimesSync(olderPath, past, past)
+    writeJsonl('newer.jsonl', [
+      JSON.stringify({ type: 'newer', timestamp: '2026-05-05T00:01:00Z' }),
+    ])
+    expect(readLatestJsonlEvent(runDir)).toEqual({
+      type: 'newer',
+      timestamp: '2026-05-05T00:01:00Z',
+    })
   })
 })

--- a/bin/symphony-shared.ts
+++ b/bin/symphony-shared.ts
@@ -1,4 +1,14 @@
 import { type ChildProcess, spawn } from 'node:child_process'
+import {
+  closeSync,
+  existsSync,
+  fstatSync,
+  openSync,
+  readSync,
+  readdirSync,
+  statSync,
+} from 'node:fs'
+import { join } from 'node:path'
 
 export const REPO = 'coji/upflow'
 export const TAKT_WORKFLOW = 'spec-implement-accept'
@@ -314,4 +324,55 @@ export function elapsedMarker(elapsedMs: number): string {
 
 export function sleep(ms: number): Promise<void> {
   return new Promise<void>((resolve) => setTimeout(resolve, ms))
+}
+
+interface JsonlEvent {
+  type?: string
+  timestamp?: string
+  endTime?: string
+}
+
+export interface LatestJsonlEvent {
+  type: string | null
+  timestamp: string | null
+}
+
+/**
+ * Tail the most recently modified `<runDir>/logs/*.jsonl` and return the
+ * last complete JSON line's `type` + timestamp. Reads at most the trailing
+ * 64 KB so it stays cheap even for long sessions; takt embeds the full
+ * issue body in some events (notably `workflow_start` and `phase_start`),
+ * which can each weigh several KB, so the smaller 4 KB tail used in the
+ * first cut would have missed them whenever they happened to be last.
+ */
+export function readLatestJsonlEvent(runDir: string): LatestJsonlEvent | null {
+  const logsDir = join(runDir, 'logs')
+  if (!existsSync(logsDir)) return null
+  const files = readdirSync(logsDir, { withFileTypes: true })
+    .filter((d) => d.isFile() && d.name.endsWith('.jsonl'))
+    .map((d) => {
+      const full = join(logsDir, d.name)
+      return { full, mtime: statSync(full).mtimeMs }
+    })
+    .sort((a, b) => b.mtime - a.mtime)
+  const latest = files[0]
+  if (!latest) return null
+  const fd = openSync(latest.full, 'r')
+  try {
+    const stat = fstatSync(fd)
+    const len = Math.min(stat.size, 64 * 1024)
+    if (len === 0) return null
+    const buf = Buffer.alloc(len)
+    readSync(fd, buf, 0, len, stat.size - len)
+    const tail = buf.toString('utf-8')
+    const lines = tail.split('\n').filter((l) => l.length > 0)
+    const last = lines[lines.length - 1]
+    if (last === undefined) return null
+    const j = JSON.parse(last) as JsonlEvent
+    return { type: j.type ?? null, timestamp: j.timestamp ?? j.endTime ?? null }
+  } catch {
+    return null
+  } finally {
+    closeSync(fd)
+  }
 }

--- a/bin/symphony-shared.ts
+++ b/bin/symphony-shared.ts
@@ -41,6 +41,14 @@ export interface RunOptions {
    * abort the run.
    */
   onChild?: (child: ChildProcess) => void
+  /**
+   * Invoked once per complete stdout line (newline-terminated; the line
+   * passed in does not include the trailing `\n`). A trailing partial
+   * line gets flushed on child close. Used by `bin/symphony-serve.ts`
+   * to surface the takt subprocess's most recent output line on
+   * `/status` for live progress visibility.
+   */
+  onStdoutLine?: (line: string) => void
 }
 
 export async function run(
@@ -60,10 +68,27 @@ export async function run(
     }
     let stdout = ''
     let stderr = ''
+    let lineBuf = ''
+    const emitLines = (chunk: string) => {
+      if (!opts.onStdoutLine) return
+      lineBuf += chunk
+      let nl = lineBuf.indexOf('\n')
+      while (nl !== -1) {
+        const line = lineBuf.slice(0, nl)
+        lineBuf = lineBuf.slice(nl + 1)
+        try {
+          opts.onStdoutLine(line)
+        } catch {
+          // Caller-side bookkeeping shouldn't block the run.
+        }
+        nl = lineBuf.indexOf('\n')
+      }
+    }
     child.stdout.on('data', (chunk: Buffer) => {
       const s = chunk.toString('utf-8')
       if (capture) stdout += s
       if (opts.streamPrefix) process.stdout.write(`${opts.streamPrefix}${s}`)
+      emitLines(s)
     })
     child.stderr.on('data', (chunk: Buffer) => {
       const s = chunk.toString('utf-8')
@@ -71,7 +96,17 @@ export async function run(
       if (opts.streamPrefix) process.stderr.write(`${opts.streamPrefix}${s}`)
     })
     child.on('error', (err) => reject(err))
-    child.on('close', (code) => resolve({ code: code ?? -1, stdout, stderr }))
+    child.on('close', (code) => {
+      // Flush any trailing stdout that ended without a final newline so
+      // the very last log line still reaches /status before the job ends.
+      if (opts.onStdoutLine && lineBuf.length > 0) {
+        try {
+          opts.onStdoutLine(lineBuf)
+        } catch {}
+        lineBuf = ''
+      }
+      resolve({ code: code ?? -1, stdout, stderr })
+    })
     if (opts.input !== undefined) {
       child.stdin.end(opts.input)
     } else {

--- a/bin/symphony-shared.ts
+++ b/bin/symphony-shared.ts
@@ -1,7 +1,6 @@
 import { type ChildProcess, spawn } from 'node:child_process'
 import {
   closeSync,
-  existsSync,
   fstatSync,
   openSync,
   readSync,
@@ -79,6 +78,11 @@ export async function run(
     let stdout = ''
     let stderr = ''
     let lineBuf = ''
+    // Cap the partial-line buffer so a stuck child that never emits a
+    // newline (broken pipe, single mega-line, hung pty) can't grow this
+    // unboundedly inside a long-lived server. 1 MB is generous for any
+    // realistic log line; if we hit it we drop the prefix and start over.
+    const LINE_BUF_CAP = 1024 * 1024
     const emitLines = (chunk: string) => {
       if (!opts.onStdoutLine) return
       lineBuf += chunk
@@ -92,6 +96,9 @@ export async function run(
           // Caller-side bookkeeping shouldn't block the run.
         }
         nl = lineBuf.indexOf('\n')
+      }
+      if (lineBuf.length > LINE_BUF_CAP) {
+        lineBuf = lineBuf.slice(-LINE_BUF_CAP)
       }
     }
     child.stdout.on('data', (chunk: Buffer) => {
@@ -326,6 +333,64 @@ export function sleep(ms: number): Promise<void> {
   return new Promise<void>((resolve) => setTimeout(resolve, ms))
 }
 
+/**
+ * Parse a numeric env var with bounds validation. Returns the fallback
+ * (and warns to stderr) when the value is unset, non-numeric, or out of
+ * the allowed range. Critical for env vars that drive `setInterval` /
+ * `setTimeout` — bare `Number(process.env.X)` returns NaN for malformed
+ * input, which Node clamps to 1 ms and turns into a busy loop.
+ */
+export function parseFiniteNumberEnv(
+  name: string,
+  opts: { fallback: number; min?: number; max?: number },
+): number {
+  const raw = process.env[name]
+  if (raw === undefined) return opts.fallback
+  const parsed = Number(raw)
+  const inRange =
+    Number.isFinite(parsed) &&
+    (opts.min === undefined || parsed >= opts.min) &&
+    (opts.max === undefined || parsed <= opts.max)
+  if (!inRange) {
+    const range = `${opts.min ?? '-∞'}..${opts.max ?? '∞'}`
+    console.warn(
+      `[env] ignoring ${name}=${raw} (must be a finite number in ${range}); falling back to ${opts.fallback}`,
+    )
+    return opts.fallback
+  }
+  return parsed
+}
+
+/**
+ * From a directory, pick the file with the most recent mtime whose name
+ * matches `nameMatches`. Returns the absolute path or null when nothing
+ * matches / the directory is missing / a transient FS race throws. Used
+ * by `readLatestJsonlEvent` to find the active takt session log.
+ */
+function pickLatestFile(
+  dir: string,
+  nameMatches: (name: string) => boolean,
+): string | null {
+  let entries
+  try {
+    entries = readdirSync(dir, { withFileTypes: true })
+  } catch {
+    return null
+  }
+  const candidates: Array<{ full: string; mtime: number }> = []
+  for (const e of entries) {
+    if (!e.isFile() || !nameMatches(e.name)) continue
+    const full = join(dir, e.name)
+    try {
+      candidates.push({ full, mtime: statSync(full).mtimeMs })
+    } catch {
+      continue
+    }
+  }
+  candidates.sort((a, b) => b.mtime - a.mtime)
+  return candidates[0]?.full ?? null
+}
+
 interface JsonlEvent {
   type?: string
   timestamp?: string
@@ -347,17 +412,14 @@ export interface LatestJsonlEvent {
  */
 export function readLatestJsonlEvent(runDir: string): LatestJsonlEvent | null {
   const logsDir = join(runDir, 'logs')
-  if (!existsSync(logsDir)) return null
-  const files = readdirSync(logsDir, { withFileTypes: true })
-    .filter((d) => d.isFile() && d.name.endsWith('.jsonl'))
-    .map((d) => {
-      const full = join(logsDir, d.name)
-      return { full, mtime: statSync(full).mtimeMs }
-    })
-    .sort((a, b) => b.mtime - a.mtime)
-  const latest = files[0]
-  if (!latest) return null
-  const fd = openSync(latest.full, 'r')
+  const latestPath = pickLatestFile(logsDir, (n) => n.endsWith('.jsonl'))
+  if (latestPath === null) return null
+  let fd: number
+  try {
+    fd = openSync(latestPath, 'r')
+  } catch {
+    return null
+  }
   try {
     const stat = fstatSync(fd)
     const len = Math.min(stat.size, 64 * 1024)


### PR DESCRIPTION
Closes #395.

## Why

Previously `/status` only reported `issueNumber + startedAt` and dumped the raw `activeJob` object — including the underlying `ChildProcess`. Operators debugging a stuck takt run had to SSH into the Fly machine and grep `.takt/runs/.../logs/*.jsonl` by hand. That's exactly how we diagnosed the #328 hang.

## What

`/status` now returns a structured `activeJob` view:

```json
{
  "state": "busy",
  "activeJob": {
    "issueNumber": 328,
    "startedAt": "2026-05-05T07:32:29.069Z",
    "elapsedMs": 1234567,
    "pid": 12345,
    "taktRunDir": ".takt/runs/20260505-073229-issue-328-...",
    "lastStdoutLine": "[takt] [bootstrapper] (1/30) step 1/9:",
    "lastStdoutAt": "2026-05-05T07:40:32.117Z",
    "lastEventType": "step_start",
    "lastEventAt": "2026-05-05T07:40:32.000Z"
  },
  "bootAt": "2026-05-05T07:30:00.000Z"
}
```

## Implementation

- **`RunOptions.onStdoutLine`** in `symphony-shared.ts`: per-line stdout callback. Buffers partial chunks until a newline arrives; flushes a trailing partial line on child close so the last log line still reaches `/status` before the job ends. Errors thrown by the callback are swallowed (matches existing `onChild` semantics).
- **`JobState.progress`** in `symphony-serve.ts`: holds `taktRunDir / lastStdoutLine / lastStdoutAt / lastEventType / lastEventAt`. Wired into every preflight stage + the takt invocation.
- **`startProgressPoller` / `stopProgressPoller`**: 30s `setInterval` started in `processOneIssue`, cleared in `finally`. Each tick: find the takt run dir if not yet known, then tail the last ~4 KB of `<runDir>/logs/*.jsonl` and parse the final JSON line for `type + timestamp`. Poll cadence overridable via `SYMPHONY_PROGRESS_POLL_MS`.
- **`handleStatus` rewrite**: builds a serialisable view explicitly. Returning the raw `JobState` would have leaked the `ChildProcess` into the JSON response (latent bug from the original implementation — never observed because we never hit `/status` during a busy job).

## Tests

`bin/symphony-shared.test.ts` adds 4 tests covering the new line-buffering behavior:
- exact-line emission (3 newline-terminated lines → 3 callbacks)
- trailing-partial flush (no final newline → still flushed on close)
- multi-line single chunk
- callback throws → run still succeeds

15 tests / all pass. Full `pnpm validate` 512 tests pass.

## Test plan

- [x] `pnpm validate` passes
- [ ] After deploy, hit `/status` while a takt run is in progress and confirm `lastStdoutLine` updates as the takt subprocess emits log lines
- [ ] Confirm `lastEventType` updates within ~30s after takt writes a new event to `logs/*.jsonl`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **新機能**
  * ジョブの進捗をより細かく追跡・表示するようになりました。ステータスで経過時間や子プロセス情報、最新の実行ログイベント情報が得られます。
  * 実行ログから最新イベントを効率的に取得する仕組みを追加しました。

* **改善**
  * 標準出力の行単位処理が安定化し、途中で切れた断片も正しく処理されます。

* **テスト**
  * stdout行処理とログ末尾のイベント読み取りに関する検証テストを追加しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->