### PR TITLE
Auto-deploy symphony on infra/symphony/** changes

### DIFF
--- a/.github/workflows/deploy-symphony.yml
+++ b/.github/workflows/deploy-symphony.yml
@@ -1,0 +1,44 @@
+name: 🎼 Deploy Symphony
+
+# Symphony は本体 upflow と別 Fly app (`upflow-symphony`) で動いてるので
+# deploy も独立。`bin/symphony*.ts` は machine boot 時の `git fetch &&
+# git reset --hard origin/main` で勝手に追従するので redeploy 不要。
+# image に焼き込むファイル (Dockerfile / fly.toml / entrypoint.sh) を
+# 触ったときだけ flyctl deploy する。
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/symphony/**'
+      - '.github/workflows/deploy-symphony.yml'
+  # 緊急時 / 設定変更なしで再 deploy したいとき用
+  workflow_dispatch:
+
+# 同時 deploy で takt 実行中の machine を巻き込まないよう、cancel じゃなく
+# キューイング。前 deploy が終わるまで次は待つ。
+concurrency:
+  group: deploy-symphony
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  deploy:
+    name: 🚀 Deploy Symphony
+    runs-on: ubuntu-latest
+    steps:
+      - name: ⬇️ Checkout repo
+        uses: actions/checkout@v6
+
+      - name: 🚀 flyctl deploy
+        uses: superfly/flyctl-actions@1.5
+        with:
+          args: >-
+            deploy
+            --app upflow-symphony
+            -c infra/symphony/fly.toml
+            --dockerfile infra/symphony/Dockerfile
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/.github/workflows/deploy-symphony.yml
+++ b/.github/workflows/deploy-symphony.yml
@@ -17,6 +17,13 @@ on:
 
 # 同時 deploy で takt 実行中の machine を巻き込まないよう、cancel じゃなく
 # キューイング。前 deploy が終わるまで次は待つ。
+#
+# ただし concurrency は deploy 同士の話で、deploy が takt 子プロセス
+# (90 分まで走り得る) を巻き込むのは別問題。新 image up で旧 machine が
+# SIGTERM (kill_timeout=30s) されるため、takt 中盤で deploy がかかると
+# その issue は強制 kill → 次 boot 時に reconcileOrphans が拾って
+# `symphony:failed` に倒れる。実害は次回 retry で解消するが、PR / issue
+# が「なぜ失敗?」となった時の手がかりとしてここに記載しておく。
 concurrency:
   group: deploy-symphony
   cancel-in-progress: false


### PR DESCRIPTION
## Why

Manually `flyctl deploy --app upflow-symphony ...` after every Dockerfile / fly.toml / entrypoint.sh edit is annoying and easy to forget (just hit this when shipping #400's atlas fix — needed a manual deploy step before #399 could be retriggered).

## What

Add `.github/workflows/deploy-symphony.yml`. Path-filtered so it only runs when image-baked files change:

```yaml
on:
  push:
    branches: [main]
    paths:
      - 'infra/symphony/**'
      - '.github/workflows/deploy-symphony.yml'
  workflow_dispatch:
```

`bin/symphony*.ts` changes are NOT in the trigger list — the machine's entrypoint does `git fetch && git reset --hard origin/main` on every boot, so server code edits flow through automatically. Only image-baked files (Dockerfile, fly.toml, entrypoint.sh) need a redeploy.

`concurrency.cancel-in-progress: false` so a back-to-back merge queues rather than cancelling an in-flight deploy mid-build.

Reuses the same `FLY_API_TOKEN` secret + `superfly/flyctl-actions@1.5` as the existing upflow deploy.

## Test plan

- [x] First merge of this PR itself triggers the workflow (path filter includes the workflow file)
- [ ] Subsequent edits under `infra/symphony/**` auto-deploy
- [ ] Edits under `bin/symphony*.ts` do NOT trigger this workflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)