### PR TITLE
Install atlas in symphony image so preflight db:setup works

### DIFF
--- a/infra/symphony/Dockerfile
+++ b/infra/symphony/Dockerfile
@@ -7,12 +7,14 @@ ARG PNPM_VERSION=10.32.1
 ARG TAKT_VERSION=0.39.0
 ARG CLAUDE_CODE_VERSION=2.1.126
 ARG CODEX_VERSION=0.128.0
+ARG ATLAS_VERSION=v1.2.1
 
 FROM node:${NODE_VERSION}-bookworm-slim
 ARG PNPM_VERSION
 ARG TAKT_VERSION
 ARG CLAUDE_CODE_VERSION
 ARG CODEX_VERSION
+ARG ATLAS_VERSION
 
 # System deps takt and the agent CLIs need at runtime.
 # - git: takt operates on a checked-out repo
@@ -40,6 +42,15 @@ RUN npm install -g \
        takt@${TAKT_VERSION} \
        @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
        @openai/codex@${CODEX_VERSION}
+
+# atlas: SQLite migration tool used by `pnpm db:setup` (db:apply / db:migrate).
+# Without it the symphony preflight stage `pnpm db:setup` fails with
+# `sh: atlas: not found`, which we observed on the first preflight-driven
+# Symphony run (issue #399). Pin via ATLAS_VERSION; the official install
+# script reads that env var, downloads the matching binary, and drops it
+# into /usr/local/bin. Container build is already root so no sudo prompt.
+RUN curl -sSf https://atlasgo.sh \
+      | env ATLAS_VERSION=${ATLAS_VERSION} sh
 
 # cursor-agent installs into the invoker's HOME, so we run the script in
 # a throwaway HOME and copy the binary into a system path. The official

--- a/infra/symphony/Dockerfile
+++ b/infra/symphony/Dockerfile
@@ -7,7 +7,7 @@ ARG PNPM_VERSION=10.32.1
 ARG TAKT_VERSION=0.39.0
 ARG CLAUDE_CODE_VERSION=2.1.126
 ARG CODEX_VERSION=0.128.0
-ARG ATLAS_VERSION=v1.2.1
+ARG ATLAS_VERSION=1.2.0
 
 FROM node:${NODE_VERSION}-bookworm-slim
 ARG PNPM_VERSION
@@ -43,14 +43,17 @@ RUN npm install -g \
        @anthropic-ai/claude-code@${CLAUDE_CODE_VERSION} \
        @openai/codex@${CODEX_VERSION}
 
-# atlas: SQLite migration tool used by `pnpm db:setup` (db:apply / db:migrate).
-# Without it the symphony preflight stage `pnpm db:setup` fails with
-# `sh: atlas: not found`, which we observed on the first preflight-driven
-# Symphony run (issue #399). Pin via ATLAS_VERSION; the official install
-# script reads that env var, downloads the matching binary, and drops it
-# into /usr/local/bin. Container build is already root so no sudo prompt.
-RUN curl -sSf https://atlasgo.sh \
-      | env ATLAS_VERSION=${ATLAS_VERSION} sh
+# atlas: SQLite migration tool used by `pnpm db:setup` (db:apply /
+# db:migrate). Without it the preflight stage `pnpm db:setup` fails
+# with `sh: atlas: not found`, which we observed on the first
+# preflight-driven Symphony run (issue #399).
+#
+# Multi-stage COPY from the official Atlas image rather than the curl|sh
+# installer: Atlas's GitHub Releases ship no binary assets / checksums /
+# signatures, so `arigaio/atlas:<version>-distroless` is the only upstream
+# with a verifiable provenance (image digest pinnable). atlasgo.io
+# explicitly recommends the official image for Docker contexts.
+COPY --from=arigaio/atlas:${ATLAS_VERSION}-distroless /atlas /usr/local/bin/atlas
 
 # cursor-agent installs into the invoker's HOME, so we run the script in
 # a throwaway HOME and copy the binary into a system path. The official

--- a/infra/symphony/Dockerfile
+++ b/infra/symphony/Dockerfile
@@ -9,12 +9,19 @@ ARG CLAUDE_CODE_VERSION=2.1.126
 ARG CODEX_VERSION=0.128.0
 ARG ATLAS_VERSION=1.2.0
 
+# Atlas only ships an official binary via its Docker image (no GitHub
+# Release artifacts / checksums), so we COPY the binary out of the
+# upstream image. ARG expansion in `COPY --from=<external image>:${ARG}`
+# is unreliable in BuildKit — capture the image as a named build stage
+# here so the variable expands at FROM time, then reference the stage
+# by name in the COPY below.
+FROM arigaio/atlas:${ATLAS_VERSION}-distroless AS atlas
+
 FROM node:${NODE_VERSION}-bookworm-slim
 ARG PNPM_VERSION
 ARG TAKT_VERSION
 ARG CLAUDE_CODE_VERSION
 ARG CODEX_VERSION
-ARG ATLAS_VERSION
 
 # System deps takt and the agent CLIs need at runtime.
 # - git: takt operates on a checked-out repo
@@ -46,14 +53,10 @@ RUN npm install -g \
 # atlas: SQLite migration tool used by `pnpm db:setup` (db:apply /
 # db:migrate). Without it the preflight stage `pnpm db:setup` fails
 # with `sh: atlas: not found`, which we observed on the first
-# preflight-driven Symphony run (issue #399).
-#
-# Multi-stage COPY from the official Atlas image rather than the curl|sh
-# installer: Atlas's GitHub Releases ship no binary assets / checksums /
-# signatures, so `arigaio/atlas:<version>-distroless` is the only upstream
-# with a verifiable provenance (image digest pinnable). atlasgo.io
-# explicitly recommends the official image for Docker contexts.
-COPY --from=arigaio/atlas:${ATLAS_VERSION}-distroless /atlas /usr/local/bin/atlas
+# preflight-driven Symphony run (issue #399). Pulled from the named
+# `atlas` stage above (see the FROM line for the version + integrity
+# rationale).
+COPY --from=atlas /atlas /usr/local/bin/atlas
 
 # cursor-agent installs into the invoker's HOME, so we run the script in
 # a throwaway HOME and copy the binary into a system path. The official


### PR DESCRIPTION
## Why

The first preflight-driven Symphony run on issue #399 surfaced that `atlas` (the SQLite migration CLI used by `pnpm db:setup`) was never installed in the symphony container image:

```
[preflight:pnpm db:setup] sh: atlas: not found
[preflight:pnpm db:setup] ERROR: "db:apply:shared" exited with 1
```

Previously the takt `bootstrapper` persona swallowed this — it would hit the same missing-binary error but die earlier on Claude CLI stream-idle timeouts (#394) before ever getting to `db:setup`. Removing the LLM bootstrapper in #397 exposed the real dependency.

## Approach

Initially proposed `curl -sSf https://atlasgo.sh | sh`. CodeRabbit flagged the lack of integrity verification on the install script. Investigated atlas's official channels:

- **GitHub Releases ship no binary assets / checksums / signatures**, so the binary-download-with-checksum approach CodeRabbit suggested isn't actually possible.
- **atlasgo.io explicitly recommends `arigaio/atlas:<version>-distroless`** for Docker contexts, with image digest pinning as the integrity story.

Switched to a multi-stage `COPY` from the official image:

```dockerfile
ARG ATLAS_VERSION=1.2.0
...
COPY --from=arigaio/atlas:${ATLAS_VERSION}-distroless /atlas /usr/local/bin/atlas
```

Verified: the binary lives at `/atlas` (root) inside the distroless image, and ENTRYPOINT is `["/atlas"]`. Pinned to `1.2.0` (latest stable on Docker Hub).

`cursor-agent` still uses `curl | bash` for its installer (cursor doesn't publish a Docker image); leaving that as-is — separate hardening concern, not blocking this.

## Test plan

- [ ] `flyctl deploy` rebuilds the image with atlas pulled from the official upstream
- [ ] Re-trigger Symphony on issue #399 and confirm preflight clears `pnpm db:setup` and proceeds into the takt run

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **保守・その他**
  * コンテナイメージのビルド手順を改善し、組み込みのマイグレーション実行ツールをイメージ内に含めることで、ビルドとデプロイの信頼性を向上しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->