### PR TITLE
fix(login): カード幅は安定化しつつ空白を作らない (#399)

### DIFF
--- a/app/routes/_auth/login.test.tsx
+++ b/app/routes/_auth/login.test.tsx
@@ -1,0 +1,48 @@
+/** @vitest-environment happy-dom */
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+import LoginPage from './login'
+import type { Route } from './+types/login'
+
+vi.mock('~/app/libs/auth.server', () => ({}))
+
+const unauthorizedCopy =
+  'This GitHub account is not authorized to sign in. Please ask an administrator to enable access.'
+
+function loginProps(error: string | null): Route.ComponentProps {
+  return {
+    loaderData: { error, redirectTo: '/' },
+  } as Route.ComponentProps
+}
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('LoginPage', () => {
+  test.each([
+    { error: null, label: 'no error' },
+    { error: 'unable_to_get_user_info', label: 'with error' },
+  ])('card width is stable ($label)', ({ error }) => {
+    const { container } = render(<LoginPage {...loginProps(error)} />)
+    const card = container.querySelector('[data-slot="card"]')
+    expect(card).toHaveClass('w-full', 'max-w-sm')
+  })
+
+  test('error param renders alert with mapped copy', () => {
+    render(<LoginPage {...loginProps('unable_to_get_user_info')} />)
+    expect(screen.getByRole('alert')).toHaveTextContent(unauthorizedCopy)
+  })
+
+  test('unknown error key falls back to generic copy', () => {
+    render(<LoginPage {...loginProps('some_other_key')} />)
+    expect(screen.getByRole('alert')).toHaveTextContent('Sign in failed.')
+  })
+
+  test('no error param renders no alert', () => {
+    render(<LoginPage {...loginProps(null)} />)
+    expect(screen.queryByRole('alert')).toBeNull()
+    expect(screen.queryByText('Sign in failed.')).not.toBeInTheDocument()
+    expect(screen.queryByText(unauthorizedCopy)).not.toBeInTheDocument()
+  })
+})

--- a/app/routes/_auth/login.test.tsx
+++ b/app/routes/_auth/login.test.tsx
@@ -20,13 +20,17 @@ afterEach(() => {
 })
 
 describe('LoginPage', () => {
-  test.each([
-    { error: null, label: 'no error' },
-    { error: 'unable_to_get_user_info', label: 'with error' },
-  ])('card width is stable ($label)', ({ error }) => {
-    const { container } = render(<LoginPage {...loginProps(error)} />)
-    const card = container.querySelector('[data-slot="card"]')
-    expect(card).toHaveClass('w-full', 'max-w-sm')
+  test('card classes are identical regardless of error', () => {
+    const { container: noError } = render(<LoginPage {...loginProps(null)} />)
+    const noErrorCard = noError.querySelector('[data-slot="card"]')?.className
+    cleanup()
+    const { container: withError } = render(
+      <LoginPage {...loginProps('unable_to_get_user_info')} />,
+    )
+    const withErrorCard =
+      withError.querySelector('[data-slot="card"]')?.className
+    expect(noErrorCard).toBe(withErrorCard)
+    expect(noErrorCard).toContain('max-w-sm')
   })
 
   test('error param renders alert with mapped copy', () => {
@@ -42,7 +46,5 @@ describe('LoginPage', () => {
   test('no error param renders no alert', () => {
     render(<LoginPage {...loginProps(null)} />)
     expect(screen.queryByRole('alert')).toBeNull()
-    expect(screen.queryByText('Sign in failed.')).not.toBeInTheDocument()
-    expect(screen.queryByText(unauthorizedCopy)).not.toBeInTheDocument()
   })
 })

--- a/app/routes/_auth/login.tsx
+++ b/app/routes/_auth/login.tsx
@@ -66,7 +66,7 @@ export default function LoginPage({
   return (
     <AppLayout>
       <Center>
-        <Card>
+        <Card className="w-full max-w-sm">
           <CardHeader className="text-center">
             <CardTitle>Upflow</CardTitle>
           </CardHeader>


### PR DESCRIPTION
## Summary

issue #399 の takt 自動実装で「エラー有無で常に同サイズ」を達成するため `<CardContent className="min-h-[9rem]">` を常時レンダリングしてしまい、エラー無しの時に巨大な空白ができていた。spec の完了条件を字面通り満たすために UX を犠牲にした典型例。

修正:
- `min-h-[9rem]` と CardContent 常時レンダリングを撤回し、`{error && <CardContent>...</CardContent>}` の条件レンダリングに戻す
- ただし `Card` の `w-full max-w-sm` (幅安定化) は維持 — エラー文言の wrap で横幅変動する問題は防ぐ
- テストも `min-h-[9rem]` の存在 assert を消し、幅クラスとエラー文言ロジックだけを検証

トレードオフ:
- issue #399 の「高さは変わらない」は厳密には満たさない (エラー時にカードが下方向に伸びる)
- 「ボタンを押した瞬間にカードのサイズが急に変わるので落ち着かない」原因のうち、横幅変動は消えた
- 縦方向の伸びは Center 内中央寄せで上下対称に伸びるため、初期表示位置からの体感ジャンプは小さい

## 学び (issue 仕様の書き方)

「サイズ安定化」系のタスクでは、order.md (spec) の完了条件に「視覚的に空白を作らない」「invisible placeholder で水増ししない」を明示しないと、agent (cursor coder) は最小工数で字面を満たす解 (= min-height で固定) を選ぶ。supervise も spec 字面でしか見ないので approve してしまう。次回類似タスクは spec 段階で degenerate solution を禁則化する。

## Self-review (2 commit 目)

- `card width is stable` test.each は同じ assertion を 2 ケース回しているだけで「両ケース間で className が変動しない」を検証していなかった。両ケース描画して className を直接比較する 1 テストに統合
- `no error param renders no alert` で `queryByRole('alert')` が null なら Alert 内文言の `queryByText` も構造的に null。冗長 assertion を削除

## Test plan

- [x] `pnpm validate` 通過
- [x] login.test.tsx の 4 テスト pass
- [x] localhost:5173/login で実画面確認 (エラー無し時に空白が消えていること、幅が安定していること)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Style**
  * ログインカードのレイアウトを調整し、幅の制限を設けて画面に応じた表示を改善しました。

* **Tests**
  * ログイン画面のテストを追加し、エラーメッセージ表示・アラートの有無・UI表示の安定性を自動検証するようにしました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coji/upflow/pull/420)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->