### PR TITLE
implement step に出力契約を導入し、判定役の解釈ぶれを止める

### DIFF
--- a/.takt/facets/output-contracts/implement-report.md
+++ b/.takt/facets/output-contracts/implement-report.md
@@ -1,0 +1,53 @@
+```markdown
+# Implementation Result
+
+## Implement: COMPLETED / BLOCKED
+
+Judgment criteria:
+
+- COMPLETED: Implementation is done. All files listed in order.md's
+  "files to change" have been modified as intended. The workflow can
+  safely proceed to acceptance.
+- BLOCKED: Cannot complete the implementation. Examples:
+  - order.md is missing required information (file path, schema, API
+    contract) and cannot be inferred from the codebase
+  - The required change conflicts with existing code in a way that
+    needs spec-level discussion (not a simple code fix)
+  - A required external resource (API, library, secret) is unavailable
+  - Honest dead-end. Use BLOCKED when continuing would mean guessing
+    or writing throwaway code.
+
+Do NOT use BLOCKED for:
+
+- "validation occasionally fails under load" — the implementation is
+  done; surface the caveat in Notes and emit COMPLETED.
+- "tests are flaky" — same as above; emit COMPLETED with a Notes entry.
+- "I am not 100% sure my fix is correct" — emit COMPLETED. Acceptance
+  step exists for this.
+
+## Summary
+
+{1-2 sentence summary of what was implemented (or why blocked)}
+
+## Files Changed
+
+- `path/to/file.ts` — {brief description of change}
+- ...
+
+## Validation
+
+Summary of `pnpm validate` output. If the run had any flakiness or
+caveats (intermittent failure, slow test, etc.), capture them in
+Notes below — NOT in the Judgment.
+
+## Notes
+
+{Anything the next step (acceptance / human reviewer) should know
+that doesn't fit elsewhere. Caveats, observed flakiness, decisions
+made under ambiguity. Leave empty if none.}
+
+## Why (if BLOCKED)
+
+{One short paragraph naming the specific blocker. The acceptance
+step will not run; this text is what the human reviewer reads first.}
+```

--- a/.takt/workflows/spec-implement-accept.yaml
+++ b/.takt/workflows/spec-implement-accept.yaml
@@ -32,6 +32,7 @@ report_formats:
   spec-review-report: ../facets/output-contracts/spec-review-report.md
   acceptance-report: ../facets/output-contracts/acceptance-report.md
   supervise-report: ../facets/output-contracts/supervise-report.md
+  implement-report: ../facets/output-contracts/implement-report.md
 
 loop_monitors:
   # Spec review <-> Spec revision loop
@@ -167,6 +168,10 @@ steps:
     # prompts in headless mode (observed: 80-min hang on issue #399).
     # cursor-agent has no edit-only flag, so all-or-nothing here.
     required_permission_mode: full
+    output_contracts:
+      report:
+        - name: implement-report.md
+          format: implement-report
     instruction: |
       Implement according to the task spec (order.md).
 
@@ -184,16 +189,35 @@ steps:
          ```bash
          pnpm format:fix && pnpm validate
          ```
+      6. Write `implement-report.md` per the format. The report MUST
+         contain exactly one of these lines (this is the Judgment marker
+         the judge reads literally):
+
+         ```
+         ## Implement: COMPLETED
+         ```
+
+         or
+
+         ```
+         ## Implement: BLOCKED
+         ```
+
+         Free-form prose elsewhere is fine; the marker line is
+         non-negotiable.
 
       **Rules:**
       - Only modify files listed in order.md's files to change
       - Do not modify PLAN.md or order.md
       - Follow existing code patterns and conventions (refer to CLAUDE.md)
       - Keep changes minimal
+      - Caveats / observed flakiness / "validation sometimes fails under
+        load" go in the Notes section, NOT in the Judgment marker. Emit
+        COMPLETED unless the implementation itself cannot be finished.
     rules:
-      - condition: Implementation complete, validation passes
+      - condition: 'implement-report.md contains the line `## Implement: COMPLETED`'
         next: acceptance
-      - condition: Cannot implement, insufficient information
+      - condition: 'implement-report.md contains the line `## Implement: BLOCKED`'
         next: ABORT
 
   # 5. Acceptance testing
@@ -240,6 +264,10 @@ steps:
     # See `implement` step for why coder uses `full`, not `edit`.
     required_permission_mode: full
     pass_previous_response: false
+    output_contracts:
+      report:
+        - name: implement-report.md
+          format: implement-report
     instruction: |
       Fix the issues raised in the acceptance testing.
 
@@ -251,14 +279,30 @@ steps:
          ```bash
          pnpm format:fix && pnpm validate
          ```
+      5. Write `implement-report.md` per the same format the implement
+         step uses. The report MUST contain exactly one of these lines:
+
+         ```
+         ## Implement: COMPLETED
+         ```
+
+         or
+
+         ```
+         ## Implement: BLOCKED
+         ```
+
+         COMPLETED means the fix is applied; BLOCKED means the fix
+         cannot be made (escalate to supervise). Caveats /
+         observed flakiness go in Notes, not in the marker.
 
       **Rules:**
       - Do not modify PLAN.md or order.md
       - Only make fixes within scope
     rules:
-      - condition: Fix complete
+      - condition: 'implement-report.md contains the line `## Implement: COMPLETED`'
         next: acceptance
-      - condition: Cannot fix
+      - condition: 'implement-report.md contains the line `## Implement: BLOCKED`'
         next: supervise
 
   # 8. Final verification

--- a/bin/symphony-serve.ts
+++ b/bin/symphony-serve.ts
@@ -161,10 +161,13 @@ function readSuperviseReport(runDir: string): string {
 }
 
 function readImplementReport(runDir: string): string {
-  // Both the implement and fix steps write to the same file name; the
-  // last write wins. classifyTakt only consults this report when the
-  // workflow aborted before reaching supervise, so the most recent
-  // implement/fix attempt is exactly what we want.
+  // Both the implement and fix steps declare `name: implement-report.md`
+  // in their output_contracts. takt's report-phase-runner backs up any
+  // existing file at this name to `<name>.<timestamp>` before writing
+  // (see `backupExistingReport` in report-phase-runner.ts), so the base
+  // name always holds the most recent attempt. classifyTakt only
+  // consults this report on aborted runs, where the latest implement /
+  // fix attempt is exactly what we want.
   const path = join(runDir, 'reports', 'implement-report.md')
   if (!existsSync(path)) return ''
   return readFileSync(path, 'utf-8')

--- a/bin/symphony-serve.ts
+++ b/bin/symphony-serve.ts
@@ -160,6 +160,16 @@ function readSuperviseReport(runDir: string): string {
   return readFileSync(path, 'utf-8')
 }
 
+function readImplementReport(runDir: string): string {
+  // Both the implement and fix steps write to the same file name; the
+  // last write wins. classifyTakt only consults this report when the
+  // workflow aborted before reaching supervise, so the most recent
+  // implement/fix attempt is exactly what we want.
+  const path = join(runDir, 'reports', 'implement-report.md')
+  if (!existsSync(path)) return ''
+  return readFileSync(path, 'utf-8')
+}
+
 function pollProgress(): void {
   if (activeJob === null) return
   try {
@@ -195,6 +205,7 @@ function stopProgressPoller(): void {
 interface TaktChildResult {
   metaStatus: TaktMetaStatus
   superviseReport: string
+  implementReport: string
   elapsedMs: number
   iterations?: number
   /** Names the failing preflight stage when metaStatus === 'preflight_failed'. */
@@ -251,6 +262,7 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
       return {
         metaStatus: 'preflight_failed',
         superviseReport: '',
+        implementReport: '',
         elapsedMs: Date.now() - startMs,
         preflightFailedAt: stage,
       }
@@ -269,7 +281,12 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
   const elapsedMs = Date.now() - startMs
   const runDir = findLatestRunDir(startMs)
   if (runDir === null) {
-    return { metaStatus: 'startup_failed', superviseReport: '', elapsedMs }
+    return {
+      metaStatus: 'startup_failed',
+      superviseReport: '',
+      implementReport: '',
+      elapsedMs,
+    }
   }
   const meta = readMeta(runDir)
   const status: TaktMetaStatus =
@@ -277,6 +294,9 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
   return {
     metaStatus: status,
     superviseReport: status === 'completed' ? readSuperviseReport(runDir) : '',
+    // Always read the implement report — classifyTakt uses it to
+    // distinguish a BLOCKED abort from a generic one.
+    implementReport: readImplementReport(runDir),
     elapsedMs,
     iterations: meta?.iterations,
   }
@@ -351,6 +371,7 @@ async function processOneIssue(): Promise<{
       taktResult = {
         metaStatus: 'failed',
         superviseReport: '',
+        implementReport: '',
         elapsedMs: Date.now() - dayjs.utc(startedAt).valueOf(),
       }
     }

--- a/bin/symphony-shared.test.ts
+++ b/bin/symphony-shared.test.ts
@@ -148,6 +148,72 @@ describe('classifyTakt', () => {
       // 200-char cap matches the supervise FIX path
       expect(r.reason.length).toBeLessThan(300)
     })
+
+    it('captures the entire multi-line Why body, not just the first line', () => {
+      // Regression: the previous single-regex `/^##\s*Why...$/im`
+      // implementation matched `$` at the first line boundary and
+      // silently dropped subsequent lines. The post-mortem comment
+      // would only show the first sentence of the blocker.
+      const report = [
+        '## Implement: BLOCKED',
+        '',
+        '## Why',
+        '',
+        'First line of the blocker.',
+        'Second line continues here.',
+        'Third line still part of the same paragraph.',
+      ].join('\n')
+      const r = classifyTakt({
+        ...baseArgs,
+        metaStatus: 'aborted',
+        superviseReport: '',
+        implementReport: report,
+      })
+      expect(r.outcome).toBe('failure_deterministic')
+      expect(r.reason).toContain('First line of the blocker.')
+      expect(r.reason).toContain('Second line continues here.')
+      expect(r.reason).toContain('Third line still part of the same paragraph.')
+    })
+
+    it('handles the literal `## Why (if BLOCKED)` heading from the contract template', () => {
+      const report = [
+        '## Implement: BLOCKED',
+        '',
+        '## Why (if BLOCKED)',
+        '',
+        'Cannot proceed without the API key.',
+      ].join('\n')
+      const r = classifyTakt({
+        ...baseArgs,
+        metaStatus: 'aborted',
+        superviseReport: '',
+        implementReport: report,
+      })
+      expect(r.outcome).toBe('failure_deterministic')
+      expect(r.reason).toContain('Cannot proceed without the API key.')
+    })
+
+    it('stops Why extraction at the next `##` heading', () => {
+      const report = [
+        '## Implement: BLOCKED',
+        '',
+        '## Why',
+        '',
+        'The actual blocker description.',
+        '',
+        '## Notes',
+        '',
+        'Unrelated extra context that should not appear in the reason.',
+      ].join('\n')
+      const r = classifyTakt({
+        ...baseArgs,
+        metaStatus: 'aborted',
+        superviseReport: '',
+        implementReport: report,
+      })
+      expect(r.reason).toContain('The actual blocker description.')
+      expect(r.reason).not.toContain('Unrelated extra context')
+    })
   })
 
   describe('completed', () => {

--- a/bin/symphony-shared.test.ts
+++ b/bin/symphony-shared.test.ts
@@ -75,6 +75,81 @@ describe('classifyTakt', () => {
     })
   }
 
+  describe('aborted with implement report', () => {
+    it('returns failure_deterministic with the Why when implement is BLOCKED', () => {
+      const report = [
+        '# Implementation Result',
+        '',
+        '## Implement: BLOCKED',
+        '',
+        '## Why',
+        '',
+        'order.md does not specify the API endpoint shape and the',
+        'caller does not exist in the repo yet.',
+      ].join('\n')
+      const r = classifyTakt({
+        ...baseArgs,
+        metaStatus: 'aborted',
+        superviseReport: '',
+        implementReport: report,
+      })
+      expect(r.outcome).toBe('failure_deterministic')
+      expect(r.reason).toContain('takt implement judgment: BLOCKED')
+      expect(r.reason).toContain('does not specify the API endpoint')
+    })
+
+    it('still returns failure_deterministic when BLOCKED has no Why section', () => {
+      const r = classifyTakt({
+        ...baseArgs,
+        metaStatus: 'aborted',
+        superviseReport: '',
+        implementReport: '## Implement: BLOCKED\n',
+      })
+      expect(r.outcome).toBe('failure_deterministic')
+      expect(r.reason).toBe('takt implement judgment: BLOCKED')
+    })
+
+    it('falls back to transient when implement marker says COMPLETED but workflow aborted elsewhere', () => {
+      // e.g. fix step succeeded but supervise ABORTed for spec-level
+      // reasons; the COMPLETED marker is stale and shouldn't fake a
+      // human-needed signal.
+      const r = classifyTakt({
+        ...baseArgs,
+        metaStatus: 'aborted',
+        superviseReport: '',
+        implementReport: '## Implement: COMPLETED\n',
+        iterations: 2,
+      })
+      expect(r.outcome).toBe('failure_transient')
+      expect(r.reason).toContain('meta.status=aborted')
+    })
+
+    it('falls back to transient when implement report has no marker', () => {
+      const r = classifyTakt({
+        ...baseArgs,
+        metaStatus: 'aborted',
+        superviseReport: '',
+        implementReport: 'random text without marker',
+        iterations: 1,
+      })
+      expect(r.outcome).toBe('failure_transient')
+      expect(r.reason).toContain('meta.status=aborted')
+    })
+
+    it('truncates very long Why text to keep the post-mortem comment readable', () => {
+      const why = 'x'.repeat(500)
+      const r = classifyTakt({
+        ...baseArgs,
+        metaStatus: 'aborted',
+        superviseReport: '',
+        implementReport: `## Implement: BLOCKED\n\n## Why\n\n${why}`,
+      })
+      expect(r.outcome).toBe('failure_deterministic')
+      // 200-char cap matches the supervise FIX path
+      expect(r.reason.length).toBeLessThan(300)
+    })
+  })
+
   describe('completed', () => {
     it('returns success on Judgment: COMPLETE', () => {
       const r = classifyTakt({

--- a/bin/symphony-shared.ts
+++ b/bin/symphony-shared.ts
@@ -238,14 +238,19 @@ export type TaktMetaStatus =
   | 'preflight_failed'
 
 /**
- * Heuristic outcome classification; M0 will replace this once takt's
- * supervise step emits a structured outcome field. Today we look at the
- * takt-reported `meta.status` and the "Remaining Issues" section of the
- * supervise report.
+ * Outcome classification driven by takt's structured judgment markers.
+ * The supervise step emits `## Judgment: COMPLETE | FIX | SPEC_REVIEW`
+ * (`.takt/facets/output-contracts/supervise-report.md`); the implement
+ * and fix steps emit `## Implement: COMPLETED | BLOCKED`
+ * (`.takt/facets/output-contracts/implement-report.md`). The implement
+ * marker is what disambiguates an "ABORT because the agent declared
+ * BLOCKED" (deterministic, surface the Why) from a generic abort
+ * (transient, retry).
  */
 export function classifyTakt(args: {
   metaStatus: TaktMetaStatus
   superviseReport: string
+  implementReport?: string
   elapsedMs: number
   iterations?: number
   preflightFailedAt?: string
@@ -253,6 +258,7 @@ export function classifyTakt(args: {
   const {
     metaStatus,
     superviseReport,
+    implementReport,
     elapsedMs,
     iterations,
     preflightFailedAt,
@@ -285,6 +291,22 @@ export function classifyTakt(args: {
     metaStatus === 'running' ||
     metaStatus === 'aborted'
   ) {
+    // If the implement/fix step explicitly emitted BLOCKED, that's a
+    // deterministic "human needed" signal — not the same as a generic
+    // aborted-by-judge. Surface the Why so the post-mortem comment
+    // tells the operator what to clarify, instead of just naming the
+    // status code.
+    const implementMarker = implementReport
+      ? extractImplementJudgment(implementReport)
+      : undefined
+    if (implementMarker === 'BLOCKED') {
+      const why = extractImplementWhy(implementReport ?? '')
+      return {
+        outcome: 'failure_deterministic',
+        reason: `takt implement judgment: BLOCKED${why ? ` — ${why.slice(0, 200)}` : ''}`,
+        elapsedMs,
+      }
+    }
     return {
       outcome: 'failure_transient',
       reason: `takt meta.status=${metaStatus} after polling (iterations=${iterations ?? '?'})`,
@@ -323,6 +345,21 @@ export function classifyTakt(args: {
     reason: `takt supervise judgment: ${judgment}${tail ? ` — ${tail.slice(0, 200)}` : ''}`,
     elapsedMs,
   }
+}
+
+function extractImplementJudgment(
+  report: string,
+): 'COMPLETED' | 'BLOCKED' | undefined {
+  const m = report.match(/^##\s*Implement:\s*(COMPLETED|BLOCKED)\b/im)
+  return m?.[1] as 'COMPLETED' | 'BLOCKED' | undefined
+}
+
+function extractImplementWhy(report: string): string {
+  // The contract puts the blocker in `## Why (if BLOCKED)`. Match that
+  // section header (with or without the parenthetical) and grab the
+  // body up to the next `##` heading or EOF.
+  const m = report.match(/^##\s*Why[^\n]*\n+([\s\S]*?)(\n##\s|$)/im)
+  return m?.[1]?.trim() ?? ''
 }
 
 export function elapsedMarker(elapsedMs: number): string {

--- a/bin/symphony-shared.ts
+++ b/bin/symphony-shared.ts
@@ -355,11 +355,18 @@ function extractImplementJudgment(
 }
 
 function extractImplementWhy(report: string): string {
-  // The contract puts the blocker in `## Why (if BLOCKED)`. Match that
+  // The contract puts the blocker in `## Why (if BLOCKED)`. Match the
   // section header (with or without the parenthetical) and grab the
-  // body up to the next `##` heading or EOF.
-  const m = report.match(/^##\s*Why[^\n]*\n+([\s\S]*?)(\n##\s|$)/im)
-  return m?.[1]?.trim() ?? ''
+  // body up to the next `##` heading or end-of-file.
+  //
+  // Done as locate-heading + slice (not a single regex with `$`) because
+  // `$` under /m matches at every line boundary, so a lazy regex stops
+  // at the first newline and silently truncates multi-line Why bodies.
+  const heading = report.match(/^##\s*Why\b[^\n]*\n+/im)
+  if (heading?.index === undefined) return ''
+  const after = report.slice(heading.index + heading[0].length)
+  const next = after.match(/\n##\s/)
+  return (next?.index === undefined ? after : after.slice(0, next.index)).trim()
 }
 
 export function elapsedMarker(elapsedMs: number): string {


### PR DESCRIPTION
## なぜ

Symphony の implement / fix step だけ自由記述の報告で、判定役の LLM が解釈する余地ができてた。issue #399 で実際に観測されたパターン:

1. cursor が良い実装を完了 + 「validation 時々 fail する」と但し書き
2. 判定役: 「validation passes じゃない」と読む → ABORT
3. iteration 2-3: cursor が「何を直せばいいか」分からなくなり、関係ない Dockerfile を触り出す (scope drift)

入力 (cursor の報告 → 判定役の feedback) が曖昧だから出力 (cursor の挙動) も発散する。他の step (spec-review / acceptance / supervise) は `.takt/facets/output-contracts/*.md` に決まった形式があり、判定役は marker 行を見るだけ。implement だけそれが無かった。

## なに

- `.takt/facets/output-contracts/implement-report.md` 新規。supervise-report.md と同じ作りで、`## Implement: COMPLETED | BLOCKED` を必須 marker に
- workflow yaml の implement / fix step に `output_contracts` を追加し、 `report_format` で結びつけ
- 各 step の `instruction:` 末尾に「marker 行を含めること、caveats は Notes 行きで Judgment じゃない」と明記
- `rules:` を marker 文言と完全一致 (`'implement-report.md contains the line \`## Implement: COMPLETED\`'`) に。判定役が間違いようがない
- `classifyTakt` を拡張: meta.status='aborted' かつ implement-report が BLOCKED なら failure_deterministic として扱い、Why セクションを事後コメントに転記。ABORT の理由が運用者に直接見える (= 副次的に observability 改善)

## やったこと / やらなかったこと

- やった: A (判定ぶれ) と C (事後コメントから理由が見える) を 1 PR で同時解消
- やらなかった: B (cursor の scope drift). A が直れば B は自然消滅する仮説で、別 PR で観測してから判断
- やらなかった: D (structural test の負荷下 flaky). 別軸の問題なので #409 に切り出し済

## Test plan

- [x] `pnpm validate` 全 pass (35 → 41 tests in symphony-shared.test.ts)
- [x] 新規テスト: aborted + BLOCKED → failure_deterministic + Why 転記、aborted + COMPLETED (stale) → transient、aborted + marker 無し → transient、Why が長すぎても切り詰め
- [ ] 実環境: 次回 symphony cycle で `## Implement: COMPLETED` marker が implement-report.md に書かれることを runDir で確認
- [ ] 実環境: 意図的に BLOCKED を誘発させる issue を 1 本投げて、事後コメントに Why が転記されるか確認

## 関連

- #399 (今回観測の元イシュー)
- #409 (D: structural test の flaky 改善は別 PR)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 新機能

* 実装結果をより明示的に報告するための新しい implement-report 形式が導入されました。ワークフローが COMPLETED/BLOCKED マーカーベースで進行状況を判定するようになり、実装ステータスの追跡がより詳細かつ決定的になりました。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->