### PR TITLE
SHA-pin deploy-symphony.yml + Dependabot bumps

### DIFF
--- a/.github/workflows/deploy-symphony.yml
+++ b/.github/workflows/deploy-symphony.yml
@@ -37,10 +37,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: ⬇️ Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: 🚀 flyctl deploy
-        uses: superfly/flyctl-actions@1.5
+        uses: superfly/flyctl-actions@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
         with:
           args: >-
             deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         name: Install pnpm
 
       - name: ⎔ Setup node
@@ -42,7 +42,7 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         name: Install pnpm
 
       - name: ⎔ Setup node
@@ -64,7 +64,7 @@ jobs:
       - name: ⬇️ Checkout repo
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         name: Install pnpm
 
       - name: ⎔ Setup node
@@ -92,7 +92,7 @@ jobs:
       - name: 🏄 Copy test env vars
         run: cp .env.example .env
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         name: Install pnpm
 
       - name: ⎔ Setup node
@@ -133,7 +133,7 @@ jobs:
       - name: 🏄 Copy test env vars
         run: cp .env.example .env
 
-      - uses: pnpm/action-setup@fc06bc1257f339d1d5d8b3a19a8cae5388b55320 # v5
+      - uses: pnpm/action-setup@8912a9102ac27614460f54aedde9e1e7f9aec20d # v6.0.5
         name: Install pnpm
 
       - name: ⎔ Setup node
@@ -164,7 +164,7 @@ jobs:
 
       - name: 💾 Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830 # v4
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
@@ -184,7 +184,7 @@ jobs:
 
       - name: ⬆️ Upload Playwright report on failure
         if: failure()
-        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: playwright-report
           path: playwright-report/
@@ -250,7 +250,7 @@ jobs:
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
       - name: 🚀 Deploy Production
-        uses: superfly/flyctl-actions@fc53c09e1bc3be6f54706524e3b82c4f462f77be # 1.5
+        uses: superfly/flyctl-actions@ed8efb33836e8b2096c7fd3ba1c8afe303ebbff1 # 1.6
         with:
           args: 'deploy --image registry.fly.io/${{ needs.build.outputs.app_name }}:${{ github.ref_name }}-${{ github.sha }}'
         env:


### PR DESCRIPTION
Closes #403 (manually superseded — see below).

## Why

Two fixes in one PR.

### 1. Lost SHA pin in `deploy-symphony.yml`

PR #401 was squash-merged with only its first two commits; my third commit (`SHA-pin actions in deploy-symphony.yml`) landed on the feature branch **after** the merge had already happened, so it never made it to main. Result: `deploy-symphony.yml` on main still uses mutable tags (`actions/checkout@v6`, `superfly/flyctl-actions@1.5`).

Re-apply the pin here. Lesson: when adding follow-up commits to a branch already merged-in-spirit, double-check the merge actually picked them up before declaring done.

### 2. Apply Dependabot's bumps (and close PR #403)

Dependabot opened #403 with 4 grouped bumps. Two issues with merging it as-is:

- It re-bumps `superfly/flyctl-actions@1.5 → @1.6` in `deploy-symphony.yml` as a **tag-only** swap (`@1.6`), perpetuating the unpinned state from issue #1 above.
- The grouped diff hides that `pnpm/action-setup` is a **major version bump** (v5 → v6.0.5) and `actions/upload-artifact` is a **multi-major bump** (v4 → v7.0.1).

Investigated both major bumps:

- **`pnpm/action-setup` v5 → v6**: external API unchanged, internal switch from `dist/pnpm.cjs` bundle to `pnpm self-update` mechanism. upflow's usage (`with:` empty, `packageManager` field in `package.json`) is the recommended v6 pattern. Safe.
- **`actions/upload-artifact` v4 → v7**: used only in the `playwright` job to upload the playwright-report on failure. Bump risk is bounded to that single conditional artifact upload.

Take all 4 bumps (with proper SHA pins) plus the recovered deploy-symphony.yml pin, all in this PR.

## Test plan

- [x] `pnpm validate` not affected (workflow YAML only)
- [ ] Next push to main runs both deploy workflows with new SHAs and succeeds
- [ ] Playwright job's `actions/upload-artifact@v7` accepts the same inputs as v4 (failure-mode artifact upload)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * GitHub Actionsのワークフロー依存関係を複数アップデートして、CI/CDパイプラインを最新化しました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->