### PR TITLE
chore(symphony): 凍結 - schedule tick と fly auto_start を停止

### DIFF
--- a/.github/workflows/symphony-tick.yml
+++ b/.github/workflows/symphony-tick.yml
@@ -4,10 +4,17 @@ name: 🎼 Symphony tick
 # period auto-starts the machine; the symphony server then either picks up
 # one ready issue (long-running takt run) or returns idle and the machine
 # self-shuts after its idle window.
+#
+# Frozen (2026-05-09): schedule trigger を外して凍結中。fly machine も
+# `auto_start_machines = false` で起動しない。残してあるのは
+# workflow_dispatch だけで、再開判断後に手動で叩いて動作確認できる。
+# 復活手順:
+#   1. infra/symphony/fly.toml の auto_start_machines を true に戻す
+#   2. fly deploy -c infra/symphony/fly.toml --dockerfile infra/symphony/Dockerfile
+#   3. gh workflow enable symphony-tick.yml
+#   4. この yml の `schedule:` を復活させる
 
 on:
-  schedule:
-    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 permissions:

--- a/infra/symphony/fly.toml
+++ b/infra/symphony/fly.toml
@@ -52,13 +52,14 @@ destination = "/data"
 [[services]]
 protocol = "tcp"
 internal_port = 8080
-# The HTTP /tick handler runs takt synchronously so the Fly proxy sees an
-# active connection for the entire 60-90 min run. We do NOT set
-# auto_stop_machines because the proxy's "no traffic" heuristic fires on
-# subprocess-only activity. The app self-exits after an idle window
-# (see bin/symphony-serve.ts) and the proxy auto-starts on the next tick.
+# Frozen (2026-05-09): symphony は claude code の SSE silent hang
+# (anthropics/claude-code#33949) と takt の 10 分 idle ハードコードの
+# 組み合わせで安定運用が困難になり、一旦凍結。`auto_start_machines`
+# を切ることで `gh workflow disable symphony-tick.yml` 後に万が一の
+# 手動 /tick が来てもマシンが起動しない。再開時は true に戻して
+# `fly deploy` + `gh workflow enable symphony-tick.yml`。
 auto_stop_machines = "off"
-auto_start_machines = true
+auto_start_machines = false
 min_machines_running = 0
 
 [[services.ports]]


### PR DESCRIPTION
## Summary

symphony を一旦凍結する。

claude code の SSE streaming silent hang (anthropics/claude-code#33949) と takt の 10 分 idle ハードコードの組み合わせで、supervise / simplify step が確率的に abort する状況が今日の検証で確証された。Anthropic 側の修正待ちで自分のレイヤーでは根治できないため、放置運用するより一旦止める。

凍結内容:

- `.github/workflows/symphony-tick.yml`: `schedule:` を外し `workflow_dispatch` のみ残す (手動動作確認用)
- `infra/symphony/fly.toml`: `auto_start_machines = false`、万が一の手動 tick でもマシンが起動しないようにする

## 残すもの

- `bin/symphony-*`, `infra/symphony/*` のコード一式
- fly app `upflow-symphony` と volume `symphony_data` (履歴用)
- PR #410-#416 で蓄積した本質的な修正 (vitest projects 直列化、auto-deliver、cursor-agent shim 等)
- `symphony:*` ラベル

## 復活手順 (両ファイルのコメントにも記載)

1. `infra/symphony/fly.toml` の `auto_start_machines` を `true` に戻す
2. `fly deploy -c infra/symphony/fly.toml --dockerfile infra/symphony/Dockerfile`
3. `gh workflow enable symphony-tick.yml`
4. `symphony-tick.yml` の `schedule:` を復活させる

## マージ後にやる手作業

- `gh workflow disable symphony-tick.yml`
- `flyctl machine stop 286d492c6521d8 -a upflow-symphony`
- 既存 `symphony:running` / `symphony:ready` ラベルの掃除 (該当 issue があれば手動)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * Symphony の自動スケジュール実行を一時停止しました。既知の問題への対応です。
  * 手動でのワークフロー実行は引き続き利用可能です。
  * インフラストラクチャ設定を更新し、システムの安定性を向上させました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coji/upflow/pull/417)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->