### PR TITLE
Use permission_mode=full for coder steps to unblock cursor-agent

### DIFF
--- a/.takt/workflows/spec-implement-accept.yaml
+++ b/.takt/workflows/spec-implement-accept.yaml
@@ -160,7 +160,13 @@ steps:
       - step-implementation
     knowledge: implementation-plan
     session: refresh
-    required_permission_mode: edit
+    # `full` (not `edit`) because takt's cursor-agent invocation only
+    # passes `--force` (the auto-approve-everything flag) when
+    # permissionMode === 'full'; `edit` mode passes nothing, and
+    # cursor-agent then blocks on file-edit / command-exec permission
+    # prompts in headless mode (observed: 80-min hang on issue #399).
+    # cursor-agent has no edit-only flag, so all-or-nothing here.
+    required_permission_mode: full
     instruction: |
       Implement according to the task spec (order.md).
 
@@ -231,7 +237,8 @@ steps:
       - step-implementation
     knowledge: implementation-plan
     session: refresh
-    required_permission_mode: edit
+    # See `implement` step for why coder uses `full`, not `edit`.
+    required_permission_mode: full
     pass_previous_response: false
     instruction: |
       Fix the issues raised in the acceptance testing.


### PR DESCRIPTION
## Why

Symphony's coder step on #399 **hung for 80 minutes** on first contact (PR #405's full-stack run). Investigation traced it to takt's cursor-agent invocation in `nrslib/takt`:

```ts
// src/infra/cursor/client.ts
const args = ['-p', '--trust', '--output-format', 'json',
              '--workspace', options.cwd];
if (options.permissionMode === 'full') {
  args.push('--force');
}
```

`-p --trust` covers headless workspace-trust auto-approve. Without `--force` cursor-agent blocks on file-edit / command-exec permission prompts in headless mode — no TTY, infinite stdin wait. Symptom matches [forum.cursor.com #150246](https://forum.cursor.com/t/cursor-agent-p-print-headless-mode-hangs-indefinitely-and-never-returns/150246).

Comparing to other providers in takt:

| provider | `edit` mode handling |
|---|---|
| claude-headless | `taktPermissionModeToClaudeExpression('edit')` → proper mode arg |
| copilot | `--allow-all-tools --no-ask-user` |
| **cursor** | **(nothing)** ← gap |

cursor-agent has no edit-only flag — it's all-or-nothing (`--force`/`--yolo` allows file edits AND command exec) or prompt. So takt's cursor client effectively only works in `full` mode.

## Change

The two coder-using steps (`implement` + `fix`) flip from `required_permission_mode: edit` to `full`. Inline comments explain why and link the symptom. Other steps (claude / codex personas) keep `edit` — their providers handle that mode correctly.

## Why not patch takt upstream

Worth doing — cursor's client should pass `--force` for `edit` too (since cursor-agent has no middle ground), or document that `edit` is unsupported there. Filing as a separate upstream issue. For our use case the workflow-side workaround unblocks Symphony immediately.

## Test plan

- [ ] No image rebuild needed (entrypoint pulls main on every boot, so next /tick picks this up automatically)
- [ ] Re-trigger Symphony on issue #399 → `implement` step should produce file edits within minutes instead of hanging 80
- [ ] Confirm a draft PR ultimately appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * ワークフロー設定の内部調整を実施しました。システムの信頼性向上に向けた改善です。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->