### PR TITLE
[codex] fix incremental branch release propagation

### DIFF
--- a/README.md
+++ b/README.md
@@ -182,6 +182,12 @@ pnpm tsx batch/cli.ts crawl <org-id>
 
 In production, `crawl` runs automatically every hour. With Method B (GitHub App + Webhook), data also updates in realtime on PR events.
 
+If `released_at` needs to be repaired after changing release detection logic or after a branch-release propagation bug, run a full refresh once:
+
+```bash
+pnpm tsx batch/cli.ts crawl <org-id> --refresh
+```
+
 ## Authentication
 
 - **GitHub OAuth only**: login requires the user's GitHub login to be registered in the org's GitHub Users list with Active status

--- a/README.md
+++ b/README.md
@@ -182,11 +182,13 @@ pnpm tsx batch/cli.ts crawl <org-id>
 
 In production, `crawl` runs automatically every hour. With Method B (GitHub App + Webhook), data also updates in realtime on PR events.
 
-If `released_at` needs to be repaired after changing release detection logic or after a branch-release propagation bug, run a full refresh once:
+If `released_at` (or other analyze-derived columns) needs to be repaired after changing release detection logic or fixing an analyze-side bug, re-run analyze over the stored raw data — no GitHub API calls, takes a few minutes:
 
 ```bash
-pnpm tsx batch/cli.ts crawl <org-id> --refresh
+pnpm tsx batch/cli.ts process <org-id>
 ```
+
+Reach for `crawl --refresh` only when the raw data itself is wrong (missing PRs, schema gaps that need re-fetch). It re-hits the GitHub API for every PR and takes 30+ minutes.
 
 ## Authentication
 

--- a/batch/github/__tests__/buildPullRequests-filter.test.ts
+++ b/batch/github/__tests__/buildPullRequests-filter.test.ts
@@ -313,6 +313,31 @@ describe('buildPullRequests filter', () => {
     expect(pr2Filtered).toEqual(pr2All)
   })
 
+  test('リリースPRがフィルタ対象なら同じリリースに乗るfeature PRも解析対象に含める', async () => {
+    // Incremental crawl では release PR だけが更新対象になることがある。
+    // その場合も、同じ releasedAt に解決される feature PR を upsert して releasedAt を補完する。
+    const filterJustReleasePr = new Set([4])
+
+    const resultAll = await buildPullRequests(config, prs, mockLoaders)
+    const resultFiltered = await buildPullRequests(
+      config,
+      prs,
+      mockLoaders,
+      filterJustReleasePr,
+    )
+
+    expect(resultFiltered.pulls.map((p) => p.number)).toEqual([1, 2, 4])
+    expect(resultFiltered.pulls).toEqual(
+      resultAll.pulls.filter((p) => [1, 2, 4].includes(p.number)),
+    )
+    expect(resultFiltered.pulls.find((p) => p.number === 1)?.releasedAt).toBe(
+      '2024-01-08T00:00:00Z',
+    )
+    expect(resultFiltered.pulls.find((p) => p.number === 2)?.releasedAt).toBe(
+      '2024-01-08T00:00:00Z',
+    )
+  })
+
   test('reviewer が 0 人の PR でも reviewers エントリが生成される', async () => {
     // PR#3 は reviewers: [] (basePr デフォルト)
     const result = await buildPullRequests(config, prs, mockLoaders)

--- a/batch/github/pullrequest.ts
+++ b/batch/github/pullrequest.ts
@@ -206,6 +206,39 @@ function buildPullRequestRow(
   }
 }
 
+function expandFilterForBranchRelease(
+  pullrequests: ShapedGitHubPullRequest[],
+  filterPrNumbers: Set<number> | undefined,
+  branchReleaseLookup: Map<number, string> | null,
+  releaseDetectionKey: string,
+) {
+  if (!filterPrNumbers || filterPrNumbers.size === 0 || !branchReleaseLookup) {
+    return filterPrNumbers
+  }
+
+  const releaseTimes = new Set<string>()
+  for (const pr of pullrequests) {
+    if (
+      filterPrNumbers.has(pr.number) &&
+      pr.mergedAt &&
+      pr.targetBranch === releaseDetectionKey
+    ) {
+      const releasedAt = branchReleaseLookup.get(pr.number)
+      if (releasedAt) releaseTimes.add(releasedAt)
+    }
+  }
+  if (releaseTimes.size === 0) return filterPrNumbers
+
+  const expanded = new Set(filterPrNumbers)
+  for (const pr of pullrequests) {
+    const releasedAt = branchReleaseLookup.get(pr.number)
+    if (releasedAt && releaseTimes.has(releasedAt)) {
+      expanded.add(pr.number)
+    }
+  }
+  return expanded
+}
+
 export const buildPullRequests = async (
   config: BuildConfig,
   pullrequests: ShapedGitHubPullRequest[],
@@ -229,6 +262,13 @@ export const buildPullRequests = async (
     )
   }
 
+  const analysisFilterPrNumbers = expandFilterForBranchRelease(
+    pullrequests,
+    filterPrNumbers,
+    branchReleaseLookup,
+    config.releaseDetectionKey,
+  )
+
   const pulls: Selectable<TenantDB.PullRequests>[] = []
   const reviews: AnalyzedReview[] = []
   const reviewers: AnalyzedReviewer[] = []
@@ -237,7 +277,7 @@ export const buildPullRequests = async (
   let processed = 0
   for (const pr of pullrequests) {
     // フィルタが指定されていれば、対象外PRをスキップ
-    if (filterPrNumbers && !filterPrNumbers.has(pr.number)) {
+    if (analysisFilterPrNumbers && !analysisFilterPrNumbers.has(pr.number)) {
       continue
     }
 

--- a/batch/github/pullrequest.ts
+++ b/batch/github/pullrequest.ts
@@ -216,11 +216,12 @@ function expandFilterForBranchRelease(
     return filterPrNumbers
   }
 
+  // フィルタに含まれる release PR (release branch を直接ターゲットにする merge) の
+  // releasedAt を集める。同じ releasedAt に解決される feature PR をフィルタに足す。
   const releaseTimes = new Set<string>()
   for (const pr of pullrequests) {
     if (
       filterPrNumbers.has(pr.number) &&
-      pr.mergedAt &&
       pr.targetBranch === releaseDetectionKey
     ) {
       const releasedAt = branchReleaseLookup.get(pr.number)
@@ -230,11 +231,8 @@ function expandFilterForBranchRelease(
   if (releaseTimes.size === 0) return filterPrNumbers
 
   const expanded = new Set(filterPrNumbers)
-  for (const pr of pullrequests) {
-    const releasedAt = branchReleaseLookup.get(pr.number)
-    if (releasedAt && releaseTimes.has(releasedAt)) {
-      expanded.add(pr.number)
-    }
+  for (const [prNumber, releasedAt] of branchReleaseLookup) {
+    if (releaseTimes.has(releasedAt)) expanded.add(prNumber)
   }
   return expanded
 }


### PR DESCRIPTION
## Summary

- `expandFilterForBranchRelease` で incremental analyze のフィルタを拡張し、フィルタ内のリリース PR と同じ `released_at` に解決される feature PR も解析対象に含める
- 回帰テスト追加 (`filterPrNumbers = {release PR}` のケース)
- README: 過去データ復旧の推奨手順を `process` ベースに修正

Fixes #432

## Root Cause

For branch-based release detection, `buildPullRequests` built `branchReleaseLookup` from all raw PRs (correct), but the analysis loop skipped every PR outside `filterPrNumbers`. When the incremental crawl passed only the release PR, dependent feature PRs had the correct lookup value in memory but were never upserted.

## Fix

`expandFilterForBranchRelease` を `buildPullRequests` の冒頭で実行:

1. フィルタ内のリリース PR (`targetBranch === releaseDetectionKey`) の `releasedAt` を集める
2. 同じ `releasedAt` に解決される PR を `branchReleaseLookup` から逆引きしてフィルタに追加

Issue #432 の方針候補 B（依存 PR を scope に追加）を analyze 側で実装。Pass 2 は `branchReleaseLookup.entries()` を直接走査するので全 PR list を再走査しない。

## Validation

- `pnpm vitest run batch/github/__tests__/buildPullRequests-filter.test.ts` — 新規回帰テストを含む全件 pass
- `pnpm typecheck`
- pre-commit format and lint
- 実テナントの raw データに対する A/B 検証で、修正前は release PR のみ・修正後は同一リリースの feature PR まで `released_at` が伝播することを確認
- 同データで `process` を実行し、過去データの NULL `released_at` がリリース単位で解消されることを確認（詳細は内部 issue 参照）

## Past data recovery

`process` で 1 回 re-analyze すれば OK (no API calls, 数分):

```bash
pnpm tsx batch/cli.ts process <org-id>
```

`crawl --refresh` は raw データ自体が壊れているときに限定する旨を README に明記。

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **ドキュメント**
  * released_at 等のデータ修復手順を README に追記しました（再解析と再取得の使い分けを明記）。

* **改善**
  * ブランチベースのリリース検出での PR フィルタリングを改善し、リリース PR を指定した場合でも関連する機能 PR を同じリリースタイムスタンプで正しく含めるようにしました。

* **テスト**
  * フィルタリング挙動を検証するテストを追加しました。

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coji/upflow/pull/433)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->