### PR TITLE
perf: cache workload loader queries + fix mutation cache invalidation

### DIFF
--- a/app/libs/pr-title-filter.server.ts
+++ b/app/libs/pr-title-filter.server.ts
@@ -53,6 +53,18 @@ export interface FilterCountStats {
 }
 
 /**
+ * Cache-key suffix for loaders that gate output on PR-title-filter state.
+ * Compose as `` `${routePrefix}:...:${filterCacheKeySuffix(filter)}` ``.
+ * `JSON.stringify` on the sorted pattern list prevents collisions when a
+ * pattern legitimately contains the cache-key separator character.
+ */
+export const filterCacheKeySuffix = (state: PrFilterLoaderState): string => {
+  const sf = state.showFiltered ? 't' : 'f'
+  const patternSignature = JSON.stringify([...state.normalizedPatterns].sort())
+  return `sf=${sf}:patterns=${patternSignature}`
+}
+
+/**
  * Computes the excluded-count banner value. `counter` は SUM(CASE WHEN ...)
  * 併用で unfiltered と filtered の両方を 1 クエリで返すこと。Skips when filter
  * isn't active.

--- a/app/routes/$orgSlug/analysis/cycle-time/index.tsx
+++ b/app/routes/$orgSlug/analysis/cycle-time/index.tsx
@@ -23,6 +23,7 @@ import dayjs from '~/app/libs/dayjs'
 import { isOrgAdmin } from '~/app/libs/member-role'
 import {
   computeExcludedCount,
+  filterCacheKeySuffix,
   loadPrFilterState,
 } from '~/app/libs/pr-title-filter.server'
 import {
@@ -120,14 +121,9 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
     ? repositoryParam
     : null
 
-  const sf = filter.showFiltered ? 't' : 'f'
-  // Pattern signature must invalidate the cache when patterns change. Use
-  // JSON.stringify so a pattern that legitimately contains the separator
-  // character can't collide with a different list.
-  const patternSignature = JSON.stringify([...filter.normalizedPatterns].sort())
   // metricMode is intentionally NOT in the cache key — raw rows are mode-
   // agnostic, the median/average choice is applied in clientLoader.
-  const cacheKey = `cycle-time:${teamParam ?? 'all'}:${repositoryId ?? 'all'}:${periodMonths}:sf=${sf}:patterns=${patternSignature}`
+  const cacheKey = `cycle-time:${teamParam ?? 'all'}:${repositoryId ?? 'all'}:${periodMonths}:${filterCacheKeySuffix(filter)}`
   const FIVE_MINUTES = 5 * 60 * 1000
 
   const [[currentRows, previousRows], excludedCount] = await Promise.all([

--- a/app/routes/$orgSlug/analysis/inventory/index.tsx
+++ b/app/routes/$orgSlug/analysis/inventory/index.tsx
@@ -20,6 +20,7 @@ import dayjs from '~/app/libs/dayjs'
 import { isOrgAdmin } from '~/app/libs/member-role'
 import {
   computeExcludedCount,
+  filterCacheKeySuffix,
   loadPrFilterState,
 } from '~/app/libs/pr-title-filter.server'
 import {
@@ -72,8 +73,7 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
 
   const filter = await loadPrFilterState(request, organization.id)
 
-  const sf = filter.showFiltered ? 't' : 'f'
-  const cacheKey = `inventory:${teamParam ?? 'all'}:${periodMonths}:${excludeBots ? 'exclude-bots' : 'include-bots'}:sf=${sf}`
+  const cacheKey = `inventory:${teamParam ?? 'all'}:${periodMonths}:${excludeBots ? 'exclude-bots' : 'include-bots'}:${filterCacheKeySuffix(filter)}`
 
   const FIVE_MINUTES = 5 * 60 * 1000
 

--- a/app/routes/$orgSlug/analysis/reviews/index.tsx
+++ b/app/routes/$orgSlug/analysis/reviews/index.tsx
@@ -18,6 +18,7 @@ import { calcSinceDate } from '~/app/libs/date-utils'
 import { isOrgAdmin } from '~/app/libs/member-role'
 import {
   computeExcludedCount,
+  filterCacheKeySuffix,
   loadPrFilterState,
 } from '~/app/libs/pr-title-filter.server'
 import {
@@ -76,8 +77,7 @@ export const loader = async ({ request, context }: Route.LoaderArgs) => {
 
   const filter = await loadPrFilterState(request, organization.id)
 
-  const sf = filter.showFiltered ? 't' : 'f'
-  const cacheKey = `reviews:${teamParam ?? 'all'}:${periodMonths}:sf=${sf}`
+  const cacheKey = `reviews:${teamParam ?? 'all'}:${periodMonths}:${filterCacheKeySuffix(filter)}`
   const FIVE_MINUTES = 5 * 60 * 1000
 
   const [[queueHistoryRaw, wipCycleRaw, prSizesRaw], excludedCount] =

--- a/app/routes/$orgSlug/settings/repositories._index/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/repositories._index/mutations.server.ts
@@ -1,4 +1,5 @@
 import { AppError } from '~/app/libs/app-error'
+import { clearOrgCache } from '~/app/services/cache.server'
 import { getTenantDb } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
@@ -17,6 +18,7 @@ export const updateRepositoryTeam = async (
   if (Number(result.numUpdatedRows ?? 0) !== 1) {
     throw new AppError('Repository not found')
   }
+  clearOrgCache(organizationId)
 }
 
 export const bulkUpdateRepositoryTeam = async (
@@ -39,4 +41,5 @@ export const bulkUpdateRepositoryTeam = async (
       throw new AppError('Some repositories were not found')
     }
   })
+  clearOrgCache(organizationId)
 }

--- a/app/routes/$orgSlug/settings/repositories/$repository/settings/+functions/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/repositories/$repository/settings/+functions/mutations.server.ts
@@ -1,5 +1,6 @@
 import type { Updateable } from 'kysely'
 import { AppError } from '~/app/libs/app-error'
+import { clearOrgCache } from '~/app/services/cache.server'
 import { getTenantDb, type TenantDB } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
@@ -16,9 +17,10 @@ export const deleteRepository = async (
   if (Number(result.numDeletedRows ?? 0) !== 1) {
     throw new AppError('Repository not found')
   }
+  clearOrgCache(organizationId)
 }
 
-export const updateRepository = (
+export const updateRepository = async (
   organizationId: OrganizationId,
   repositoryId: string,
   data: Pick<
@@ -27,9 +29,11 @@ export const updateRepository = (
   >,
 ) => {
   const tenantDb = getTenantDb(organizationId)
-  return tenantDb
+  const result = await tenantDb
     .updateTable('repositories')
     .where('id', '=', repositoryId)
     .set(data)
     .executeTakeFirst()
+  clearOrgCache(organizationId)
+  return result
 }

--- a/app/routes/$orgSlug/settings/teams._index/mutations.server.ts
+++ b/app/routes/$orgSlug/settings/teams._index/mutations.server.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_PERSONAL_LIMIT } from '~/app/routes/$orgSlug/workload/+functions/aggregate-stacks'
+import { clearOrgCache } from '~/app/services/cache.server'
 import { getTenantDb } from '~/app/services/tenant-db.server'
 import type { OrganizationId } from '~/app/types/organization'
 
@@ -18,6 +19,7 @@ export const addTeam = async (params: {
       personalLimit: params.personalLimit ?? DEFAULT_PERSONAL_LIMIT,
     })
     .execute()
+  clearOrgCache(params.organizationId)
 }
 
 export const updateTeam = async (params: {
@@ -37,6 +39,7 @@ export const updateTeam = async (params: {
     })
     .where('id', '=', params.id)
     .execute()
+  clearOrgCache(params.organizationId)
 }
 
 export const deleteTeam = async (
@@ -45,4 +48,5 @@ export const deleteTeam = async (
 ) => {
   const tenantDb = getTenantDb(organizationId)
   await tenantDb.deleteFrom('teams').where('id', '=', id).execute()
+  clearOrgCache(organizationId)
 }

--- a/app/routes/$orgSlug/workload/index.tsx
+++ b/app/routes/$orgSlug/workload/index.tsx
@@ -14,6 +14,7 @@ import {
 import { orgContext, teamContext } from '~/app/middleware/context'
 import { PrTitleFilterStatus } from '~/app/routes/$orgSlug/+components/pr-title-filter-status'
 import { listTeams } from '~/app/routes/$orgSlug/settings/teams._index/queries.server'
+import { getOrgCachedData } from '~/app/services/cache.server'
 import { TeamStacksChart } from './+components/team-stacks-chart'
 import {
   DEFAULT_PERSONAL_LIMIT,
@@ -45,18 +46,35 @@ export const loader = async ({ context, request }: Route.LoaderArgs) => {
 
   const filter = await loadPrFilterState(request, organization.id)
 
-  const [openPRs, pendingReviews, reviewHistory, excludedCount] =
+  const sf = filter.showFiltered ? 't' : 'f'
+  const patternSignature = JSON.stringify([...filter.normalizedPatterns].sort())
+  const cacheKey = `workload:${teamId ?? 'all'}:sf=${sf}:patterns=${patternSignature}`
+  const SIXTY_SECONDS = 60 * 1000
+
+  const [[openPRs, pendingReviews, reviewHistory], excludedCount] =
     await Promise.all([
-      getOpenPullRequests(organization.id, teamId, filter.normalizedPatterns),
-      getPendingReviewAssignments(
+      getOrgCachedData(
         organization.id,
-        teamId,
-        filter.normalizedPatterns,
-      ),
-      getOpenPullRequestReviews(
-        organization.id,
-        teamId,
-        filter.normalizedPatterns,
+        cacheKey,
+        () =>
+          Promise.all([
+            getOpenPullRequests(
+              organization.id,
+              teamId,
+              filter.normalizedPatterns,
+            ),
+            getPendingReviewAssignments(
+              organization.id,
+              teamId,
+              filter.normalizedPatterns,
+            ),
+            getOpenPullRequestReviews(
+              organization.id,
+              teamId,
+              filter.normalizedPatterns,
+            ),
+          ]),
+        SIXTY_SECONDS,
       ),
       computeExcludedCount(filter, (patterns) =>
         countOpenPullRequests(organization.id, teamId, patterns),

--- a/app/routes/$orgSlug/workload/index.tsx
+++ b/app/routes/$orgSlug/workload/index.tsx
@@ -9,6 +9,7 @@ import { Stack } from '~/app/components/ui/stack'
 import { isOrgAdmin } from '~/app/libs/member-role'
 import {
   computeExcludedCount,
+  filterCacheKeySuffix,
   loadPrFilterState,
 } from '~/app/libs/pr-title-filter.server'
 import { orgContext, teamContext } from '~/app/middleware/context'
@@ -46,9 +47,7 @@ export const loader = async ({ context, request }: Route.LoaderArgs) => {
 
   const filter = await loadPrFilterState(request, organization.id)
 
-  const sf = filter.showFiltered ? 't' : 'f'
-  const patternSignature = JSON.stringify([...filter.normalizedPatterns].sort())
-  const cacheKey = `workload:${teamId ?? 'all'}:sf=${sf}:patterns=${patternSignature}`
+  const cacheKey = `workload:${teamId ?? 'all'}:${filterCacheKeySuffix(filter)}`
   const SIXTY_SECONDS = 60 * 1000
 
   const [[openPRs, pendingReviews, reviewHistory], excludedCount] =

--- a/app/services/cache.server.ts
+++ b/app/services/cache.server.ts
@@ -15,8 +15,7 @@
 // `docs/rdd/issue-307-pr-title-filter.md:469` for the pr_title_filters
 // emergency-disable case but the rule is general to every cached table.
 
-// biome-ignore lint/suspicious/noExplicitAny: simple in-memory cache implementation
-type CacheEntry = { data: any; expires: number }
+type CacheEntry = { data: Promise<unknown>; expires: number }
 
 /** org-scoped two-level cache: orgId → key → entry */
 const orgCacheStore = new Map<string, Map<string, CacheEntry>>()
@@ -40,12 +39,19 @@ export function getOrgCachedData<T>(
   const store = getOrgStore(orgId)
   const entry = store.get(key)
   if (entry && entry.expires > now) {
-    return entry.data
+    return entry.data as Promise<T>
   }
-  return loader().then((data) => {
-    store.set(key, { data, expires: now + ttl })
-    return data
+  // Store the in-flight promise so concurrent callers share a single loader
+  // invocation. Without this, N concurrent cold-miss requests for the same key
+  // all run loader() in parallel.
+  const promise = loader()
+  store.set(key, { data: promise, expires: now + ttl })
+  promise.catch(() => {
+    if (store.get(key)?.data === promise) {
+      store.delete(key)
+    }
   })
+  return promise
 }
 
 export const clearOrgCache = (orgId: string) => {


### PR DESCRIPTION
## Summary

- workload (default landing) の loader にある 3 つの heavy query (`getOpenPullRequests` / `getPendingReviewAssignments` / `getOpenPullRequestReviews`) を `getOrgCachedData` で包んで TTL 60 秒のキャッシュを追加。
- 同時に既存の cache 整合性バグを修正: team の add/update/delete、repository の team 割り当て / 削除 / メタ更新の mutation で `clearOrgCache(organizationId)` を呼んでいなかったため、cycle-time / inventory / reviews でも team 編集後に最大 5 分間古い結果が見える状態だった。`pr-title-filter-mutations.server.ts` の規約に揃えて mutation 内部で write 直後に呼ぶ形に。

## なぜ

VM スケールアップ + `merged_at` index で CPU と scan コストは下がったが、workload は default landing で毎リクエスト 3 query が走る。アクセス頻度が一番高い route なのでキャッシュ ROI が大きい。

cycle-time が既に `getOrgCachedData` を使っているので、規約を踏襲した。

## TTL を 60 秒にした理由

- cycle-time の 5 分は集計データ (月単位の trend) なので妥当
- workload は open PR の現在状態を見るページで、PR を push して reviewer に出した直後にダッシュボードを見る使い方が多い
- crawl 完了で cache は自動的に invalidate される (`crawl.server.ts:302`, `shared-steps.server.ts:176`)。クロール完了より前にユーザがダッシュボードを再読み込みするケースで「最大 60 秒古いまま」になる
- 60 秒は経験則。Sentry transactions で実測してから 30s〜120s の間で調整可能

## 修正した cache 不整合の影響範囲

| mutation | 影響していた route |
| --- | --- |
| `addTeam` / `updateTeam` / `deleteTeam` | cycle-time / inventory / reviews (`personalLimit` も workload で使うので workload も) |
| `updateRepositoryTeam` / `bulkUpdateRepositoryTeam` | 同上 (team filter で repository を絞っているため) |
| `deleteRepository` | 同上 (repository 一覧と紐づく PR が消える) |
| `updateRepository` (owner / repo / releaseDetection) | 同上 (表示名とリリース検出方式が変わる) |

`addRepository` は `repositories.add/index.tsx:250` で既に `clearOrgCache` を呼んでいたので変更なし。

## Test plan

- [x] `pnpm validate` パス (565 tests passed, lint 0 warnings/errors)
- [x] cache key が `teamId` と `normalizedPatterns` で differentiate されることを diff で確認
- [ ] デプロイ後、workload のレスポンス時間が cache hit 時に大幅短縮されることを Sentry transactions / `fly logs` で確認
- [ ] team を編集 → cycle-time の集計が即時更新されることを目視確認

## self-review (push 前)

1. 既存 contract 参照: `cycle-time/index.tsx` の cache 使用パターン + `pr-title-filter-mutations.server.ts` の clearOrgCache 規約を full read で確認。
2. failure path: `getOrgCachedData` 内で `loader()` reject 時は entry が cache されない (then チェーン内のため) → 次回再試行で正常動作。
3. 入力 validation: cache key の `teamId` は loader 内で validate 済みの値 (`selectedTeam?.id ?? null`)。`patternSignature` は sorted JSON.stringify で順序不依存。
4. やらなかったこと: TTL を 60s に決め打ち。実測で再調整可能。`addRepository` 経路は既に整合済みなので触らない。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * リポジトリ／チームの変更後に組織キャッシュを自動クリアし、表示データの整合性を向上
  * ワークロードや解析ページでフィルターに基づくキャッシュ鍵を統一して再利用性を向上
  * 同一組織の並列読み込みでキャッシュを共有するようにし、重複呼び出しを削減して応答性を改善

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/coji/upflow/pull/435)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->