### PR TITLE
Bump symphony VM to shared-cpu-4x / 4GB

### DIFF
--- a/infra/symphony/fly.toml
+++ b/infra/symphony/fly.toml
@@ -72,5 +72,11 @@ handlers = ["tls", "http"]
 
 [[vm]]
 cpu_kind = "shared"
-cpus = 1
-memory = "2gb"
+# Bumped from 1 vCPU to 4 vCPU after issue #399 cursor-coder traced to
+# `react-router typegen` taking 2.6 min per invocation on shared-cpu-1x
+# (cursor would retry typegen in test-fix loops, eating the 90-min budget).
+# Memory bumped 2→4 GB because cursor + typegen + tsc + vitest can run
+# concurrently during the implement step. Idle shutdown still keeps the
+# real cost dominated by actual run time, not provisioned size.
+cpus = 4
+memory = "4gb"


### PR DESCRIPTION
## Why

Issue #399's coder step on `shared-cpu-1x` was traced via cursor's session transcript to **`react-router typegen` taking 2.6 min per invocation**:

```
command: "cd /data/upflow && timeout 90 pnpm exec react-router typegen 2>&1 | tail -20"
exit_code: 124  # timeout
elapsed_ms: 156641
```

Plus a rolldown `PLUGIN_TIMINGS Warning` for `externalize-deps`. cursor's test-fix retry loop kept invoking typegen and never finished — eating the 90-min budget without producing the draft PR.

This is the actual root cause behind what we initially called "cursor hanging" — cursor was busy retrying.

## Change

| Resource | Before | After |
|---|---|---|
| `cpus` | 1 | 4 |
| `memory` | 2 GB | 4 GB |
| `swap_size_mb` | 1024 | 1024 (unchanged) |

CPU 1→4: typegen and tsgo --build are CPU-bound; rolldown's `externalize-deps` plugin in particular benefits from parallelism.

Memory 2→4 GB: cursor agent + typegen + tsc + vitest can run concurrently in the implement step. The preflight worked fine on 2GB, but cursor's test-fix loop is heavier.

## Cost

Symphony's idle-shutdown model means real cost ≈ time actually running takt (not provisioned size). Going 1→4 vCPU at hypothetical 1 hour/day = ~$0.40 → ~$1.50/month delta. Acceptable for unblocking real Symphony runs.

## Test plan

- [ ] `flyctl deploy` auto-fires from this PR's merge (path filter includes `infra/symphony/**`)
- [ ] Re-trigger Symphony on issue #399 — `react-router typegen` should now complete in well under 90s, freeing cursor's test-fix loop to finish

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * インフラストラクチャのリソース割り当てを最適化し、サーバーのパフォーマンスと処理能力を向上させました。これにより、アプリケーションの安定性と応答性が改善されます。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->