### PR TITLE
chore: pin node engine to 24.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "sideEffects": false,
   "type": "module",
   "engines": {
-    "node": "24.x"
+    "node": "24.14.0"
   },
   "scripts": {
     "build": "run-s build:react-router build:job build:workers build:db-scripts",


### PR DESCRIPTION
## Summary

`engines.node = "24.x"` だと setup-node が 24 系列の最新を勝手に拾うため、今日 release された Node 24.14.1 を CI が使い始めた。`better-sqlite3@12.9.1` (lock 上の現バージョン) の prebuilt は ABI v141 = Node 24.14.0 までしか提供されていないので、24.14.1 では `prebuild-install` が miss → `node-gyp` フォールバック → GitHub Actions 環境に node-gyp が無いため `pnpm install` 失敗。

PR #417 (symphony 凍結) など今日以降に作る PR の Vitest job が全部この理由で落ちている。

## やること

`package.json` の `engines.node` を `"24.x"` → `"24.14.0"` に固定。Dockerfile は既に `NODE_VERSION=24.14.0` で固定済みなので、これで CI / production / 開発が揃う。

## やらないこと

- better-sqlite3 を bump して新 ABI 対応版を待つルートは upstream 待ち。pin の方が即効性ある
- Node 24.14.1 や 24.15.0 への bump も同じ理由で先送り。better-sqlite3 が新 ABI 用 prebuilt を出してから手動 bump する

## Test plan

- [x] PR の Vitest job が緑になる
- [ ] マージ後、PR #417 を rebase して同様に緑になるのを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)