### PR TITLE
perf: add merged_at index on tenant pull_requests

### DIFF
--- a/db/migrations/tenant/20260513065807.sql
+++ b/db/migrations/tenant/20260513065807.sql
@@ -1,0 +1,2 @@
+-- Create index "pull_requests_merged_at_idx" to table: "pull_requests"
+CREATE INDEX `pull_requests_merged_at_idx` ON `pull_requests` (`merged_at`);

--- a/db/migrations/tenant/atlas.sum
+++ b/db/migrations/tenant/atlas.sum
@@ -1,4 +1,4 @@
-h1:Fz/rrVuDRhZwwFpEf66oasUjz/xtxTrUgPe1asV7wjQ=
+h1:/Pc7xukoxTqQwUN8+hiF3sWvSf/0eRh7EsnXyUgUDNk=
 20260226112249_initial_tenant.sql h1:dIhBg2gzyh+ZjLzPXdHYafd5e62yIEjk1eFlllEyYX0=
 20260226233619_add_teams.sql h1:n8MRMUA4BgeXYEnL9HJPc8mnXh8lqIfrCcdYtFFoWqw=
 20260227163239.sql h1:ENMZUW7zHK8UjG2TdYlBOZSVPPUCXftIw5U5k2C54oo=
@@ -24,3 +24,4 @@ h1:Fz/rrVuDRhZwwFpEf66oasUjz/xtxTrUgPe1asV7wjQ=
 20260407004753_add_scan_watermark.sql h1:ULts2U5BxtBoi5Qjb2+0o4SrJ3RBg7zcC47xKsMpk6o=
 20260407084907.sql h1:Od/kmdlIWGP6zFN6yOYT/dABUOFK9fhCM1dDdbDK0g8=
 20260417065446.sql h1:SqaRx6B5R8SnjyyJUeSsaqifv+WdrQFT8y1NGVxD3cg=
+20260513065807.sql h1:z3atE/ynNtSNzc0TfxW7D7l4FD5ilRI7rIijjF/J3NM=

--- a/db/tenant.sql
+++ b/db/tenant.sql
@@ -87,6 +87,9 @@ CREATE TABLE `pull_requests` (
   PRIMARY KEY (`number`, `repository_id`),
   CONSTRAINT `pull_requests_repository_id_fkey` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`) ON UPDATE CASCADE ON DELETE CASCADE
 );
+-- Index for cycle-time / throughput / workload loaders that filter on merged_at
+-- (range scan for merged windows; IS NULL slice for open-PR queries).
+CREATE INDEX `pull_requests_merged_at_idx` ON `pull_requests` (`merged_at`);
 -- Create "pull_request_reviews" table
 CREATE TABLE `pull_request_reviews` (
   `id` text NOT NULL,

--- a/db/tenant.sql
+++ b/db/tenant.sql
@@ -87,8 +87,7 @@ CREATE TABLE `pull_requests` (
   PRIMARY KEY (`number`, `repository_id`),
   CONSTRAINT `pull_requests_repository_id_fkey` FOREIGN KEY (`repository_id`) REFERENCES `repositories` (`id`) ON UPDATE CASCADE ON DELETE CASCADE
 );
--- Index for cycle-time / throughput / workload loaders that filter on merged_at
--- (range scan for merged windows; IS NULL slice for open-PR queries).
+-- Create index "pull_requests_merged_at_idx" to table: "pull_requests"
 CREATE INDEX `pull_requests_merged_at_idx` ON `pull_requests` (`merged_at`);
 -- Create "pull_request_reviews" table
 CREATE TABLE `pull_request_reviews` (


### PR DESCRIPTION
## Summary

- workload / cycle-time / throughput の loader が `pull_requests.merged_at` を範囲 scan / `IS NULL` 抽出していたが index が無く full table scan になっていた
- `db/tenant.sql` に `CREATE INDEX pull_requests_merged_at_idx ON pull_requests (merged_at)` を追加、`atlas migrate diff --env tenant` で migration を 1 本生成
- ローカルの全テナント DB に適用、最大 9〜22ms で完了 (DDL のみ、destructive な操作なし)

## EXPLAIN 確認

サイズが大きい本番相当のテナント DB で `EXPLAIN QUERY PLAN`:

| クエリ | 結果 |
| --- | --- |
| `WHERE merged_at >= ? AND merged_at < ?` (cycle-time / throughput) | `SEARCH ... USING COVERING INDEX pull_requests_merged_at_idx` |
| `WHERE merged_at IS NULL AND closed_at IS NULL` (workload の open PR) | `SEARCH ... USING INDEX pull_requests_merged_at_idx (merged_at=?)` |

両方とも新 index を使用。COVERING INDEX 側はテーブル本体参照すら不要。

## やらなかったこと

- `closed_at` に専用 index は付けない: workload の open-PR クエリは `merged_at IS NULL` の slice 内で `closed_at IS NULL` を後段 filter するだけで十分速いと判断 (上の EXPLAIN で確認)。書き込みコストとのバランス。
- partial index (`WHERE merged_at IS NULL AND closed_at IS NULL`): 同様に必要性が薄い。実測で workload が遅いままなら別 PR で追加検討。

## Test plan

- [x] `pnpm validate` (lint / format / typecheck / build / test) パス
- [x] `pnpm db:apply` で 6 テナント DB に既存データありの状態で migration を適用、全部成功
- [x] EXPLAIN QUERY PLAN で index 利用確認
- [ ] デプロイ後、Fly のログで `/$orgSlug/workload`, `/analysis/cycle-time`, `/throughput/*` のレイテンシが下がっていることを確認 (Sentry transactions または `fly logs` の Express morgan ライン)

## self-review (push 前)

スキーマ変更のみで failure path / output contract / regex 関連の確認は N/A。CLAUDE.md のチェックリストは「マイグレーションは本番 DB の既存データで安全か」のみ該当: `CREATE INDEX` は idempotent ではないが追加のみで destructive ではなく、index build が完了するまでテーブルは locked になる点だけ注意 (最大テーブルでも 22ms なので問題なし)。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **Chores**
  * マージされたプルリクエストに関連するクエリのパフォーマンスを向上させるため、データベースの最適化を実施しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coji/upflow/pull/434)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->