### PR TITLE
symphony preflight で cursor-agent の project memory を毎回 wipe する

### DIFF
--- a/bin/symphony-serve.ts
+++ b/bin/symphony-serve.ts
@@ -239,17 +239,14 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
   // here only.
   const preflightStages: Array<[string, string]> = [
     // cursor-agent's composer model retrieves prompts from its
-    // persistent project memory under `/data/home/.cursor/` when
-    // composing subagent tasks. Sessions left over from prior symphony
-    // runs or manual SSH testing leak in as subagent prompts and cause
-    // out-of-scope edits — observed on issue #399 where a stale
-    // `cleanup-install-versions 2026.05.05-84a231c` prompt from a
-    // 14-hour-old SSH test became the rogue subagent's task during a
-    // login UI fix, so cursor edited Dockerfile and docs as "related"
-    // work. Cursor exposes no CLI flag or config option to disable
-    // subagent project memory (verified against cursor.com/docs/cli
-    // and cursor.com/docs/subagents), so we have to manage the state
-    // file tree ourselves before each takt run.
+    // persistent project memory under `$HOME/.cursor/` when composing
+    // subagent tasks. Stale sessions left over from prior symphony
+    // runs or manual SSH testing leak in as subagent prompts and
+    // trigger out-of-scope edits (observed on issue #399). Cursor
+    // exposes no CLI flag or config option to disable subagent project
+    // memory (verified against cursor.com/docs/cli and
+    // cursor.com/docs/subagents), so we have to manage the state file
+    // tree ourselves before each takt run.
     //
     // Archive (not delete) the active dirs into a timestamped sibling
     // so cursor sees an empty starting state but we keep forensic
@@ -257,16 +254,25 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
     // pruning archives beyond the most recent 10. Side effect: any
     // ongoing manual SSH cursor session loses its scratch state when
     // a tick fires.
+    //
+    // The `data-upflow` literal in the projects path is cursor's own
+    // slug for the workspace (slashes in `/data/upflow` collapsed to
+    // dashes). If SYMPHONY_REPO_DIR ever moves, this slug changes and
+    // the mv silently misses — re-derive then.
     [
       'cursor state reset',
+      // Joined with `;` (not `&&` like sibling stages) because each
+      // step is independently optional: source dirs may not exist on
+      // first boot, prune may have nothing to remove. Trailing `true`
+      // pins the stage exit to 0 so a stray `rm` failure on an
+      // unreadable archive doesn't fail preflight.
       [
-        'set +e',
-        'ARCHIVE_ROOT=/data/home/.cursor/_archive',
+        'ARCHIVE_ROOT=$HOME/.cursor/_archive',
         'ARCHIVE=$ARCHIVE_ROOT/$(date -u +%Y%m%dT%H%M%SZ)',
         'mkdir -p "$ARCHIVE"',
-        '[ -d /data/home/.cursor/chats ] && mv /data/home/.cursor/chats "$ARCHIVE/"',
-        '[ -d /data/home/.cursor/projects/data-upflow/agent-transcripts ] && mv /data/home/.cursor/projects/data-upflow/agent-transcripts "$ARCHIVE/"',
-        'mkdir -p /data/home/.cursor/chats /data/home/.cursor/projects/data-upflow/agent-transcripts',
+        'mv $HOME/.cursor/chats "$ARCHIVE/" 2>/dev/null',
+        'mv $HOME/.cursor/projects/data-upflow/agent-transcripts "$ARCHIVE/" 2>/dev/null',
+        'mkdir -p $HOME/.cursor/chats $HOME/.cursor/projects/data-upflow/agent-transcripts',
         'ls -dt $ARCHIVE_ROOT/*/ 2>/dev/null | tail -n +11 | xargs -r rm -rf',
         'true',
       ].join('; '),

--- a/bin/symphony-serve.ts
+++ b/bin/symphony-serve.ts
@@ -234,7 +234,27 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
   // Stages MUST stay in lockstep with `infra/symphony/preflight-local.sh`,
   // which runs the same chain locally for pre-deploy verification. There's
   // no shared definition yet — keep the two arrays manually in sync.
+  // Exception: `cursor state reset` only matters on the persistent fly
+  // volume, not in the throwaway local preflight container, so it lives
+  // here only.
   const preflightStages: Array<[string, string]> = [
+    // cursor-agent's composer model retrieves prompts from its
+    // persistent project memory under `/data/home/.cursor/` when
+    // composing subagent tasks. Sessions left over from prior symphony
+    // runs or manual SSH testing leak in as subagent prompts and cause
+    // out-of-scope edits — observed on issue #399 where a stale
+    // `cleanup-install-versions 2026.05.05-84a231c` prompt from a
+    // 14-hour-old SSH test became the rogue subagent's task during a
+    // login UI fix, so cursor edited Dockerfile and docs as "related"
+    // work. Cursor exposes no CLI flag or config option to disable
+    // subagent project memory (verified against cursor.com/docs/cli
+    // and cursor.com/docs/subagents), so wipe the state file tree
+    // ourselves before each takt run. Side effect: any ongoing manual
+    // SSH cursor session loses its scratch state when a tick fires.
+    [
+      'cursor state reset',
+      'rm -rf /data/home/.cursor/chats/* /data/home/.cursor/projects/*/agent-transcripts/* 2>/dev/null; true',
+    ],
     [
       'git sync',
       [

--- a/bin/symphony-serve.ts
+++ b/bin/symphony-serve.ts
@@ -248,12 +248,28 @@ async function runTakt(issueNumber: number): Promise<TaktChildResult> {
     // login UI fix, so cursor edited Dockerfile and docs as "related"
     // work. Cursor exposes no CLI flag or config option to disable
     // subagent project memory (verified against cursor.com/docs/cli
-    // and cursor.com/docs/subagents), so wipe the state file tree
-    // ourselves before each takt run. Side effect: any ongoing manual
-    // SSH cursor session loses its scratch state when a tick fires.
+    // and cursor.com/docs/subagents), so we have to manage the state
+    // file tree ourselves before each takt run.
+    //
+    // Archive (not delete) the active dirs into a timestamped sibling
+    // so cursor sees an empty starting state but we keep forensic
+    // transcripts for post-mortem inspection. Bound disk usage by
+    // pruning archives beyond the most recent 10. Side effect: any
+    // ongoing manual SSH cursor session loses its scratch state when
+    // a tick fires.
     [
       'cursor state reset',
-      'rm -rf /data/home/.cursor/chats/* /data/home/.cursor/projects/*/agent-transcripts/* 2>/dev/null; true',
+      [
+        'set +e',
+        'ARCHIVE_ROOT=/data/home/.cursor/_archive',
+        'ARCHIVE=$ARCHIVE_ROOT/$(date -u +%Y%m%dT%H%M%SZ)',
+        'mkdir -p "$ARCHIVE"',
+        '[ -d /data/home/.cursor/chats ] && mv /data/home/.cursor/chats "$ARCHIVE/"',
+        '[ -d /data/home/.cursor/projects/data-upflow/agent-transcripts ] && mv /data/home/.cursor/projects/data-upflow/agent-transcripts "$ARCHIVE/"',
+        'mkdir -p /data/home/.cursor/chats /data/home/.cursor/projects/data-upflow/agent-transcripts',
+        'ls -dt $ARCHIVE_ROOT/*/ 2>/dev/null | tail -n +11 | xargs -r rm -rf',
+        'true',
+      ].join('; '),
     ],
     [
       'git sync',

--- a/infra/symphony/preflight-local.sh
+++ b/infra/symphony/preflight-local.sh
@@ -63,6 +63,13 @@ ENV_ARGS=(
 # Stage commands below MUST stay in lockstep with `bin/symphony-serve.ts`
 # `runTakt` `preflightStages`. There's no shared definition yet — see
 # the cross-reference comment there.
+#
+# Intentional asymmetry: the production preflight has a `cursor state
+# reset` stage that wipes `/data/home/.cursor/`. We do NOT mirror it
+# here because the local preflight uses a throwaway docker container
+# with no persistent /data/home — there's no leftover cursor state to
+# clean. Adding it would just be a no-op rm that masks the actual
+# coverage gap.
 echo "[host] running preflight stages inside $IMAGE_TAG"
 docker run --rm \
   --entrypoint bash \


### PR DESCRIPTION
## なぜ

#399 verification で **A (judge ぶれ) は機能した**ことを確認したが、別の問題が露呈した: cursor-agent が parent / subagent の 2 セッションを spawn し、subagent 側が **14 時間前の SSH manual test の prompt** を user_query として受け取り、関係ない infra ファイルを編集してた。

具体観測:

| session | 種類 | first user_query | 編集ファイル |
|---|---|---|---|
| `9cd785c1` (15:20:09) | parent | takt の正しい fix-step prompt | `app/routes/_auth/login.tsx` (in scope) |
| `71a584ee` (15:20:13) | subagent | `cleanup-install-versions 2026.05.05-84a231c` | `infra/symphony/Dockerfile`, `docs/symphony-setup-sprite.md`, `docs/symphony-setup.md` (all out of scope) |

cursor 公式 docs によると subagent は parent が composer model で **能動的に prompt を組み立てて**渡す。つまり parent の model が「過去に `cleanup-install-versions ...` という関連タスクがあった」と判断して subagent に振り分けてる。出処は cursor の **persistent project memory** (`/data/home/.cursor/chats/` + per-project agent-transcripts)。

cursor 側に opt-out が無い (確認済み: `cursor.com/docs/cli/reference/parameters`, `cursor.com/docs/cli/reference/configuration`, `cursor.com/docs/subagents`)。手元で制御できるのはディスク上の state ファイルだけ。

## なに

`bin/symphony-serve.ts` の `runTakt` preflight stages の **先頭** に `cursor state reset` stage を追加。ただし**消さずに archive する**:

```bash
ARCHIVE=/data/home/.cursor/_archive/$(date -u +%Y%m%dT%H%M%SZ)
mv /data/home/.cursor/chats "$ARCHIVE/"
mv /data/home/.cursor/projects/data-upflow/agent-transcripts "$ARCHIVE/"
mkdir -p (active dirs)
# keep most recent 10 archives, prune older
```

cursor は active dir が空に見えるので memory leak は止まる。一方で transcripts と SQLite store は archive に残るので、今回みたいな post-mortem 調査ができる。

## なぜ archive (rm じゃなく)

最初は `rm -rf` で書いてたが、coji 指摘: 今回 #399 の rogue session を特定できたのはまさに `/data/home/.cursor/projects/data-upflow/agent-transcripts/` の jsonl を読めたから。毎 tick で消すと future debug capability を失う。

archive 方式なら:
- `_archive/<ts>/agent-transcripts/<session-id>/<session-id>.jsonl` で過去 N tick 分の cursor session が全部残る
- 古い archive は 10 件超えたら自動 prune (disk 圧迫しない)
- 必要なら `fly ssh` から普通に閲覧できる

## やったこと / やらなかったこと

- やった: `bin/symphony-serve.ts` の preflight に archive 型 cleanup 追加
- やった: `infra/symphony/preflight-local.sh` に「ローカルは throwaway container なので不要」のコメント追加 (mirror の意図的非対称性を明示)
- やらなかった: machine boot (`entrypoint.sh`) での cleanup。preflight が毎 tick 走るので boot 時は冗長
- やらなかった: cursor-agent をコーダーから外す案 (claude/codex への切替)。cleanup で症状が消えるか実機で確認してから判断する方が情報量が多い。コスト的にも先に cleanup で済めばその方が良い

## 副作用

manual SSH 中に cursor で何か作業してて、その間に symphony tick が発火すると、scratch session が `_archive/<ts>/` に飛ばされる。delete じゃないので失われない。

## Test plan

- [x] `pnpm validate` 通る (existing tests)
- [x] cleanup script 単体を `/tmp` で dry-run 検証。active dir → archive への mv、active dir 再作成、prune ロジックすべて期待通り
- [ ] デプロイ後の次 symphony 試行で `<runDir>/agent-transcripts/` に rogue session (`cleanup-install-versions` の user_query を持つ) が**生成されない**ことを fly ssh で確認
- [ ] 同 cycle で acceptance step が「scope 外ファイル変更」の REJECT を出さないことを確認
- [ ] `_archive/<ts>/` に過去 tick の cursor session が保持されてることを確認 (10 件まで)

## 関連

- #399 (観測元)
- #410 (A: judge ぶれ — こちらは独立、すでにマージ済み)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * スタートアップ時のカーソル状態管理を改善しました。起動処理の初期段階でカーソル関連の状態をリセットし、スムーズな起動環境を整備します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->